### PR TITLE
add prefill option and logic to populate the slabs with data

### DIFF
--- a/src/server/twemcache/data/process.c
+++ b/src/server/twemcache/data/process.c
@@ -25,6 +25,41 @@ typedef enum put_rstatus {
 static bool process_init = false;
 static process_metrics_st *process_metrics = NULL;
 static bool allow_flush = ALLOW_FLUSH;
+static bool prefill = PREFILL;
+static uint32_t prefill_ksize;
+static char prefill_kbuf[UINT8_MAX]; /* slab implementation has klen as unint8_t */
+static uint32_t prefill_vsize;
+/* val_buf size is arbitrary , update if want to warm up with larger objects */
+static char prefill_vbuf[ITEM_SIZE_MAX];
+static uint64_t prefill_nkey;
+
+static void
+_prefill_slab(void)
+{
+    struct bstring key, val;
+    item_rstatus_e istatus;
+    struct item *it;
+
+    key.len = prefill_ksize;
+    key.data = prefill_kbuf;
+    val.len = prefill_vsize;
+    val.data = prefill_vbuf;
+
+    for (uint32_t i = 0; i < prefill_nkey; ++i) {
+        /* print fixed-length key with leading 0's for padding */
+        cc_snprintf(&prefill_kbuf, key.len + 1, "%.*d", key.len, i);
+        /* fill val, use the same value as key for now */
+        cc_snprintf(&prefill_vbuf, val.len + 1, "%.*d", val.len, i);
+        /* insert into slab/heap */
+        istatus = item_reserve(&it, &key, &val, val.len, DATAFLAG_SIZE,
+                time_convert_proc_sec((time_i)INT32_MAX));
+        ASSERT(istatus == ITEM_OK);
+        item_insert(it, &key);
+    }
+
+    log_info("prefilling slab with %"PRIu64" keys, of key len %"PRIu32" & val "
+            "len %"PRIu32);
+}
 
 void
 process_setup(process_options_st *options, process_metrics_st *metrics)
@@ -40,6 +75,14 @@ process_setup(process_options_st *options, process_metrics_st *metrics)
 
     if (options != NULL) {
         allow_flush = option_bool(&options->allow_flush);
+        prefill = option_bool(&options->prefill);
+        prefill_ksize = (uint32_t)option_uint(&options->prefill_ksize);
+        prefill_vsize = (uint32_t)option_uint(&options->prefill_vsize);
+        prefill_nkey = (uint64_t)option_uint(&options->prefill_nkey);
+    }
+
+    if (prefill) {
+        _prefill_slab();
     }
 
     process_init = true;


### PR DESCRIPTION
This allows us to quickly fill a slab's heap with printed numeric keys/values, this is useful for performance tests.

Cache's RSS, which is primarily driven by the amount data stored in slab, is an important factor for performance. As memory gets bigger on modern hardware, it takes longer to fill the heap by external traffic. For example, if we want to warm up a 32GB heap, using 64 bit key+val sizes, we will need to create 300M keys. If we use 100K qps to warm it up, it will take almost an hour. This clearly makes realistic load testing fairly slow and expensive to conduct. In comparison, prefilling the memory inside the server can make this process at least an order of magnitude faster.

The implementation introduces a master switch `prefill`, and 3 options that control how prefilling should be performed, regarding key size, value size, and number of keys inserted. It also provides a summary of the operation including timing in the log.