### PR TITLE
Add perslab metrics that help understand item size distribution

### DIFF
--- a/src/protocol/admin/parse.c
+++ b/src/protocol/admin/parse.c
@@ -71,19 +71,20 @@ admin_parse_req(struct request *req, struct buf *buf)
     }
     p = q = buf->rpos;
 
-    /* First find CRLF, this simplifies parsing. For admin port we don't care
-     * much about efficiency.
+    /* First find CRLF and store it in p, this simplifies parsing.
+     * For admin port we don't care much about efficiency.
      */
     for (; !_is_crlf(buf, p) && p < buf->wpos; p++);
     if (p == buf->wpos) {
         return PARSE_EUNFIN;
     }
 
+    /* type: between rpos and q */
     for (; *q != ' ' && q < p; q++);
-
     type.data = buf->rpos;
     type.len = q - buf->rpos;
-    if (p < q) { /* intentional: pointing to the leading space */
+
+    if (p > q) { /* intentional: pointing to the leading space */
         req->arg.len = p - q;
         req->arg.data = q;
     }

--- a/src/server/twemcache/admin/process.c
+++ b/src/server/twemcache/admin/process.c
@@ -1,6 +1,7 @@
 #include "process.h"
 
 #include "protocol/admin/admin_include.h"
+#include "storage/slab/slab.h"
 #include "util/procinfo.h"
 
 #include <cc_mm.h>
@@ -12,9 +13,12 @@
 #define METRIC_PRINT_LEN 64 /* > 5("STAT ") + 32 (name) + 20 (value) + CRLF */
 #define METRIC_DESCRIBE_FMT "%33s %15s %s\r\n"
 #define METRIC_DESCRIBE_LEN 120 /* 34 (name) + 16 (type) + 68 (description) + CRLF */
-#define METRIC_FOOTER CRLF
 #define METRIC_END "END\r\n"
 #define METRIC_END_LEN (sizeof(METRIC_END) - 1)
+
+#define PERSLAB_PREFIX_FMT "CLASS %u:"
+#define PERSLAB_METRIC_FMT " %s %s"
+#define PERSLAB_SUFFIX_FMT "\r\n"
 
 #define VERSION_PRINT_FMT "VERSION %s\r\n"
 #define VERSION_PRINT_LEN 30
@@ -27,6 +31,7 @@ static admin_process_metrics_st *admin_metrics = NULL;
 static char *stats_buf = NULL;
 static char version_buf[VERSION_PRINT_LEN];
 static size_t stats_len;
+static unsigned int nmetric_perslab;
 
 void
 admin_process_setup(admin_process_metrics_st *metrics)
@@ -39,7 +44,10 @@ admin_process_setup(admin_process_metrics_st *metrics)
 
     admin_metrics = metrics;
 
-    stats_len = METRIC_PRINT_LEN * nmetric;
+    nmetric_perslab = METRIC_CARDINALITY(perslab[0]);
+    /* perslab metric size <(32 + 20)B, prefix/suffix 12B, total < 64 */
+    stats_len = MAX(nmetric, nmetric_perslab * SLABCLASS_MAX_ID) *
+        METRIC_PRINT_LEN;
     stats_buf = cc_alloc(stats_len + METRIC_END_LEN);
     /* TODO: check return status of cc_alloc */
 
@@ -59,7 +67,31 @@ admin_process_teardown(void)
 }
 
 static void
-_admin_stats(struct response *rsp, struct request *req)
+_admin_stats_slab(struct response *rsp, struct request *req)
+{
+    uint8_t id;
+    size_t offset = 0;
+
+    for (id = SLABCLASS_MIN_ID; id <= profile_last_id; id++) {
+        struct metric *metrics = (struct metric *)&perslab[id];
+        offset += cc_scnprintf(stats_buf + offset, stats_len - offset,
+                PERSLAB_PREFIX_FMT, id);
+        for (int i = 0; i < nmetric_perslab; i++) {
+            offset += metric_print(stats_buf + offset, stats_len - offset,
+                   PERSLAB_METRIC_FMT, &metrics[i]);
+        }
+        offset += cc_scnprintf(stats_buf + offset, stats_len - offset,
+                PERSLAB_SUFFIX_FMT);
+    }
+    offset += cc_scnprintf(stats_buf + offset, stats_len - offset, METRIC_END);
+
+    rsp->type = RSP_GENERIC;
+    rsp->data.data = stats_buf;
+    rsp->data.len = offset;
+}
+
+static void
+_admin_stats_default(struct response *rsp, struct request *req)
 {
     size_t offset = 0;
     struct metric *metrics = (struct metric *)&stats;
@@ -71,11 +103,25 @@ _admin_stats(struct response *rsp, struct request *req)
         offset += metric_print(stats_buf + offset, stats_len - offset,
                 METRIC_PRINT_FMT, &metrics[i]);
     }
