### PR TITLE
allow request to include to a response object

### DIFF
--- a/src/protocol/data/memcache/request.c
+++ b/src/protocol/data/memcache/request.c
@@ -41,6 +41,7 @@ request_reset(struct request *req)
 
     req->nremain = 0;
     req->reserved = NULL;
+    req->rsp = NULL;
 
     req->partial = 0;
     req->first = 0;

--- a/src/protocol/data/memcache/request.h
+++ b/src/protocol/data/memcache/request.h
@@ -66,6 +66,8 @@ typedef enum request_state {
     REQ_DONE
 } request_state_t;
 
+struct response;
+
 /*
  * NOTE(yao): we store key and value as location in rbuf, this assumes the data
  * will not be overwritten before the current request is completed.
@@ -91,6 +93,7 @@ struct request {
 
     uint32_t                nremain;
     void                    *reserved;  /* storage reserved for partial value */
+    struct response         *rsp;       /* response object(s) reserved */
 
     unsigned                partial:1;  /* partial value received? */
     unsigned                first:1;    /* first segment? */

--- a/test/integration/twemcache/seq-1
+++ b/test/integration/twemcache/seq-1
@@ -1,5 +1,2 @@
 >>> get foo
 <<< END
-
->>> quit
-+++ request_free +1


### PR DESCRIPTION
add a field in request struct to chain to response(s), so we can avoid allocating memory dynamically to keep track of req/rsp pointers