### PR TITLE
fix stats not writing END\r\n

### DIFF
--- a/src/core/admin.c
+++ b/src/core/admin.c
@@ -158,7 +158,7 @@ _admin_post_read(struct buf_sock *s)
             size_t card = stats_card();
 
             /* start at i == 0, since we want an extra reply object for "END" */
-            for (i = 0, nr = rep; i < card; ++i) {
+            for (i = 0, nr = rep; i <= card; ++i) {
                 STAILQ_NEXT(nr, next) = reply_create();
                 nr = STAILQ_NEXT(nr, next);
                 if (nr == NULL) {
@@ -182,7 +182,7 @@ _admin_post_read(struct buf_sock *s)
                 }
             }
         }
-        n = compose_rep(&s->wbuf, rep);
+        n = compose_rep(&s->wbuf, nr);
         if (n < 0) {
             log_error("compose reply error");
             goto error;


### PR DESCRIPTION
pt 2 will come after timing wheel PR #55 is merged, since I suspect it's an issue with log_core and log_core should be moved to use timing_wheel.
