### PR TITLE
refactor slab module to generalize dataflag into metadata storage

### DIFF
--- a/src/protocol/data/memcache/constant.h
+++ b/src/protocol/data/memcache/constant.h
@@ -3,3 +3,5 @@
 #define MAX_KEY_LEN     250
 #define MAX_TOKEN_LEN   256
 #define MAX_BATCH_SIZE  100
+
+#define DATAFLAG_SIZE   4

--- a/src/server/twemcache/data/process.c
+++ b/src/server/twemcache/data/process.c
@@ -61,13 +61,13 @@ process_teardown(void)
 static inline uint32_t
 _get_dataflag(struct item *it)
 {
-    return *((uint32_t *)item_metadata(it));
+    return *((uint32_t *)item_optional(it));
 }
 
 static inline void
 _set_dataflag(struct item *it, uint32_t flag)
 {
-    *((uint32_t *)item_metadata(it)) = flag;
+    *((uint32_t *)item_optional(it)) = flag;
 }
 
 static bool
@@ -417,7 +417,7 @@ _process_delta(struct response *rsp, struct item *it, struct request *req,
     rsp->vint = vint;
     nval.len = cc_print_uint64_unsafe(buf, vint);
     nval.data = buf;
-    if (item_slabid(it->klen, nval.len, it->mlen) == it->id) {
+    if (item_slabid(it->klen, nval.len, it->olen) == it->id) {
         item_update(it, &nval);
         return ITEM_OK;
     }

--- a/src/storage/slab/item.c
+++ b/src/storage/slab/item.c
@@ -17,7 +17,7 @@ _item_expired(struct item *it)
 static inline void
 _copy_key_item(struct item *nit, struct item *oit)
 {
-    nit->mlen = oit->mlen;
+    nit->olen = oit->olen;
     cc_memcpy(item_key(nit), item_key(oit), oit->klen);
     nit->klen = oit->klen;
 }
@@ -43,7 +43,7 @@ _item_reset(struct item *it)
     it->is_raligned = 0;
     it->vlen = 0;
     it->klen = 0;
-    it->mlen = 0;
+    it->olen = 0;
     it->expire_at = 0;
     it->create_at = 0;
 }
@@ -55,9 +55,9 @@ _item_reset(struct item *it)
  * On success we return the pointer to the allocated item.
  */
 static item_rstatus_t
-_item_alloc(struct item **it_p, uint8_t klen, uint32_t vlen, uint8_t mlen)
+_item_alloc(struct item **it_p, uint8_t klen, uint32_t vlen, uint8_t olen)
 {
-    uint8_t id = slab_id(item_ntotal(klen, vlen, mlen));
+    uint8_t id = slab_id(item_ntotal(klen, vlen, olen));
     struct item *it;
 
     log_verb("allocate item with klen %u vlen %u", klen, vlen);
@@ -121,7 +121,7 @@ _item_link(struct item *it)
 
     INCR(slab_metrics, item_linked_curr);
     INCR(slab_metrics, item_link);
-    /* TODO(yao): how do we track metadata storage? Separate or treat as val? */
+    /* TODO(yao): how do we track optional storage? Separate or treat as val? */
     INCR_N(slab_metrics, item_keyval_byte, it->klen + it->vlen);
     INCR_N(slab_metrics, item_val_byte, it->vlen);
     PERSLAB_INCR_N(it->id, item_keyval_byte, it->klen + it->vlen);
@@ -195,12 +195,13 @@ item_get(const struct bstring *key)
 
 /* TODO(yao): move this to memcache-specific location */
 static void
-_item_define(struct item *it, const struct bstring *key, const struct bstring *val, uint8_t mlen, rel_time_t expire_at)
+_item_define(struct item *it, const struct bstring *key, const struct bstring
+        *val, uint8_t olen, rel_time_t expire_at)
 {
     it->create_at = time_now();
     it->expire_at = expire_at;
     item_set_cas(it);
-    it->mlen = mlen;
+    it->olen = olen;
     cc_memcpy(item_key(it), key->data, key->len);
     it->klen = key->len;
     cc_memcpy(item_data(it), val->data, val->len);
@@ -208,22 +209,23 @@ _item_define(struct item *it, const struct bstring *key, const struct bstring *v
 }
 
 item_rstatus_t
-item_reserve(struct item **it_p, const struct bstring *key, const struct bstring *val, uint32_t vlen, uint8_t mlen, rel_time_t expire_at)
+item_reserve(struct item **it_p, const struct bstring *key, const struct bstring
+        *val, uint32_t vlen, uint8_t olen, rel_time_t expire_at)
 {
     item_rstatus_t status;
     struct item *it;
 
-    if ((status = _item_alloc(it_p, key->len, vlen, mlen)) != ITEM_OK) {
+    if ((status = _item_alloc(it_p, key->len, vlen, olen)) != ITEM_OK) {
         log_debug("item reservation failed");
         return status;
     }
 
     it = *it_p;
 
-    _item_define(it, key, val, mlen, expire_at);
+    _item_define(it, key, val, olen, expire_at);
 
-    log_verb("reserve it %p of id %"PRIu8" for key '%.*s' metadata len %"PRIu8,
-            it, it->id,key->len, key->data, mlen);
+    log_verb("reserve it %p of id %"PRIu8" for key '%.*s' optional len %"PRIu8,
+            it, it->id,key->len, key->data, olen);
 
     return ITEM_OK;
 }
@@ -248,14 +250,15 @@ item_backfill(struct item *it, const struct bstring *val)
 }
 
 item_rstatus_t
-item_annex(struct item *oit, const struct bstring *key, const struct bstring *val, bool append)
+item_annex(struct item *oit, const struct bstring *key, const struct bstring
+        *val, bool append)
 {
     item_rstatus_t status = ITEM_OK;
     struct item *nit = NULL;
     uint8_t id;
     uint32_t ntotal = oit->vlen + val->len;
 
-    id = item_slabid(oit->klen, ntotal, oit->mlen);
+    id = item_slabid(oit->klen, ntotal, oit->olen);
     if (id == SLABCLASS_INVALID_ID) {
         log_info("client error: annex operation results in oversized item with"
                    "key size %"PRIu8" old value size %"PRIu32" and new value "
@@ -277,7 +280,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             INCR_N(slab_metrics, item_val_byte, val->len);
             item_set_cas(oit);
         } else {
-            status = _item_alloc(&nit, oit->klen, ntotal, oit->mlen);
+            status = _item_alloc(&nit, oit->klen, ntotal, oit->olen);
             if (status != ITEM_OK) {
                 log_debug("annex failed due to failure to allocate new item");
                 return status;
@@ -305,7 +308,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             INCR_N(slab_metrics, item_val_byte, val->len);
             item_set_cas(oit);
         } else {
-            status = _item_alloc(&nit, oit->klen, ntotal, oit->mlen);
+            status = _item_alloc(&nit, oit->klen, ntotal, oit->olen);
             if (status != ITEM_OK) {
                 log_debug("annex failed due to failure to allocate new item");
                 return status;
@@ -332,7 +335,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
 void
 item_update(struct item *it, const struct bstring *val)
 {
-    ASSERT(item_slabid(it->klen, val->len, it->mlen) == it->id);
+    ASSERT(item_slabid(it->klen, val->len, it->olen) == it->id);
 
     it->vlen = val->len;
     cc_memcpy(item_data(it), val->data, val->len);

--- a/src/storage/slab/item.c
+++ b/src/storage/slab/item.c
@@ -17,6 +17,7 @@ _item_expired(struct item *it)
 static inline void
 _copy_key_item(struct item *nit, struct item *oit)
 {
+    nit->mlen = oit->mlen;
     cc_memcpy(item_key(nit), item_key(oit), oit->klen);
     nit->klen = oit->klen;
 }
@@ -41,8 +42,8 @@ _item_reset(struct item *it)
     it->in_freeq = 0;
     it->is_raligned = 0;
     it->vlen = 0;
-    it->dataflag = 0;
     it->klen = 0;
+    it->mlen = 0;
     it->expire_at = 0;
     it->create_at = 0;
 }
@@ -54,9 +55,9 @@ _item_reset(struct item *it)
  * On success we return the pointer to the allocated item.
  */
 static item_rstatus_t
-_item_alloc(struct item **it_p, uint8_t klen, uint32_t vlen)
+_item_alloc(struct item **it_p, uint8_t klen, uint32_t vlen, uint8_t mlen)
 {
-    uint8_t id = slab_id(item_ntotal(klen, vlen));
+    uint8_t id = slab_id(item_ntotal(klen, vlen, mlen));
     struct item *it;
 
     log_verb("allocate item with klen %u vlen %u", klen, vlen);
@@ -120,6 +121,7 @@ _item_link(struct item *it)
 
     INCR(slab_metrics, item_linked_curr);
     INCR(slab_metrics, item_link);
+    /* TODO(yao): how do we track metadata storage? Separate or treat as val? */
     INCR_N(slab_metrics, item_keyval_byte, it->klen + it->vlen);
     INCR_N(slab_metrics, item_val_byte, it->vlen);
     PERSLAB_INCR_N(it->id, item_keyval_byte, it->klen + it->vlen);
@@ -193,12 +195,12 @@ item_get(const struct bstring *key)
 
 /* TODO(yao): move this to memcache-specific location */
 static void
-_item_define(struct item *it, const struct bstring *key, const struct bstring *val, uint32_t dataflag, rel_time_t expire_at)
+_item_define(struct item *it, const struct bstring *key, const struct bstring *val, uint8_t mlen, rel_time_t expire_at)
 {
     it->create_at = time_now();
     it->expire_at = expire_at;
-    it->dataflag = dataflag;
     item_set_cas(it);
+    it->mlen = mlen;
     cc_memcpy(item_key(it), key->data, key->len);
     it->klen = key->len;
     cc_memcpy(item_data(it), val->data, val->len);
@@ -206,22 +208,22 @@ _item_define(struct item *it, const struct bstring *key, const struct bstring *v
 }
 
 item_rstatus_t
-item_reserve(struct item **it_p, const struct bstring *key, const struct bstring *val, uint32_t vlen, uint32_t dataflag, rel_time_t expire_at)
+item_reserve(struct item **it_p, const struct bstring *key, const struct bstring *val, uint32_t vlen, uint8_t mlen, rel_time_t expire_at)
 {
     item_rstatus_t status;
     struct item *it;
 
-    if ((status = _item_alloc(it_p, key->len, vlen)) != ITEM_OK) {
+    if ((status = _item_alloc(it_p, key->len, vlen, mlen)) != ITEM_OK) {
         log_debug("item reservation failed");
         return status;
     }
 
     it = *it_p;
 
-    _item_define(it, key, val, dataflag, expire_at);
+    _item_define(it, key, val, mlen, expire_at);
 
-    log_verb("reserve it %p of id %"PRIu8" for key '%.*s' dataflag %u", it,
-            it->id, key->len, key->data, it->dataflag);
+    log_verb("reserve it %p of id %"PRIu8" for key '%.*s' metadata len %"PRIu8,
+            it, it->id,key->len, key->data, mlen);
 
     return ITEM_OK;
 }
@@ -253,7 +255,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
     uint8_t id;
     uint32_t ntotal = oit->vlen + val->len;
 
-    id = item_slabid(oit->klen, ntotal);
+    id = item_slabid(oit->klen, ntotal, oit->mlen);
     if (id == SLABCLASS_INVALID_ID) {
         log_info("client error: annex operation results in oversized item with"
                    "key size %"PRIu8" old value size %"PRIu32" and new value "
@@ -275,7 +277,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             INCR_N(slab_metrics, item_val_byte, val->len);
             item_set_cas(oit);
         } else {
-            status = _item_alloc(&nit, oit->klen, ntotal);
+            status = _item_alloc(&nit, oit->klen, ntotal, oit->mlen);
             if (status != ITEM_OK) {
                 log_debug("annex failed due to failure to allocate new item");
                 return status;
@@ -283,7 +285,6 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             _copy_key_item(nit, oit);
             nit->expire_at = oit->expire_at;
             nit->create_at = time_now();
-            nit->dataflag = oit->dataflag;
             item_set_cas(nit);
             /* value is left-aligned */
             cc_memcpy(item_data(nit), item_data(oit), oit->vlen);
@@ -304,7 +305,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             INCR_N(slab_metrics, item_val_byte, val->len);
             item_set_cas(oit);
         } else {
-            status = _item_alloc(&nit, oit->klen, ntotal);
+            status = _item_alloc(&nit, oit->klen, ntotal, oit->mlen);
             if (status != ITEM_OK) {
                 log_debug("annex failed due to failure to allocate new item");
                 return status;
@@ -312,7 +313,6 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
             _copy_key_item(nit, oit);
             nit->expire_at = oit->expire_at;
             nit->create_at = time_now();
-            nit->dataflag = oit->dataflag;
             item_set_cas(nit);
             /* value is right-aligned */
             nit->is_raligned = 1;
@@ -332,7 +332,7 @@ item_annex(struct item *oit, const struct bstring *key, const struct bstring *va
 void
 item_update(struct item *it, const struct bstring *val)
 {
-    ASSERT(item_slabid(it->klen, val->len) == it->id);
+    ASSERT(item_slabid(it->klen, val->len, it->mlen) == it->id);
 
     it->vlen = val->len;
     cc_memcpy(item_data(it), val->data, val->len);

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -185,9 +185,9 @@ uint8_t slab_id(size_t size);
 
 /* Calculate slab id that will accommodate item with given key/val lengths */
 static inline uint8_t
-item_slabid(uint8_t klen, uint32_t vlen)
+item_slabid(uint8_t klen, uint32_t vlen, uint8_t mlen)
 {
-    return slab_id(item_ntotal(klen, vlen));
+    return slab_id(item_ntotal(klen, vlen, mlen));
 }
 
 void slab_setup(slab_options_st *options, slab_metrics_st *metrics);


### PR DESCRIPTION
Previously, slab follows memcached semantics a little too closely, especially the use of `dataflag`. This is a known issue / TODO. This PR addresses that.

After this change, metadata storage is generalized, and caller can specify how much metadata storage is needed when reserving an item, so that value is customizable not only per-backend type but also per-key.