### PR TITLE
disable partial-parsing and request-caching

### DIFF
--- a/src/protocol/data/memcache/request.c
+++ b/src/protocol/data/memcache/request.c
@@ -27,7 +27,6 @@ request_reset(struct request *req)
     req->free = false;
 
     req->rstate = REQ_PARSING;
-    req->pstate = REQ_HDR;
     req->type = REQ_UNKNOWN;
 
     req->keys->nelem = 0;

--- a/src/protocol/data/memcache/request.h
+++ b/src/protocol/data/memcache/request.h
@@ -66,11 +66,6 @@ typedef enum request_state {
     REQ_DONE
 } request_state_t;
 
-typedef enum request_parse_state {
-    REQ_HDR,
-    REQ_VAL
-} request_parse_state_t;
-
 /*
  * NOTE(yao): we store key and value as location in rbuf, this assumes the data
  * will not be overwritten before the current request is completed.
@@ -81,7 +76,6 @@ struct request {
     bool                    free;
 
     request_state_t         rstate;     /* request state */
-    request_parse_state_t   pstate;     /* parsing state */
 
     request_type_t          type;
 

--- a/src/protocol/data/memcache/response.c
+++ b/src/protocol/data/memcache/response.c
@@ -28,7 +28,6 @@ response_reset(struct response *rsp)
     rsp->free = false;
 
     rsp->rstate = RSP_PARSING;
-    rsp->pstate = RSP_HDR;
     rsp->type = RSP_UNKNOWN;
 
     bstring_init(&rsp->key);

--- a/src/protocol/data/memcache/response.h
+++ b/src/protocol/data/memcache/response.h
@@ -65,12 +65,6 @@ typedef enum response_state {
     RSP_DONE
 } response_state_t;
 
-typedef enum response_parse_state {
-    RSP_HDR,
-    RSP_VAL
-} response_parse_state_t;
-
-
 /*
  * NOTE(yao): we store fields as location in rbuf, this assumes the data will
  * not be overwritten prematurely.
@@ -81,7 +75,6 @@ struct response {
     bool                    free;
 
     response_state_t        rstate;     /* response state */
-    response_parse_state_t  pstate;     /* parsing state */
 
     response_type_t         type;
 

--- a/src/server/twemcache/data/process.c
+++ b/src/server/twemcache/data/process.c
@@ -513,7 +513,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 
     log_verb("post-read processing");
 
-    req =  (*data == NULL) ? request_borrow() : *data;
+    req = request_borrow();
     if (req == NULL) {
         /* TODO(yao): simply return for now, better to respond with OOM */
         log_error("cannot acquire request: OOM");
@@ -532,9 +532,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 
         status = parse_req(req, *rbuf);
         if (status == PARSE_EUNFIN) {
-            *data = req; /* save partially parsed request */
-
-            return 0;
+            goto done;
         }
         if (status != PARSE_OK) {
             /* parsing errors are all client errors, since we don't know
@@ -543,9 +541,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
              * ends), we should close the connection
              */
             log_warn("illegal request received, status: %d", status);
-            _cleanup(&req, &rsp);
-
-            return -1;
+            goto error;
         }
 
         /* stage 2: processing- check for quit, allocate response(s), process */
@@ -553,9 +549,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
         /* quit is special, no response expected */
         if (req->type == REQ_QUIT) {
             log_info("peer called quit");
-            _cleanup(&req, &rsp);
-
-            return -1;
+            goto error;
         }
 
         /* find cardinality of the request and get enough response objects */
@@ -571,16 +565,13 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
             if (nr == NULL) {
                 log_error("cannot acquire response: OOM");
                 INCR(process_metrics, process_ex);
-                _cleanup(&req, &rsp);
-
-                return -1;
+                goto error;
             }
         }
 
         /* actual processing & command logging */
         process_request(rsp, req);
         klog_write(req, rsp);
-
 
         /* stage 3: write response(s) */
 
@@ -599,17 +590,18 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
             if (compose_rsp(wbuf, nr) < 0) {
                 log_error("composing rsp erred");
                 INCR(process_metrics, process_ex);
-                _cleanup(&req, &rsp);
-
-                return -1;
+                goto error;
             }
         }
     }
 
+done:
     _cleanup(&req, &rsp);
-    *data = NULL;
-
     return 0;
+
+error:
+    _cleanup(&req, &rsp);
+    return -1;
 }
 
 int


### PR DESCRIPTION
This addresses the bug in https://github.com/twitter/pelikan/issues/98

Note that now the data field is not used at all in handling memcached requests. But in general it is nice to have a wildcard field for generic structures like `buf_sock`, since users often want context affiliated with each socket. So not using it doesn't necessarily mean we should take out the data field from the underlying library.
