### PR TITLE
Change processor signature to expose buf_sock

### DIFF
--- a/src/core/data/worker.h
+++ b/src/core/data/worker.h
@@ -33,17 +33,17 @@ extern worker_metrics_st *worker_metrics;
 /*
  * To allow the use application-specific logic in the handling of read/write
  * events, each application is expected to implement their own versions of
- * post_processing functions called after the channel-level read/write is done.
+ * (post) processing functions called after the channel-level read/write is done.
  *
- * Applications should set and pass their instance of post_processor as argument
+ * Applications should set and pass their instance of processor as argument
  * to core_worker_evloop().
  */
-struct buf;
-typedef int (*post_process_fn)(struct buf **, struct buf **, void **);
-struct post_processor {
-    post_process_fn post_read;
-    post_process_fn post_write;
-    post_process_fn post_error;
+struct buf_sock;
+typedef int (*process_fn)(struct buf_sock *);
+struct processor {
+    process_fn read;
+    process_fn write;
+    process_fn error;
 };
 
 void core_worker_setup(worker_options_st *options, worker_metrics_st *metrics);

--- a/src/server/pingserver/data/process.c
+++ b/src/server/pingserver/data/process.c
@@ -4,7 +4,6 @@
 
 #include <buffer/cc_dbuf.h>
 #include <cc_debug.h>
-#include <stream/cc_sockio.h>
 
 int
 pingserver_process_read(struct buf_sock *s)

--- a/src/server/pingserver/data/process.c
+++ b/src/server/pingserver/data/process.c
@@ -4,19 +4,20 @@
 
 #include <buffer/cc_dbuf.h>
 #include <cc_debug.h>
+#include <stream/cc_sockio.h>
 
 int
-pingserver_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
+pingserver_process_read(struct buf_sock *s)
 {
     parse_rstatus_t status;
 
     log_verb("post-read processing");
 
     /* keep parse-process-compose until running out of data in rbuf */
-    while (buf_rsize(*rbuf) > 0) {
-        log_verb("%"PRIu32" bytes left", buf_rsize(*rbuf));
+    while (buf_rsize(s->rbuf) > 0) {
+        log_verb("%"PRIu32" bytes left", buf_rsize(s->rbuf));
 
-        status = parse_req(*rbuf);
+        status = parse_req(s->rbuf);
         if (status == PARSE_EUNFIN) {
             return 0;
         }
@@ -24,7 +25,7 @@ pingserver_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
             return -1;
         }
 
-        if (compose_rsp(wbuf) != COMPOSE_OK) {
+        if (compose_rsp(&s->wbuf) != COMPOSE_OK) {
             return -1;
         }
     }
@@ -33,12 +34,12 @@ pingserver_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 }
 
 int
-pingserver_process_write(struct buf **rbuf, struct buf **wbuf, void **data)
+pingserver_process_write(struct buf_sock *s)
 {
     log_verb("post-write processing");
 
-    dbuf_shrink(rbuf);
-    dbuf_shrink(wbuf);
+    dbuf_shrink(&s->rbuf);
+    dbuf_shrink(&s->wbuf);
 
     return 0;
 }

--- a/src/server/pingserver/data/process.h
+++ b/src/server/pingserver/data/process.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <buffer/cc_buf.h>
+#include <stream/cc_sockio.h>
 
-int pingserver_process_read(struct buf **rbuf, struct buf **wbuf, void **data);
-int pingserver_process_write(struct buf **rbuf, struct buf **wbuf, void **data);
+int pingserver_process_read(struct buf_sock *s);
+int pingserver_process_write(struct buf_sock *s);

--- a/src/server/pingserver/main.c
+++ b/src/server/pingserver/main.c
@@ -13,7 +13,7 @@
 #include <sys/socket.h>
 #include <sysexits.h>
 
-struct post_processor worker_processor = {
+struct processor worker_processor = {
     pingserver_process_read,
     pingserver_process_write
 };

--- a/src/server/slimcache/data/process.h
+++ b/src/server/slimcache/data/process.h
@@ -3,6 +3,7 @@
 #include <buffer/cc_buf.h>
 #include <cc_metric.h>
 #include <cc_option.h>
+#include <stream/cc_sockio.h>
 
 #define ALLOW_FLUSH false
 
@@ -64,5 +65,5 @@ typedef struct {
 void process_setup(process_options_st *options, process_metrics_st *metrics);
 void process_teardown(void);
 
-int slimcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data);
-int slimcache_process_write(struct buf **rbuf, struct buf **wbuf, void **data);
+int slimcache_process_read(struct buf_sock *s);
+int slimcache_process_write(struct buf_sock *s);

--- a/src/server/slimcache/main.c
+++ b/src/server/slimcache/main.c
@@ -13,7 +13,7 @@
 #include <sys/socket.h>
 #include <sysexits.h>
 
-struct post_processor worker_processor = {
+struct processor worker_processor = {
     slimcache_process_read,
     slimcache_process_write
 };

--- a/src/server/twemcache/data/process.c
+++ b/src/server/twemcache/data/process.c
@@ -652,7 +652,7 @@ _data_create(void)
 }
 
 int
-twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
+twemcache_process_read(struct buf_sock *s)
 {
     parse_rstatus_t status;
     struct data *state;
@@ -662,8 +662,8 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
     log_verb("post-read processing");
 
     /* deal with the stateful part: request and response */
-    if (*data == NULL) {
-        if ((*data = _data_create()) == NULL) {
+    if (s->data == NULL) {
+        if ((s->data = _data_create()) == NULL) {
             /* TODO(yao): simply return for now, better to respond with OOM */
             log_error("cannot process request: OOM");
             INCR(process_metrics, process_ex);
@@ -671,21 +671,21 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
             return -1;
         }
     }
-    state = (struct data *)*data;
+    state = (struct data *)s->data;
     req = state->req;
     rsp = state->rsp;
 
     /* keep parse-process-compose until running out of data in rbuf */
-    while (buf_rsize(*rbuf) > 0) {
+    while (buf_rsize(s->rbuf) > 0) {
         struct response *nr;
         int i, card;
 
         /* stage 1: parsing */
-        log_verb("%"PRIu32" bytes left", buf_rsize(*rbuf));
+        log_verb("%"PRIu32" bytes left", buf_rsize(s->rbuf));
 
-        status = parse_req(req, *rbuf);
+        status = parse_req(req, s->rbuf);
         if (status == PARSE_EUNFIN) {
-            buf_lshift(*rbuf);
+            buf_lshift(s->rbuf);
             return 0;
         }
         if (status != PARSE_OK) {
@@ -732,7 +732,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
         process_request(rsp, req);
         if (req->partial) { /* implies end of rbuf w/o complete processing */
             /* in this case, do not attempt to log or write response */
-            buf_lshift(*rbuf);
+            buf_lshift(s->rbuf);
             return 0;
         }
 
@@ -747,7 +747,7 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
                 card = req->nfound + 1;
             }
             for (i = 0; i < card; nr = STAILQ_NEXT(nr, next), ++i) {
-                if (compose_rsp(wbuf, nr) < 0) {
+                if (compose_rsp(&s->wbuf, nr) < 0) {
                     log_error("composing rsp erred");
                     INCR(process_metrics, process_ex);
                     _cleanup(req, rsp);
@@ -766,36 +766,36 @@ twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 
 
 int
-twemcache_process_write(struct buf **rbuf, struct buf **wbuf, void **data)
+twemcache_process_write(struct buf_sock *s)
 {
     log_verb("post-write processing");
 
-    buf_lshift(*rbuf);
-    buf_lshift(*wbuf);
-    dbuf_shrink(rbuf);
-    dbuf_shrink(wbuf);
+    buf_lshift(s->rbuf);
+    dbuf_shrink(&s->rbuf);
+    buf_lshift(s->wbuf);
+    dbuf_shrink(&s->wbuf);
 
     return 0;
 }
 
 
 int
-twemcache_process_error(struct buf **rbuf, struct buf **wbuf, void **data)
+twemcache_process_error(struct buf_sock *s)
 {
-    struct data *state = (struct data *)*data;
+    struct data *state = (struct data *)s->data;
     struct request *req;
     struct response *rsp;
 
     log_verb("post-error processing");
 
     /* normalize buffer size */
-    buf_reset(*rbuf);
-    dbuf_shrink(rbuf);
-    buf_reset(*wbuf);
-    dbuf_shrink(wbuf);
+    buf_reset(s->rbuf);
+    dbuf_shrink(&s->rbuf);
+    buf_reset(s->wbuf);
+    dbuf_shrink(&s->wbuf);
 
     /* release request data & associated reserved data */
-    if (*data != NULL) {
+    if (state != NULL) {
         req = state->req;
         rsp = state->rsp;
         if (req->reserved != NULL) {

--- a/src/server/twemcache/data/process.h
+++ b/src/server/twemcache/data/process.h
@@ -3,6 +3,7 @@
 #include <buffer/cc_buf.h>
 #include <cc_metric.h>
 #include <cc_option.h>
+#include <stream/cc_sockio.h>
 
 #define ALLOW_FLUSH false
 
@@ -73,6 +74,6 @@ typedef struct {
 void process_setup(process_options_st *options, process_metrics_st *metrics);
 void process_teardown(void);
 
-int twemcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data);
-int twemcache_process_write(struct buf **rbuf, struct buf **wbuf, void **data);
-int twemcache_process_error(struct buf **rbuf, struct buf **wbuf, void **data);
+int twemcache_process_read(struct buf_sock *s);
+int twemcache_process_write(struct buf_sock *s);
+int twemcache_process_error(struct buf_sock *s);

--- a/src/server/twemcache/main.c
+++ b/src/server/twemcache/main.c
@@ -13,7 +13,7 @@
 #include <sys/socket.h>
 #include <sysexits.h>
 
-struct post_processor worker_processor = {
+struct processor worker_processor = {
     twemcache_process_read,
     twemcache_process_write,
     twemcache_process_error,


### PR DESCRIPTION
While working on a pubsub prototype, it was evident that the processing logic has to be aware of the identification of the channel to properly index all subscribers. This prompts me to change the signature of the worker thread to accommodate this use case.

Note buf_sock is not quite the final signature I want- I would like to pass in the stream object, which is the abstract type for which buf_sock is an implementation. But this is not currently necessary as we only support buf_sock.

I would like to refactor both channel and stream in ccommon to make it easier to call the right methods (handlers) against various channel types (TCP socket, Unix domain socket, pipe, etc). And I would like to come back and further refactor the core functionalities when that is done in ccommon.