### PR TITLE
Fix pkg config detection and code cleanup

### DIFF
--- a/cmake/FindLIBPMEM.cmake
+++ b/cmake/FindLIBPMEM.cmake
@@ -1,0 +1,33 @@
+# Find the libpmem library.
+# Output variables:
+#  LIBPMEM_INCLUDE_DIRS : e.g., /usr/include/.
+#  LIBPMEM_LIBRARIES    : Library path of libpmem
+#  LIBPMEM_FOUND        : True if found.
+
+  ##_____________________________________________________________________________
+  ## Check for the header files
+
+  find_path (LIBPMEM_INCLUDE_DIRS
+    NAMES libpmem.h
+    PATH_SUFFIXES include
+    )
+
+  ##_____________________________________________________________________________
+  ## Check for the library
+
+  find_library (LIBPMEM_LIBRARIES pmem
+    PATH_SUFFIXES lib64 lib
+    )
+
+  ##_____________________________________________________________________________
+  ## Actions taken when all components have been found
+
+  find_package_handle_standard_args (LIBPMEM DEFAULT_MSG LIBPMEM_LIBRARIES LIBPMEM_INCLUDE_DIRS)
+
+if (LIBPMEM_FOUND)
+    message (STATUS "Found components for LIBPMEM")
+    message (STATUS "LIBPMEM_INCLUDE_DIRS  = ${LIBPMEM_INCLUDE_DIRS}")
+    message (STATUS "LIBPMEM_LIBRARIES  = ${LIBPMEM_LIBRARIES}")
+else ()
+    message(FATAL_ERROR "Could not find LIBPMEM, download and install from https://github.com/pmem/pmdk/releases")
+endif ()

--- a/src/storage/slab/slab.h
+++ b/src/storage/slab/slab.h
@@ -22,7 +22,6 @@
 #define SLAB_EVICT_OPT  EVICT_RS
 #define SLAB_USE_FREEQ  true
 #define SLAB_PROFILE    NULL
-#define SLAB_HASH       16
 #define SLAB_USE_CAS    true
 #define ITEM_SIZE_MIN   44      /* 40 bytes item overhead */
 #define ITEM_SIZE_MAX   (SLAB_SIZE - SLAB_HDR_SIZE)


### PR DESCRIPTION
Fix libpmem detection in case of pkg_config is missing 
Remove SLAB_HASH macro (all occurrences were replaced by HASH_POWER macro in b12de66)