### PR TITLE
cmake: fix check detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,16 +126,15 @@ add_subdirectory(${CCOMMON_SOURCE_DIR} ${PROJECT_BINARY_DIR}/ccommon)
 include(FindPackageHandleStandardArgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
-find_package(Check)
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK QUIET check>=0.10)
+endif()
+
 if(NOT CHECK_FOUND)
-    message(WARNING "Check is required to build and run tests")
-endif(NOT CHECK_FOUND)
-if(CHECK_FOUND)
-    check_symbol_exists(ck_assert_int_eq check.h CHECK_WORKING)
-    if(NOT CHECK_WORKING)
-        message(WARNING "Check version too old to build tests")
-    endif(NOT CHECK_WORKING)
-endif(CHECK_FOUND)
+    find_package(Check QUIET 0.10)
+endif()
 
 find_package(Threads)
 
@@ -155,10 +154,10 @@ include_directories(${include_directories}
 add_subdirectory(src)
 
 # tests: always build last
-if(CHECK_WORKING)
-    include_directories(${include_directories} "${CHECK_INCLUDES}")
+if(CHECK_FOUND)
+    include_directories(${include_directories} ${CHECK_INCLUDES})
     add_subdirectory(test)
-endif(CHECK_WORKING)
+endif(CHECK_FOUND)
 
 # print a summary
 message(STATUS "PLATFORM: " ${OS_PLATFORM})

--- a/deps/ccommon/CMakeLists.txt
+++ b/deps/ccommon/CMakeLists.txt
@@ -140,16 +140,15 @@ endif(COVERAGE)
 include(FindPackageHandleStandardArgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 
-find_package(Check)
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK QUIET check>=0.10)
+endif()
+
 if(NOT CHECK_FOUND)
-    message(WARNING "Check is required to build and run tests")
-endif(NOT CHECK_FOUND)
-if(CHECK_FOUND)
-    check_symbol_exists(ck_assert_int_eq check.h CHECK_WORKING)
-    if(NOT CHECK_WORKING)
-        message(WARNING "Check version too old to build tests")
-    endif(NOT CHECK_WORKING)
-endif(CHECK_FOUND)
+    find_package(Check QUIET 0.10)
+endif()
 
 find_package(Threads)
 
@@ -166,10 +165,10 @@ include_directories(
 
 add_subdirectory(src)
 
-if(CHECK_WORKING)
-    include_directories(${include_directories} "${CHECK_INCLUDES}")
+if(CHECK_FOUND)
+    include_directories(${include_directories} ${CHECK_INCLUDES})
     add_subdirectory(test)
-endif(CHECK_WORKING)
+endif(CHECK_FOUND)
 
 
 if(HAVE_RUST)
@@ -193,4 +192,4 @@ message(STATUS "HAVE_SIGNAME: " ${HAVE_SIGNAME})
 
 message(STATUS "HAVE_BACKTRACE: " ${HAVE_BACKTRACE})
 
-message(STATUS "CHECK_WORKING: " ${CHECK_WORKING})
+message(STATUS "CHECK_FOUND: " ${CHECK_FOUND})


### PR DESCRIPTION
Building on Ubuntu 18.04 fails with missing symbols message
due to lack of proper libraries being automatically linked
against tests.

This patch uses pkgconfig to automatically detect system-installed
libcheck, and also gets rid of the unnecessery symbol requirement in
favor of a simple version check.