-    strcpy(stats_buf + offset, METRIC_END);
+    offset += cc_scnprintf(stats_buf + offset, stats_len - offset, METRIC_END);
 
     rsp->type = RSP_GENERIC;
     rsp->data.data = stats_buf;
-    rsp->data.len = offset + METRIC_END_LEN;
+    rsp->data.len = offset;
+}
+
+static void
+_admin_stats(struct response *rsp, struct request *req)
+{
+    if (bstring_empty(&req->arg)) {
+        _admin_stats_default(rsp, req);
+        return;
+    }
+    if (req->arg.len == 5 && str5cmp(req->arg.data, ' ', 's', 'l', 'a', 'b')) {
+        _admin_stats_slab(rsp, req);
+    } else {
+        rsp->type = RSP_INVALID;
+    }
 }
 
 static void

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -25,6 +25,8 @@ struct slab_heapinfo {
     struct slab_tqh slab_lruq;   /* lru slab q */
 };
 
+perslab_metrics_st perslab[SLABCLASS_MAX_ID];
+
 static struct slab_heapinfo heapinfo;             /* info of all allocated slabs */
 static size_t profile[SLABCLASS_MAX_ID + 1];      /* slab profile */
 static uint8_t profile_last_id;                   /* last id in slab profile */
@@ -205,6 +207,8 @@ _slab_heapinfo_setup(void)
         return CC_ENOMEM;
     }
     TAILQ_INIT(&heapinfo.slab_lruq);
+
+    metric_reset((struct metric *)perslab, METRIC_CARDINALITY(perslab));
 
     log_vverb("created slab table with %"PRIu32" entries",
               heapinfo.max_nslab);
@@ -542,7 +546,8 @@ _slab_get_new(void)
 
     _slab_table_update(slab);
     INCR(slab_metrics, slab_curr);
-    INCR_N(slab_metrics, slab_memory,slab_size);
+    PERSLAB_INCR(slab->id, slab_curr);
+    INCR_N(slab_metrics, slab_memory, slab_size);
 
     return slab;
 }
@@ -577,6 +582,8 @@ _slab_evict_one(struct slab *slab)
 
     p = &slabclass[slab->id];
 
+    INCR(slab_metrics, slab_evict);
+
     /* candidate slab is also the current slab */
     if (p->next_item_in_slab != NULL && slab == item_to_slab(p->next_item_in_slab)) {
         p->nfree_item = 0;
@@ -603,8 +610,6 @@ _slab_evict_one(struct slab *slab)
 
     /* unlink the slab from its class */
     _slab_lruq_remove(slab);
-
-    INCR(slab_metrics, slab_evict);
 }
 
 /*
@@ -765,6 +770,7 @@ _slab_get_item_from_freeq(uint8_t id)
     ASSERT(p->nfree_itemq > 0);
     p->nfree_itemq--;
     SLIST_REMOVE(&p->free_itemq, it, item, i_sle);
+    PERSLAB_DECR(id, item_free);
 
     log_verb("get free q it %p at offset %"PRIu32" with id %"PRIu8, it,
             it->offset, it->id);
@@ -843,6 +849,8 @@ _slab_put_item_into_freeq(struct item *it, uint8_t id)
 
     p->nfree_itemq++;
     SLIST_INSERT_HEAD(&p->free_itemq, it, i_sle);
+
+    PERSLAB_INCR(id, item_free);
 }
 
 /*

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -26,10 +26,10 @@ struct slab_heapinfo {
 };
 
 perslab_metrics_st perslab[SLABCLASS_MAX_ID];
+uint8_t profile_last_id; /* last id in slab profile */
 
 static struct slab_heapinfo heapinfo;             /* info of all allocated slabs */
 static size_t profile[SLABCLASS_MAX_ID + 1];      /* slab profile */
-static uint8_t profile_last_id;                   /* last id in slab profile */
 struct slabclass slabclass[SLABCLASS_MAX_ID + 1]; /* collection of slabs bucketed by slabclass */
 
 size_t slab_size = SLAB_SIZE;           /* # bytes in a slab */
@@ -156,6 +156,10 @@ _slab_slabclass_setup(void)
         p->nitem = nitem;
         p->size = item_sz;
 
