### PR TITLE
Addresssanitizer: Fix buffer overflow in test_bitset_getset

### DIFF
--- a/test/data_structure/bitmap/check_bitmap.c
+++ b/test/data_structure/bitmap/check_bitmap.c
@@ -12,7 +12,8 @@
 #define BUF_SIZE 32
 
 #define NCOL1 64
-static uint16_t cols[4] = { 0, 7, 29, 42 };
+#define COLS_SIZE 4
+static uint16_t cols[COLS_SIZE] = { 0, 7, 29, 42 };
 
 static uint8_t buf[BUF_SIZE];
 static struct bitset *bs = (struct bitset *)buf;
@@ -43,7 +44,7 @@ START_TEST(test_bitset_getset)
     int i, j;
 
     bitset_init(bs, NCOL1);
-    for (i = 0, j = 0; i < NCOL1; i++) {
+    for (i = 0, j = 0; i < NCOL1 && j < COLS_SIZE; i++) {
         if (i == cols[j]) {
             bitset_set(bs, i, 1);
             j++;
@@ -53,7 +54,7 @@ START_TEST(test_bitset_getset)
         }
     }
 
-    for (j=0; j < 4; j++) { /* set these bits back to 0 */
+    for (j = 0; j < COLS_SIZE; j++) { /* set these bits back to 0 */
         ck_assert_int_eq(bitset_get(bs, cols[j]), 1);
         bitset_set(bs, cols[j], 0);
         ck_assert_int_eq(bitset_get(bs, cols[j]), 0);


### PR DESCRIPTION
Summary:
    ==79284==ERROR: AddressSanitizer: global-buffer-overflow on address
    0x00010d405de8 at pc 0x00010d404f79 bp 0x7ffee27fc5c0 sp 0x7ffee27fc5b8
    READ of size 2 at 0x00010d405de8 thread T0
        #0 0x10d404f78 in test_bitset_getset check_bitmap.c:47
        #1 0x10d40e898 in srunner_run_tagged (libcheck.0.dylib:x86_64+0x4898)
        #2 0x10d404c04 in main check_bitmap.c:90
        #3 0x7fff69fa2014 in start (libdyld.dylib:x86_64+0x1014)