### PR TITLE
dump all keys; count size of all/subset of keys based on prefix

### DIFF
--- a/src/protocol/admin/format.h
+++ b/src/protocol/admin/format.h
@@ -8,6 +8,8 @@
 #define METRIC_DESCRIBE_LEN 120 /* 34 (name) + 16 (type) + 68 (description) + CRLF */
 #define METRIC_END "END\r\n"
 #define METRIC_END_LEN (sizeof(METRIC_END) - 1)
+#define KEYCOUNT_FMT "%zu %zu %zu\r\n"
+#define KEYCOUNT_LEN 64 /* 20 * 3 (numbers) + 2 (spaces) + CRLF */
 
 #define VERSION_PRINTED "VERSION " VERSION_STRING "\r\n"
 

--- a/src/protocol/admin/parse.c
+++ b/src/protocol/admin/parse.c
@@ -26,10 +26,16 @@ _get_req_type(struct request *req, struct bstring *type)
 {
     ASSERT(req->type == REQ_UNKNOWN);
 
+    /* use loop + bcmp() to simplify this function, perf doesn't matter */
     switch (type->len) {
     case 4:
         if (str4cmp(type->data, 'q', 'u', 'i', 't')) {
             req->type = REQ_QUIT;
+            break;
+        }
+
+        if (str4cmp(type->data, 'd', 'u', 'm', 'p')) {
+            req->type = REQ_DUMP;
             break;
         }
 
@@ -38,6 +44,11 @@ _get_req_type(struct request *req, struct bstring *type)
     case 5:
         if (str5cmp(type->data, 's', 't', 'a', 't', 's')) {
             req->type = REQ_STATS;
+            break;
+        }
+
+        if (str5cmp(type->data, 'c', 'o', 'u', 'n', 't')) {
+            req->type = REQ_COUNT;
             break;
         }
 

--- a/src/protocol/admin/request.h
+++ b/src/protocol/admin/request.h
@@ -25,6 +25,8 @@
     ACTION( REQ_UNKNOWN,       ""          )\
     ACTION( REQ_STATS,         "stats"     )\
     ACTION( REQ_VERSION,       "version"   )\
+    ACTION( REQ_COUNT,         "count"     )\
+    ACTION( REQ_DUMP,          "dump"      )\
     ACTION( REQ_QUIT,          "quit"      )
 
 #define GET_TYPE(_name, _str) _name,
@@ -41,8 +43,8 @@ typedef enum request_state {
 } request_state_t;
 
 struct request {
-    request_state_t      state; /* request state */
-    request_type_t       type;
+    request_state_t state; /* request state */
+    request_type_t  type;
     struct bstring  arg;
 };
 

--- a/src/protocol/data/memcache/request.h
+++ b/src/protocol/data/memcache/request.h
@@ -48,7 +48,7 @@ typedef struct {
     ACTION( REQ_INCR,           "incr "            )\
     ACTION( REQ_DECR,           "decr "            )\
     ACTION( REQ_FLUSH,          "flush_all\r\n"    )\
-    ACTION( REQ_QUIT,           "quit\r\n"         )\
+    ACTION( REQ_QUIT,           "quit\r\n"         )
 
 #define GET_TYPE(_name, _str) _name,
 typedef enum request_type {

--- a/src/server/twemcache/admin/process.c
+++ b/src/server/twemcache/admin/process.c
@@ -94,6 +94,42 @@ _admin_stats(struct response *rsp, struct request *req)
     }
 }
 
+static void
+_key_dump(struct response *rsp, struct request *req)
+{
+    if (item_dump() == true) {
+        rsp->type = RSP_OK;
+    } else {
+        rsp->type = RSP_GENERIC;
+        rsp->data = str2bstr("ERROR: key dump unsuccesful");
+    }
+
+    log_info("dump request %p processed");
+}
+
+static void
+_key_count(struct response *rsp, struct request *req)
+{
+    size_t nkey, ksize, vsize;
+    int ret = 0;
+
+    if (req->arg.len > 0) { /* skip initial space */
+        req->arg.len--;
+        req->arg.data++;
+    }
+    log_info("count keys with prefix %.*s", req->arg.len, req->arg.data);
+
+    item_count(&nkey, &ksize, &vsize, &req->arg);
+    rsp->type = RSP_GENERIC;
+    ret = cc_scnprintf(buf, cap, KEYCOUNT_FMT, nkey, ksize, vsize);
+    if (ret < 0) {
+        rsp->data = str2bstr("ERROR: cannot format key count");
+    } else {
+        rsp->data.len = ret;
+        rsp->data.data = buf;
+    }
+}
+
 void
 admin_process_request(struct response *rsp, struct request *req)
 {
@@ -103,9 +139,19 @@ admin_process_request(struct response *rsp, struct request *req)
     case REQ_STATS:
         _admin_stats(rsp, req);
         break;
+
     case REQ_VERSION:
         rsp->data = str2bstr(VERSION_PRINTED);
         break;
+
+    case REQ_DUMP:
+        _key_dump(rsp, req);
+        break;
+
+    case REQ_COUNT:
+        _key_count(rsp, req);
+        break;
+
     default:
         rsp->type = RSP_INVALID;
         break;

--- a/src/storage/slab/item.c
+++ b/src/storage/slab/item.c
@@ -1,7 +1,9 @@
 #include "slab.h"
 
 #include <cc_debug.h>
+#include <cc_log.h>
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -371,4 +373,77 @@ item_flush(void)
     time_update();
     flush_at = time_now();
     log_info("all keys flushed at %"PRIu32, flush_at);
+}
+
+void
+item_count(size_t *nkey, size_t *ksize, size_t *vsize, struct bstring *prefix)
+{
+    uint32_t nbucket = HASHSIZE(hash_table->hash_power);
+
+    log_info("start scanning all %"PRIu32" keys", hash_table->nhash_item);
+
+    *nkey = 0;
+    *ksize = 0;
+    *vsize = 0;
+    for (uint32_t i = 0; i < nbucket; i++) {
+        struct item_slh *entry = &hash_table->table[i];
+        struct item *it;
+
+        SLIST_FOREACH(it, entry, i_sle) {
+            if (it->klen >= prefix->len &&
+                    cc_bcmp(prefix->data, item_key(it), prefix->len) == 0) {
+                *nkey += 1;
+                *ksize += it->klen;
+                *vsize += it->vlen;
+            }
+        }
+
+        if (i % 1000000 == 0) {
+            log_info("... %"PRIu32" out of %"PRIu32" buckets scanned ...", i,
+                    nbucket);
+        }
+    }
+
+    log_info("finish scanning all keys");
+}
+
+bool
+item_dump(void)
+{
+    int fd;
+    uint32_t nbucket = HASHSIZE(hash_table->hash_power);
+
+    log_info("start scanning all %"PRIu32" keys", hash_table->nhash_item);
+
+    fd = open("key.dump", O_WRONLY | O_TRUNC | O_CREAT, 0644);
+    if (fd < 0) {
+        log_stderr("Could not create key dump - cannot open file");
+        return false;
+    }
+
+    for (uint32_t i = 0; i < nbucket; i++) {
+        struct item_slh *entry = &hash_table->table[i];
+        struct item *it;
+
+        SLIST_FOREACH(it, entry, i_sle) {
+            if (write(fd, item_key(it), it->klen) < it->klen) {
+                log_error("write error, aborting at hash bucket %"PRIu32, i);
+                return false;
+            }
+            if  (write(fd, CRLF, CRLF_LEN) < CRLF_LEN) {
+                log_error("write error, aborting at hash bucket %"PRIu32, i);
+                return false;
+            }
+        }
+
+        if (i % 1000000 == 0) {
+            log_info("... %"PRIu32" out of %"PRIu32" buckets scanned ...", i,
+                    nbucket);
+        }
+    }
+    close(fd);
+
+    log_info("finish scanning all keys");
+
+    return true;
 }

--- a/src/storage/slab/item.h
+++ b/src/storage/slab/item.h
@@ -204,3 +204,6 @@ bool item_delete(const struct bstring *key);
 
 /* flush the cache */
 void item_flush(void);
+
+void item_count(size_t *nkey, size_t *ksize, size_t *vsize, struct bstring *prefix);
+bool item_dump(void);


### PR DESCRIPTION
I got a request to find out how many keys there are in cache that belong to a particular dataset (represented by a specific prefix). I thought about it for a bit and realized this feature might be generally useful to perform a total key dump for analysis or get an dataset level overview of the cache, so I checked this code it.

Not sure if this is ready for merge at this point: big issue is thread-safety. Since we perform the scanning on the admin thread, to avoid reading dirty keys (keys that are being updated by the worker thread) requires some kind of locking/synchronization. This we can do rather cheaply by using an atomic instruction to let worker thread alter a flag when an hashbucket is being actively modified, and having the admin thread blocked if it runs into a dirty hashtable entry. But the one-off usage I'm asked to provide can be done on a staging host after live traffic is shut off, so it doesn't seem to warrant the extra rigor for now.

I just want to have a place where this feature is visible/checked in.