### PR TITLE
Add basic support of build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,22 @@ configure_file(
 # set compiler flags
 # string concat is easier in 3.0, but older versions don't have the concat subcommand
 # so we are using list as input until we move to new version
-# TODO once we add build types, we should also set flags such as "-O2 "
 add_definitions(-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64)
+# Set a default build type (Release) if none was specified
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+endif()
 add_definitions()
 set(CFLAGS_LIST
     "-std=c11 "
-    "-ggdb3 -O2 "
+    "-ggdb3 "
     "-Wall -Wshadow -Winline "
     "-Wstrict-prototypes -Wmissing-prototypes "
     "-Wmissing-declarations -Wredundant-decls "
@@ -114,7 +124,10 @@ string(REPLACE "" "" LOCAL_CFLAGS ${CFLAGS_LIST})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  ${LOCAL_CFLAGS}")
 
 if (COVERAGE)
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -W -fprofile-arcs -ftest-coverage")
+    if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+        message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading" )
+    endif()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 endif(COVERAGE)
 
 # build dependencies
@@ -172,6 +185,9 @@ endif(CHECK_FOUND)
 add_subdirectory(benchmarks)
 
 # print a summary
+
+message(STATUS "CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+
 message(STATUS "PLATFORM: " ${OS_PLATFORM})
 
 message(STATUS "CPPFLAGS: " ${CMAKE_CPP_FLAGS})

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -5,7 +5,7 @@ rm -rf lcov _build _bin
 
 mkdir _build
 pushd _build
-cmake -DCOVERAGE=on ..
+cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=on ..
 make -j
 make test
 popd


### PR DESCRIPTION
- debug build type to pass O0 flag, other to pass O2 flag
- remove unnecessary flags from COVERAGE -g -Wall -W
- ref: twitter/ccommon@1c8df4200ca245fc87b07a235b490e91e88f7b48