### PR TITLE
ThreadSanitizer: Fix thread leak in test_thread in ring_array suite

### DIFF
--- a/deps/ccommon/test/ring_array/check_ring_array.c
+++ b/deps/ccommon/test/ring_array/check_ring_array.c
@@ -207,6 +207,7 @@ START_TEST(test_thread)
         }
     }
 
+    pthread_join(producer, NULL);
     ring_array_destroy(&arr);
 #undef ELEM_SIZE
 #undef CAP


### PR DESCRIPTION
Summary:
WARNING: ThreadSanitizer: thread leak (pid=73068)
Thread T1 (tid=6684080, finished) created by main thread at:
    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2999d)
    #1 test_thread check_ring_array.c:199 (check_ring_array:x86_64+0x10000231f)
    #2 srunner_run_tagged <null> (libcheck.0.dylib:x86_64+0x4898)
    #3 start <null> (libdyld.dylib:x86_64+0x1014)

ThreadSanitizer: thread leak check_ring_array.c:199 in test_thread