### PR TITLE
fix stats segfault issue

### DIFF
--- a/src/protocol/admin/reply.c
+++ b/src/protocol/admin/reply.c
@@ -1,7 +1,6 @@
 #include <protocol/admin/reply.h>
 
 #include <cc_debug.h>
-#include <cc_log.h>
 #include <cc_mm.h>
 
 #define GET_STRING(_name, _str) {sizeof(_str) - 1, (_str)},


### PR DESCRIPTION
"next" member in struct reply was not getting reset, which caused chained replies to segfault.
