### PR TITLE
Fix cleaning after partial request

### DIFF
--- a/src/server/slimcache/data/process.c
+++ b/src/server/slimcache/data/process.c
@@ -448,6 +448,12 @@ _cleanup(struct request **req, struct response **rsp)
     response_return_all(rsp);
 }
 
+static inline void
+_cleanup_req(struct request **req)
+{
+    request_return(req);
+}
+
 int
 slimcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
 {
@@ -480,6 +486,7 @@ slimcache_process_read(struct buf **rbuf, struct buf **wbuf, void **data)
         if (status == PARSE_EUNFIN || req->partial) { /* ignore partial */
             (*rbuf)->rpos = old_rpos;
             buf_lshift(*rbuf);
+            _cleanup_req(&req);
             return 0;
         }
         if (status != PARSE_OK) {


### PR DESCRIPTION
Using partial request, like from rpc-perf, causes first request
buffer not to be returned to requests pool.

This commits adds function which will return this buffer to pool.