### PR TITLE
fix the bug of not resetting buf_sock object when terminating connections

### DIFF
--- a/src/core/data/server.c
+++ b/src/core/data/server.c
@@ -96,6 +96,7 @@ _server_pipe_read(void)
         }
         log_verb("Recycling buf_sock %p from worker thread", s);
         hdl->term(s->ch);
+        buf_sock_reset(s);
         buf_sock_return(&s);
     }
 }

--- a/src/protocol/data/memcache/response.c
+++ b/src/protocol/data/memcache/response.c
@@ -163,11 +163,6 @@ response_return_all(struct response **response)
 
     struct response *nr, *rsp = *response;
 
-    if (rsp == NULL) {
-        return;
-    }
-
-    nr = STAILQ_NEXT(rsp, next);
     while (rsp != NULL) {
         nr = STAILQ_NEXT(rsp, next);
         response_return(&rsp);

--- a/src/server/twemcache/data/process.c
+++ b/src/server/twemcache/data/process.c
@@ -844,9 +844,11 @@ twemcache_process_error(struct buf **rbuf, struct buf **wbuf, void **data)
         if (req->reserved != NULL) {
             item_release((struct item **)&req->reserved);
         }
-        request_return(&req);
         response_return_all(&rsp);
+        request_return(&req);
     }
+
+    *data = NULL;
 
     return 0;
 }


### PR DESCRIPTION
This leads to request object being double returned when the buf_sock object gets handed out again.