### PR TITLE
Use INT32_MAX for unbounded expiry

### DIFF
--- a/src/server/redis/data/cmd_list.c
+++ b/src/server/redis/data/cmd_list.c
@@ -34,7 +34,7 @@ _add_key(struct response *rsp, struct bstring *key)
         return NULL;
     } else {
         /* TODO: figure out a TTL story here */
-        istatus = item_reserve(&it, key, NULL, ZIPLIST_HEADER_SIZE, 0, UINT32_MAX);
+        istatus = item_reserve(&it, key, NULL, ZIPLIST_HEADER_SIZE, 0, INT32_MAX);
         if (istatus != ITEM_OK) {
             rsp->type = reply->type = ELEM_ERR;
             reply->bstr = str2bstr(RSP_ERR_STORAGE);

--- a/src/server/slimredis/data/cmd_bitmap.c
+++ b/src/server/slimredis/data/cmd_bitmap.c
@@ -78,7 +78,7 @@ _add_key(struct response *rsp, struct bstring *key)
     } else { /* cuckoo insert current won't fail as long as size is valid */
         /* Set expire to be a large number, since redis protocol sets expiry
            in a separate command. */
-        it = cuckoo_insert(key, NULL, INT32_MAX - 1);
+        it = cuckoo_insert(key, NULL, INT32_MAX);
         if (it == NULL) {
             rsp->type = reply->type = ELEM_ERR;
             reply->bstr = str2bstr(RSP_ERR_STORAGE);

--- a/src/storage/cuckoo/cuckoo.c
+++ b/src/storage/cuckoo/cuckoo.c
@@ -100,7 +100,11 @@ _select_candidate(const uint32_t offset[])
     if (cuckoo_policy == CUCKOO_POLICY_RANDOM) {
         selected = offset[RANDOM(D)];
     } else if (cuckoo_policy == CUCKOO_POLICY_EXPIRE) {
-        proc_time_i expire, min = UINT32_MAX; /* legal ts should < UINT32_MAX */
+        /*
+         * Selection prefers the item expiring soonest, followed by the one
+         * with the smallest offset.
+         */
+        proc_time_i expire, min = INT32_MAX;
         uint32_t i;
 
         for (i = 0; i < D; ++i) {

--- a/src/time/time.h
+++ b/src/time/time.h
@@ -239,7 +239,7 @@ static inline proc_time_i
 time_memcache2proc_sec(memcache_time_u t)
 {
     if (t == 0) {
-        return INT32_MAX - 1;
+        return INT32_MAX;
     }
 
     if (t > TIME_MEMCACHE_MAXDELTA_SEC) {
@@ -253,7 +253,7 @@ static inline proc_time_fine_i
 time_memcache2proc_ms(memcache_time_fine_u t)
 {
     if (t == 0) {
-        return INT64_MAX - 1;
+        return INT64_MAX;
     }
 
     if (t > TIME_MEMCACHE_MAXDELTA_MS) {
@@ -267,7 +267,7 @@ static inline proc_time_fine_i
 time_memcache2proc_us(memcache_time_fine_u t)
 {
     if (t == 0) {
-        return INT64_MAX - 1;
+        return INT64_MAX;
     }
 
     if (t > TIME_MEMCACHE_MAXDELTA_US) {
@@ -281,7 +281,7 @@ static inline proc_time_fine_i
 time_memcache2proc_ns(memcache_time_fine_u t)
 {
     if (t == 0) {
-        return INT64_MAX - 1;
+        return INT64_MAX;
     }
 
     if (t > TIME_MEMCACHE_MAXDELTA_NS) {

--- a/test/storage/cuckoo/check_cuckoo.c
+++ b/test/storage/cuckoo/check_cuckoo.c
@@ -72,7 +72,7 @@ test_insert_basic(uint32_t policy, bool cas)
     val.vstr.len = sizeof(VAL) - 1;
 
     time_update();
-    it = cuckoo_insert(&key, &val, INT32_MAX - 1);
+    it = cuckoo_insert(&key, &val, INT32_MAX);
     ck_assert_msg(it != NULL, "cuckoo_insert not OK");
 
     it = cuckoo_get(&key);
@@ -106,7 +106,7 @@ test_insert_collision(uint32_t policy, bool cas)
         val.type = VAL_TYPE_INT;
         val.vint = i;
 
-        it = cuckoo_insert(&key, &val, INT32_MAX - 1);
+        it = cuckoo_insert(&key, &val, INT32_MAX);
         ck_assert_msg(it != NULL, "cuckoo_insert not OK");
     }
 
@@ -150,7 +150,7 @@ test_cas(uint32_t policy)
     val.vstr.len = sizeof(VAL) - 1;
 
     time_update();
-    it = cuckoo_insert(&key, &val, INT32_MAX - 1);
+    it = cuckoo_insert(&key, &val, INT32_MAX);
     ck_assert_msg(it != NULL, "cuckoo_insert not OK");
 
     it = cuckoo_get(&key);
@@ -160,7 +160,7 @@ test_cas(uint32_t policy)
     val.vstr.data = VAL2;
     val.vstr.len = sizeof(VAL2) - 1;
 
-    status = cuckoo_update(it, &val, INT32_MAX - 1);
+    status = cuckoo_update(it, &val, INT32_MAX);
     ck_assert_msg(status == CC_OK, "cuckoo_update not OK - return status %d",
             status);
 
@@ -193,7 +193,7 @@ test_delete_basic(uint32_t policy, bool cas)
     val.vstr.len = sizeof(VAL) - 1;
 
     time_update();
-    it = cuckoo_insert(&key, &val, INT32_MAX - 1);
+    it = cuckoo_insert(&key, &val, INT32_MAX);
     ck_assert_msg(it != NULL, "cuckoo_insert not OK");
 
     it = cuckoo_get(&key);

--- a/test/storage/slab/check_slab.c
+++ b/test/storage/slab/check_slab.c
@@ -57,7 +57,7 @@ START_TEST(test_insert_basic)
     val = str2bstr(VAL);
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, MLEN, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, MLEN, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d",
             status);
     ck_assert_msg(!it->is_linked, "item with key %.*s not linked", key.len,
@@ -106,7 +106,7 @@ START_TEST(test_insert_large)
     val.len = VLEN;
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     free(val.data);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
@@ -152,7 +152,7 @@ START_TEST(test_reserve_backfill_release)
     cc_memset(val.data, 'A', val.len);
 
     /* reserve */
-    status = item_reserve(&it, &key, &val, vlen, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, vlen, 0, INT32_MAX);
     free(val.data);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d",
             status);
@@ -210,7 +210,7 @@ START_TEST(test_reserve_backfill_link)
 
     /* reserve */
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     free(val.data);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
 
@@ -248,7 +248,7 @@ START_TEST(test_append_basic)
     append = str2bstr(APPEND);
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
 
@@ -291,7 +291,7 @@ START_TEST(test_prepend_basic)
     prepend = str2bstr(PREPEND);
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
 
@@ -339,7 +339,7 @@ START_TEST(test_annex_sequence)
     append2 = str2bstr(APPEND2);
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
 
@@ -408,7 +408,7 @@ START_TEST(test_update_basic)
     new_val = str2bstr(NEW_VAL);
 
     time_update();
-    status = item_reserve(&it, &key, &old_val, old_val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &old_val, old_val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
 
@@ -448,7 +448,7 @@ START_TEST(test_delete_basic)
     val = str2bstr(VAL);
 
     time_update();
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key);
 
@@ -485,12 +485,12 @@ START_TEST(test_flush_basic)
     val2 = str2bstr(VAL2);
 
     time_update();
-    status = item_reserve(&it, &key1, &val1, val1.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key1, &val1, val1.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key1);
 
     time_update();
-    status = item_reserve(&it, &key2, &val2, val2.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key2, &val2, val2.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     item_insert(it, &key2);
 
@@ -551,7 +551,7 @@ START_TEST(test_evict_lru_basic)
 
     for (i = 0; i < NUM_ITEMS + 1; i++) {
         time_update();
-        status = item_reserve(&it, &key[i], &val[i], val[i].len, 0, INT32_MAX - 1);
+        status = item_reserve(&it, &key[i], &val[i], val[i].len, 0, INT32_MAX);
         ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
         item_insert(it, &key[i]);
         ck_assert_msg(item_get(&key[i]) != NULL, "item %lu not found", i);
@@ -587,7 +587,7 @@ START_TEST(test_refcount)
     val = str2bstr(VAL);
 
     /* reserve & release */
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     s = item_to_slab(it);
     ck_assert_msg(s->refcount == 1, "slab refcount %"PRIu32"; 1 expected", s->refcount);
@@ -595,7 +595,7 @@ START_TEST(test_refcount)
     ck_assert_msg(s->refcount == 0, "slab refcount %"PRIu32"; 0 expected", s->refcount);
 
     /* reserve & backfill (& link) */
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
     s = item_to_slab(it);
     ck_assert_msg(s->refcount == 1, "slab refcount %"PRIu32"; 1 expected", s->refcount);
@@ -635,13 +635,13 @@ START_TEST(test_evict_refcount)
     key = str2bstr(KEY);
     val = str2bstr(VAL);
 
-    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&it, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
-    status = item_reserve(&nit, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&nit, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_ENOMEM, "item_reserve should fail - return status %d", status);
 
     item_insert(it, &key); /* clears slab refcount, can be evicted */
-    status = item_reserve(&nit, &key, &val, val.len, 0, INT32_MAX - 1);
+    status = item_reserve(&nit, &key, &val, val.len, 0, INT32_MAX);
     ck_assert_msg(status == ITEM_OK, "item_reserve not OK - return status %d", status);
 
 #undef KEY


### PR DESCRIPTION
Addresses #189. I believe using UINT32_MAX - 1 was in reaction to cuckoo, where we assumed that timestamp will be less than UINT32_MAX for the sake of expiry based eviction. This change updates the behavior to use INT32_MAX to mean unbounded expiry in all places, and slightly changes the behavior of cuckoo's selection for eviction when using CUCKOO_POLICY_EXPIRE policy when multiple items share the min expiry timestamp. The new behavior makes it so that instead of selecting the first one in this case, the last one will be selected since we now select if expiry is <= to the min we've inspected, rather than <. I don't think this should cause any issue.