### PR TITLE
coding style guide update

### DIFF
--- a/docs/coding_style.rst
+++ b/docs/coding_style.rst
@@ -49,7 +49,10 @@ Indentation
             ACTION( foo_free,       METRIC_GAUGE,   "# free foo"       )\
             ACTION( foo_borrow,     METRIC_COUNTER, "# foos borrowed"  )\
             ACTION( foo_return,     METRIC_COUNTER, "# foos returned"  )\
-        /* type starts on column 29, description on column 45 */
+        /* name starts on column 13
+         * type starts on column 29
+         * description on column 45
+         */
 
         struct foo {
             struct foo      *next;


### PR DESCRIPTION
1. remove recommendation about one-var-per-line;
2. add section about forward declaration;
3. relax wording on nested levels;
4. update how to break down a long line to reflect our actual practice- 8-char indentation after the first line;
5. clarify when to and why use of stdint types;
6. one typo fixed.
