### PR TITLE
regulate core_admin naming; mini-refactor module dependencies

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(admin)
 add_subdirectory(data)
 
 set(SOURCE
+    ${SOURCE}
     core.c)
 
 add_library(core ${SOURCE})
-target_link_libraries(core core_admin core_data)

--- a/src/core/admin/CMakeLists.txt
+++ b/src/core/admin/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(core_admin admin.c)
-target_link_libraries(core_admin protocol_admin)
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/admin.c
+    PARENT_SCOPE)

--- a/src/core/admin/admin.c
+++ b/src/core/admin/admin.c
@@ -200,7 +200,7 @@ _admin_event(void *arg, uint32_t events)
 }
 
 rstatus_i
-admin_add_timed_ev(struct timeout_event *tev)
+core_admin_add_tev(struct timeout_event *tev)
 {
     ASSERT(!__atomic_load_n(&admin_running, __ATOMIC_RELAXED));
     ASSERT(admin_init);
@@ -209,7 +209,7 @@ admin_add_timed_ev(struct timeout_event *tev)
 }
 
 rstatus_i
-admin_setup(struct addrinfo *ai, int intvl, uint64_t tw_tick_ns,
+core_admin_setup(struct addrinfo *ai, int intvl, uint64_t tw_tick_ns,
             size_t tw_cap, size_t tw_ntick)
 {
     struct tcp_conn *c;
@@ -265,7 +265,7 @@ admin_setup(struct addrinfo *ai, int intvl, uint64_t tw_tick_ns,
 }
 
 void
-admin_teardown(void)
+core_admin_teardown(void)
 {
     log_info("tear down the %s module", ADMIN_MODULE_NAME);
 
@@ -281,7 +281,7 @@ admin_teardown(void)
 }
 
 static rstatus_i
-admin_evwait(void)
+_admin_evwait(void)
 {
     int n;
 
@@ -294,12 +294,12 @@ admin_evwait(void)
 }
 
 void *
-admin_evloop(void *arg)
+core_admin_evloop(void *arg)
 {
     rstatus_i status;
 
     for(;;) {
-        status = admin_evwait();
+        status = _admin_evwait();
         if (status != CC_OK) {
             log_crit("admin loop exited due to failure");
             break;

--- a/src/core/admin/admin.h
+++ b/src/core/admin/admin.h
@@ -31,11 +31,11 @@ struct timeout_event;
 extern struct timing_wheel *tw;
 extern bool admin_running;
 
-rstatus_i admin_setup(struct addrinfo *ai, int intvl, uint64_t tw_tick_ns,
+rstatus_i core_admin_setup(struct addrinfo *ai, int intvl, uint64_t tw_tick_ns,
                       size_t tw_cap, size_t tw_ntick);
-void admin_teardown(void);
+void core_admin_teardown(void);
 
 /* timeout events must be added while admin evloop is not running */
-rstatus_i admin_add_timed_ev(struct timeout_event *tev);
+rstatus_i core_admin_add_tev(struct timeout_event *tev);
 
-void *admin_evloop(void *arg);
+void *core_admin_evloop(void *arg);

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -63,7 +63,7 @@ core_setup(struct addrinfo *data_ai, struct addrinfo *admin_ai,
         return ret;
     }
 
-    ret = admin_setup(admin_ai, maint_intvl, tw_tick, tw_cap, tw_ntick);
+    ret = core_admin_setup(admin_ai, maint_intvl, tw_tick, tw_cap, tw_ntick);
     if (ret != CC_OK) {
         return ret;
     }
@@ -75,8 +75,9 @@ core_setup(struct addrinfo *data_ai, struct addrinfo *admin_ai,
 void
 core_teardown(void)
 {
-    core_server_teardown();
+    core_admin_teardown();
     core_worker_teardown();
+    core_server_teardown();
 
     ring_array_destroy(conn_arr);
     pipe_conn_destroy(&pipe_c);
@@ -103,7 +104,7 @@ core_run(void)
     }
 
     __atomic_store_n(&admin_running, true, __ATOMIC_RELAXED);
-    ret = pthread_create(&admin, NULL, admin_evloop, NULL);
+    ret = pthread_create(&admin, NULL, core_admin_evloop, NULL);
     if (ret != 0) {
         log_crit("pthread create failed for admin thread: %s", strerror(ret));
         goto error;

--- a/src/core/data/CMakeLists.txt
+++ b/src/core/data/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCE
-    server.c
-    shared.c
-    worker.c)
-
-add_library(core_data ${SOURCE})
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/server.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/worker.c
+    PARENT_SCOPE)

--- a/src/slimcache/CMakeLists.txt
+++ b/src/slimcache/CMakeLists.txt
@@ -2,17 +2,22 @@ add_subdirectory(admin)
 add_subdirectory(data)
 
 set(SOURCE
+    ${SOURCE}
     main.c
     stats.c)
 
-set(LIBS
+set(MODULES
     core
     cuckoo
+    protocol_admin
+    protocol_memcache
     time
-    util
+    util)
+
+set(LIBS
     ccommon-static
     ${CMAKE_THREAD_LIBS_INIT})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/_bin)
 add_executable(${PROJECT_NAME}_slimcache ${SOURCE})
-target_link_libraries(${PROJECT_NAME}_slimcache ${LIBS} slimcache_admin slimcache_data)
+target_link_libraries(${PROJECT_NAME}_slimcache ${MODULES} ${LIBS})

--- a/src/slimcache/admin/CMakeLists.txt
+++ b/src/slimcache/admin/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(slimcache_admin process.c)
-target_link_libraries(slimcache_admin protocol_admin)
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/process.c
+    PARENT_SCOPE)

--- a/src/slimcache/data/CMakeLists.txt
+++ b/src/slimcache/data/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(slimcache_data process.c)
-target_link_libraries(slimcache_data protocol_memcache)
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/process.c
+    PARENT_SCOPE)

--- a/src/slimcache/main.c
+++ b/src/slimcache/main.c
@@ -156,13 +156,13 @@ setup(void)
         goto error;
     }
 
-    status = admin_add_timed_ev(dlog_tev);
+    status = core_admin_add_tev(dlog_tev);
     if (status != CC_OK) {
         log_stderr("Could not add debug log timed event to admin thread");
         goto error;
     }
 
-    status = admin_add_timed_ev(klog_tev);
+    status = core_admin_add_tev(klog_tev);
     if (status != CC_OK) {
         log_error("Could not add klog timed event to admin thread");
         goto error;

--- a/src/twemcache/CMakeLists.txt
+++ b/src/twemcache/CMakeLists.txt
@@ -2,17 +2,22 @@ add_subdirectory(admin)
 add_subdirectory(data)
 
 set(SOURCE
+    ${SOURCE}
     main.c
     stats.c)
 
-set(LIBS
+set(MODULES
     core
+    protocol_admin
+    protocol_memcache
     slab
     time
-    util
+    util)
+
+set(LIBS
     ccommon-static
     ${CMAKE_THREAD_LIBS_INIT})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/_bin)
 add_executable(${PROJECT_NAME}_twemcache ${SOURCE})
-target_link_libraries(${PROJECT_NAME}_twemcache ${LIBS} twemcache_admin twemcache_data)
+target_link_libraries(${PROJECT_NAME}_twemcache ${MODULES} ${LIBS})

--- a/src/twemcache/admin/CMakeLists.txt
+++ b/src/twemcache/admin/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(twemcache_admin process.c)
-target_link_libraries(twemcache_admin protocol_admin)
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/process.c
+    PARENT_SCOPE)

--- a/src/twemcache/data/CMakeLists.txt
+++ b/src/twemcache/data/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_library(twemcache_data process.c)
-target_link_libraries(twemcache_data protocol_memcache)
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/process.c
+    PARENT_SCOPE)

--- a/src/twemcache/main.c
+++ b/src/twemcache/main.c
@@ -166,13 +166,13 @@ setup(void)
         goto error;
     }
 
-    status = admin_add_timed_ev(dlog_tev);
+    status = core_admin_add_tev(dlog_tev);
     if (status != CC_OK) {
         log_stderr("Could not add debug log timed event to admin thread");
         goto error;
     }
 
-    status = admin_add_timed_ev(klog_tev);
+    status = core_admin_add_tev(klog_tev);
     if (status != CC_OK) {
         log_error("Could not add klog timed event to admin thread");
         goto error;


### PR DESCRIPTION
Three changes here:
- fixed a bug where `core_teardown` did not call `admin_teardown` in `core.c`
- renamed functions under `core/admin` to follow the same conventions as the server/worker counterparts
- refactored some CMake files to change what objects get built and how they are linked, which is explained further below

The bug, as found by @kevyang, was that the binaries failed at link time when building on Linux/CentOS. This happened as an unfortunate combination of the library linkage ordering (see below) and the particular linker used.
Library order:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang    -std=c11 -ggdb3 -O2 -Wall -Wshadow -Winline -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wunused-function -Wunused-value -Wunused-variable -fno-strict-aliasing  -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  CMakeFiles/pelikan_slimcache.dir/main.c.o CMakeFiles/pelikan_slimcache.dir/stats.c.o  -o ../../../_bin/pelikan_slimcache  ../../core/libcore.a ../../storage/cuckoo/libcuckoo.a ../../time/libtime.a ../../util/libutil.a ../../ccommon/lib/libccommon-1.0.2.a admin/libslimcache_admin.a data/libslimcache_data.a ../../core/admin/libcore_admin.a ../../core/data/libcore_data.a ../../protocol/admin/libprotocol_admin.a ../../protocol/data/memcache/libprotocol_memcache.a
```

As you can see from above, `libccommon` does not appear on the right most side of the list. And given how gcc scans and links libraries, the libraries appearing after libccommon will not be able to find symbols included in the former, and thus started to throw errors. I'm not exactly sure why using gcc on Mac OS X still compiles fine, but this is the source of flakiness.

After trying for a while to enforce a particular ordering on the library linkage list, without success, I realized the trouble here probably has something to do with transitive linkage (libcore is linked to libcore_data and libcore_admin), and somehow the dependencies appear far from the top-level library, indicating a particular way such transitivity is handled and scanned for by CMake. Unfortunately, I couldn't find much documentation on that topic, and stopped searching after a while.

Given what I have found so far, I think the best strategy, for now, is to avoid transitive linking within Pelikan. Therefore, I modified the subdirectories under `core`, `slimcache` and `twemcache` to build a single object from all source files (including subdirectories) for each directory. Until we have a better understanding of link-time behavior, the flat linkage model will prevent more flaky behavior in the code base.

Also split libraries in to `MODULES` (local to pelikan) and `LIBS` (dependencies outside of `src`) to improve readability.