+        /* chunk_size is static */
+        perslab[id] = (perslab_metrics_st){PERSLAB_METRIC(METRIC_INIT)};
+        UPDATE_VAL(&perslab[id], chunk_size, item_sz);
+
         p->nfree_itemq = 0;
         SLIST_INIT(&p->free_itemq);
 
@@ -207,8 +211,6 @@ _slab_heapinfo_setup(void)
         return CC_ENOMEM;
     }
     TAILQ_INIT(&heapinfo.slab_lruq);
-
-    metric_reset((struct metric *)perslab, METRIC_CARDINALITY(perslab));
 
     log_vverb("created slab table with %"PRIu32" entries",
               heapinfo.max_nslab);

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -76,13 +76,9 @@ typedef struct {
     SLAB_METRIC(METRIC_DECLARE)
 } slab_metrics_st;
 
-/*
- *
-    ACTION( chunk_size,         METRIC_GAUGE,   "# byte per item"      )\
-    ACTION( chunks_per_page,    METRIC_GAUGE,   "# items in each slab" )\
- */
 /*          name                type            description */
 #define PERSLAB_METRIC(ACTION)                                          \
+    ACTION( chunk_size,         METRIC_GAUGE,   "# byte per item cunk" )\
     ACTION( item_keyval_byte,   METRIC_GAUGE,   "keyval stored (byte) ")\
     ACTION( item_val_byte,      METRIC_GAUGE,   "value portion of data")\
     ACTION( item_curr,          METRIC_GAUGE,   "# items stored"       )\
@@ -94,6 +90,7 @@ typedef struct {
 } perslab_metrics_st;
 
 extern perslab_metrics_st perslab[SLABCLASS_MAX_ID];
+extern uint8_t profile_last_id;
 
 #define PERSLAB_INCR(id, metric) INCR(&perslab[id], metric)
 #define PERSLAB_DECR(id, metric) DECR(&perslab[id], metric)

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -72,10 +72,33 @@ typedef struct {
     ACTION( item_keyval_byte,   METRIC_GAUGE,   "key+val in bytes, linked" )\
     ACTION( item_val_byte,      METRIC_GAUGE,   "value only in bytes"      )
 
-
 typedef struct {
     SLAB_METRIC(METRIC_DECLARE)
 } slab_metrics_st;
+
+/*
+ *
+    ACTION( chunk_size,         METRIC_GAUGE,   "# byte per item"      )\
+    ACTION( chunks_per_page,    METRIC_GAUGE,   "# items in each slab" )\
+ */
+/*          name                type            description */
+#define PERSLAB_METRIC(ACTION)                                          \
+    ACTION( item_keyval_byte,   METRIC_GAUGE,   "keyval stored (byte) ")\
+    ACTION( item_val_byte,      METRIC_GAUGE,   "value portion of data")\
+    ACTION( item_curr,          METRIC_GAUGE,   "# items stored"       )\
+    ACTION( item_free,          METRIC_GAUGE,   "# free items"         )\
+    ACTION( slab_curr,          METRIC_GAUGE,   "# slabs"              )
+
+typedef struct {
+    PERSLAB_METRIC(METRIC_DECLARE)
+} perslab_metrics_st;
+
+extern perslab_metrics_st perslab[SLABCLASS_MAX_ID];
+
+#define PERSLAB_INCR(id, metric) INCR(&perslab[id], metric)
+#define PERSLAB_DECR(id, metric) DECR(&perslab[id], metric)
+#define PERSLAB_INCR_N(id, metric, delta) INCR_N(&perslab[id], metric, delta)
+#define PERSLAB_DECR_N(id, metric, delta) DECR_N(&perslab[id], metric, delta)
 
 /*
  * Every slab (struct slab) in the cache starts with a slab header


### PR DESCRIPTION
We deviate from memcached's slab metrics format because honestly it was not particular readable. Now they look like this:
```
stats slab
CLASS 1: chunk_size 48 item_keyval_byte 0 item_val_byte 0 item_curr 0 item_free 0 slab_curr 0
CLASS 2: chunk_size 56 item_keyval_byte 0 item_val_byte 0 item_curr 0 item_free 0 slab_curr 0
CLASS 3: chunk_size 64 item_keyval_byte 0 item_val_byte 0 item_curr 0 item_free 0 slab_curr 0
...
END
```

Compatibility is not important because internally we never exported these numbers anywhere, and the current table format is easier to read than one metric per line.