### PR TITLE
declare project as C-only to avoid looking for CXX related symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project(pelikan)
+project(pelikan C)
 
 enable_testing()
 

--- a/deps/ccommon/CMakeLists.txt
+++ b/deps/ccommon/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
-project(ccommon)
+project(ccommon C)
 
 enable_testing()
 


### PR DESCRIPTION
This reduces the dependency requirement when building docker images (otherwise we will have to pull g++ when building image based on debian:jessie)