### PR TITLE
switch to upper case PING

### DIFF
--- a/src/protocol/data/ping/request.h
+++ b/src/protocol/data/ping/request.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define REQUEST "ping\r\n"
+#define REQUEST "PING\r\n"
 #define REQ_LEN (sizeof(REQUEST) - 1)

--- a/src/protocol/data/ping/response.h
+++ b/src/protocol/data/ping/response.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define RESPONSE "pong\r\n"
+#define RESPONSE "PONG\r\n"
 #define RSP_LEN (sizeof(RESPONSE) - 1)


### PR DESCRIPTION
Redis uses uppercase, and rpc-perf expects it.
