### PR TITLE
initial check-in of intarray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,10 +116,15 @@ if(BUILD_AND_INSTALL_CHECK)
     set(CMAKE_REQUIRED_LIBRARIES "${CHECK_ROOT_DIR}/lib")
 endif()
 
+find_package(PkgConfig QUIET)
+
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(CHECK QUIET check>=0.10)
+endif()
+
 if(NOT CHECK_FOUND)
     find_package(Check QUIET 0.10)
 endif()
-
 
 
 if(${OS_PLATFORM} MATCHES "OS_LINUX")
@@ -145,12 +150,6 @@ add_subdirectory(${CCOMMON_SOURCE_DIR} ${PROJECT_BINARY_DIR}/ccommon)
 # other dependencies
 include(FindPackageHandleStandardArgs)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
-
-find_package(PkgConfig QUIET)
-
-if(PKG_CONFIG_FOUND)
-    pkg_check_modules(CHECK QUIET check>=0.10)
-endif()
 
 if (USE_PMEM)
     if(PKG_CONFIG_FOUND)
@@ -186,7 +185,9 @@ if(CHECK_FOUND)
     add_subdirectory(test)
 endif(CHECK_FOUND)
 
-# add_subdirectory(benchmarks)
+if(${OS_PLATFORM} MATCHES "OS_LINUX")
+  add_subdirectory(benchmarks)
+endif()
 
 # print a summary
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ if(BUILD_AND_INSTALL_CHECK)
     set(CMAKE_REQUIRED_LIBRARIES "${CHECK_ROOT_DIR}/lib")
 endif()
 
+if(NOT CHECK_FOUND)
+    find_package(Check QUIET 0.10)
+endif()
+
+
+
 if(${OS_PLATFORM} MATCHES "OS_LINUX")
   set(CFLAGS_LIST "${CFLAGS_LIST} -lrt")
 endif()
@@ -144,10 +150,6 @@ find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)
     pkg_check_modules(CHECK QUIET check>=0.10)
-endif()
-
-if(NOT CHECK_FOUND)
-    find_package(Check QUIET 0.10)
 endif()
 
 if (USE_PMEM)
@@ -179,11 +181,12 @@ add_subdirectory(src)
 
 # tests: always build last
 if(CHECK_FOUND)
-    include_directories(${include_directories} ${CHECK_INCLUDES})
+    include_directories(${CHECK_INCLUDE_DIRS})
+    link_directories(${CHECK_LIBRARY_DIRS})
     add_subdirectory(test)
 endif(CHECK_FOUND)
 
-add_subdirectory(benchmarks)
+# add_subdirectory(benchmarks)
 
 # print a summary
 

--- a/src/data_structure/CMakeLists.txt
+++ b/src/data_structure/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(bitmap)
+add_subdirectory(intarray)
 add_subdirectory(ziplist)

--- a/src/data_structure/intarray/CMakeLists.txt
+++ b/src/data_structure/intarray/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(ds_intarray intarray.c)

--- a/src/data_structure/intarray/intarray.c
+++ b/src/data_structure/intarray/intarray.c
@@ -93,7 +93,7 @@ _linear_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, ui
 
 
     for (i = 0; i < nentry; ++i, ++*idx) {
-        if (val == _get_value(_position(body, esize, 0), esize)) {
+        if (val == _get_value(_position(body, esize, i), esize)) {
             return true;
         }
     }
@@ -115,6 +115,11 @@ _binary_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, ui
 
     if (val == _get_value(_position(body, esize, 0), esize)) {
         return true;
+    }
+
+    if (val > _get_value(_position(body, esize, nentry - 1), esize)) {
+        *idx = nentry;
+        return false;
     }
 
     imin = 1;
@@ -188,7 +193,7 @@ intarray_value(uint64_t *val, const intarray_p ia, uint32_t idx)
     }
 
     esize = intarray_esize(ia);
-    *val = _get_value(IA_BODY(ia) + esize * idx, esize);
+    *val = _get_value(_position(IA_BODY(ia), esize, idx), esize);
 
     return INTARRAY_OK;
 }
@@ -303,8 +308,10 @@ intarray_truncate(intarray_p ia, int64_t count)
 
     if (count > 0) { /* only need to move data if truncating from left */
         cc_memmove(body, body + esize * count, esize * (nentry - count));
+        IA_NENTRY(ia) -= count;
+    } else {
+        IA_NENTRY(ia) += count;
     }
-    IA_NENTRY(ia) -= count;
 
     return INTARRAY_OK;
 }

--- a/src/data_structure/intarray/intarray.c
+++ b/src/data_structure/intarray/intarray.c
@@ -161,7 +161,7 @@ intarray_init(intarray_p ia, uint32_t esize)
         return INTARRAY_ERROR;
     }
 
-    if (esize != 1 || esize != 2 || esize != 4 || esize != 8) {
+    if (esize != 1 && esize != 2 && esize != 4 && esize != 8) {
         return INTARRAY_EINVALID;
     }
 

--- a/src/data_structure/intarray/intarray.c
+++ b/src/data_structure/intarray/intarray.c
@@ -2,7 +2,6 @@
 
 #include <cc_debug.h>
 
-//#include <stdbool.h>
 
 #define IA_BODY(_ia) ((uint8_t *)(_ia) + INTARRAY_HEADER_SIZE)
 #define SCAN_THRESHOLD 64

--- a/src/data_structure/intarray/intarray.c
+++ b/src/data_structure/intarray/intarray.c
@@ -1,0 +1,311 @@
+#include "intarray.h"
+
+#include <cc_debug.h>
+
+//#include <stdbool.h>
+
+#define IA_BODY(_ia) ((uint8_t *)(_ia) + INTARRAY_HEADER_SIZE)
+#define SCAN_THRESHOLD 64
+
+static inline uint8_t *
+_position(uint8_t *body, uint32_t esize, uint32_t idx)
+{
+    return body + esize * idx;
+}
+
+
+/* false if value is out of range for entry size */
+static inline bool
+_validate_range(uint32_t esize, uint64_t val)
+{
+    switch (esize) {
+    case 8:
+        return true;
+    case 4:
+        return val <= UINT32_MAX;
+    case 2:
+        return val <= UINT16_MAX;
+    case 1:
+        return val <= UINT8_MAX;
+    default:
+        NOT_REACHED();
+        return false;
+    }
+}
+
+static inline uint64_t
+_get_value(uint8_t *p, uint32_t esize)
+{
+    switch (esize) {
+    case 8:
+        return *((uint64_t *)p);
+    case 4:
+        return *((uint32_t *)p);
+    case 2:
+        return *((uint16_t *)p);
+    case 1:
+        return *p;
+    default:
+        NOT_REACHED();
+        return 0;
+    }
+}
+
+static inline void
+_set_value(uint8_t *p, uint32_t esize, uint64_t val)
+{
+    switch (esize) {
+    case 8:
+        *((uint64_t *)p) = val;
+        break;
+    case 4:
+        *((uint32_t *)p) = val;
+        break;
+    case 2:
+        *((uint16_t *)p) = val;
+        break;
+    case 1:
+        *p = val;
+        break;
+    default:
+        NOT_REACHED();
+    }
+}
+
+static inline bool
+_should_scan(uint32_t nentry, uint32_t esize) {
+    return nentry * esize <= SCAN_THRESHOLD;
+}
+
+/* returns true if an exact match is found, false otherwise.
+ * If a match is found, the index of the element is stored in idx;
+ * otherwise, idx contains the index of the insertion spot
+ */
+static inline bool
+_linear_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+{
+    uint32_t i;
+
+    *idx = 0;
+
+    if (nentry == 0) {
+        return false;
+    }
+
+
+    for (i = 0; i < nentry; ++i, ++*idx) {
+        if (val == _get_value(_position(body, esize, 0), esize)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static inline bool
+_binary_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+{
+    uint32_t id, imin, imax;
+    uint32_t curr;
+
+    *idx = 0;
+
+    if (nentry == 0) {
+        return false;
+    }
+
+    if (val == _get_value(_position(body, esize, 0), esize)) {
+        return true;
+    }
+
+    imin = 1;
+    imax = nentry - 1;
+    while (imin <= imax) {
+        id = (imin + imax) / 2;
+        curr = _get_value(_position(body, esize, id), esize);
+        if (val == curr) {
+            *idx = id;
+            return true;
+        }
+
+        if (val > curr) {
+            imin = id + 1;
+        } else {
+            if (val <= _get_value(_position(body, esize, id - 1), esize)) {
+                imax = id - 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    *idx = id;
+
+    return false;
+}
+
+static inline bool
+_locate(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+{
+    if (_should_scan(nentry, esize)) { /* linear scan */
+        return _linear_search(idx, body, nentry, esize, val);
+    } else { /* otherwise, binary search  */
+        return _binary_search(idx, body, nentry, esize, val);
+    }
+}
+
+
+intarray_rstatus_e
+intarray_init(intarray_p ia, uint32_t esize)
+{
+    if (ia == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    if (esize != 1 || esize != 2 || esize != 4 || esize != 8) {
+        return INTARRAY_EINVALID;
+    }
+
+    IA_NENTRY(ia) = 0;
+    IA_ESIZE(ia) = esize;
+
+    return INTARRAY_OK;
+}
+
+
+intarray_rstatus_e
+intarray_value(uint64_t *val, const intarray_p ia, uint32_t idx)
+{
+    uint32_t esize, nentry;
+
+    if (val == NULL || ia == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    nentry = intarray_nentry(ia);
+    idx += (idx < 0) * nentry;
+    if (idx < 0 || idx >= nentry) {
+        return INTARRAY_EOOB;
+    }
+
+    esize = intarray_esize(ia);
+    *val = _get_value(IA_BODY(ia) + esize * idx, esize);
+
+    return INTARRAY_OK;
+}
+
+/* caller should discard values in idx if function returns ENOTFOUND */
+intarray_rstatus_e
+intarray_index(uint32_t *idx, const intarray_p ia, uint64_t val)
+{
+    uint32_t esize;
+    bool found;
+
+    if (ia == NULL || idx == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    esize = intarray_esize(ia);
+    if (!_validate_range(esize, val)) {
+        return INTARRAY_EINVALID;
+    }
+
+    found = _locate(idx, IA_BODY(ia), intarray_nentry(ia), esize, val);
+    if (found) {
+        return INTARRAY_OK;
+    } else {
+        return INTARRAY_ENOTFOUND;
+    }
+}
+
+
+intarray_rstatus_e
+intarray_insert(intarray_p ia, uint64_t val)
+{
+    bool found;
+    uint8_t *body, *p;
+    uint32_t idx, esize, nentry;
+
+    if (ia == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    esize = intarray_esize(ia);
+    if (!_validate_range(esize, val)) {
+        return INTARRAY_EINVALID;
+    }
+
+    body = IA_BODY(ia);
+    nentry = intarray_nentry(ia);
+    found = _locate(&idx, body, nentry, esize, val);
+    if (found) {
+        return INTARRAY_EDUP;
+    }
+
+    p = _position(body, esize, idx);
+    cc_memmove(p + esize, p, esize * (nentry - idx));
+    _set_value(p, esize, val);
+    IA_NENTRY(ia)++;
+
+    return INTARRAY_OK;
+}
+
+intarray_rstatus_e
+intarray_remove(intarray_p ia, uint64_t val)
+{
+    bool found;
+    uint8_t *body, *p;
+    uint32_t idx, esize, nentry;
+
+    if (ia == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    esize = intarray_esize(ia);
+    if (!_validate_range(esize, val)) {
+        return INTARRAY_EINVALID;
+    }
+
+    body = IA_BODY(ia);
+    nentry = intarray_nentry(ia);
+    found = _locate(&idx, body, nentry, esize, val);
+    if (found) {
+        p = _position(body, esize, idx);
+        cc_memmove(p, p + esize, esize * (nentry - idx - 1));
+        IA_NENTRY(ia)--;
+
+        return INTARRAY_OK;
+    }
+
+    return INTARRAY_ENOTFOUND;
+}
+
+intarray_rstatus_e
+intarray_truncate(intarray_p ia, int64_t count)
+{
+    uint8_t *body;
+    uint32_t esize, nentry;
+
+    if (ia == NULL) {
+        return INTARRAY_ERROR;
+    }
+
+    if (count == 0) {
+        return INTARRAY_OK;
+    }
+
+    body = IA_BODY(ia);
+    esize = intarray_esize(ia);
+    nentry = intarray_nentry(ia);
+    /* if abs(count) >= num entries in the array, remove all */
+    if (count >= nentry || -count >= nentry) {
+        return intarray_init(ia, intarray_esize(ia));
+    }
+
+    if (count > 0) { /* only need to move data if truncating from left */
+        cc_memmove(body, body + esize * count, esize * (nentry - count));
+    }
+    IA_NENTRY(ia) -= count;
+
+    return INTARRAY_OK;
+}

--- a/src/data_structure/intarray/intarray.h
+++ b/src/data_structure/intarray/intarray.h
@@ -84,6 +84,7 @@ intarray_esize(const intarray_p ia)
     return IA_ESIZE(ia);
 }
 
+/* initialize an intarray of element size 1/2/4/8 bytes */
 intarray_rstatus_e intarray_init(intarray_p ia, uint32_t esize);
 
 /* intarray APIs: seek */

--- a/src/data_structure/intarray/intarray.h
+++ b/src/data_structure/intarray/intarray.h
@@ -1,0 +1,102 @@
+#pragma once
+
+/* The intarray is designed for sorted array of integers of uniform but
+ * configurable sizes, including 1-, 2-, 4-, 8-byte unsigned integers.
+ * The array can be of ASC or DESC order. Once an array is created, these
+ * configurable attributes cannot be changed.
+ *
+ * Because of the limitation on data type, intarray is both more memory-
+ * efficient and faster for value lookups compared to a more generic data
+ * structure such as ziplist. It is particularly useful if users intend to
+ * keep a sorted list of numbers without duplication, such as an index of
+ * numeric IDs.
+ *
+ * NOTE: start with ASC order, allow DESC later.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * INTARRAY OVERALL LAYOUT
+ * =======================
+ *
+ * The general layout of the intarray is as follows:
+ *
+ * <nentry><esize> <entry> <entry> ... <entry>
+ * ╰------------╯    ╰-------------------------╯
+ *     header                   body
+ *
+ * Overhead: 8 bytes
+ *
+ * <uint32_t nentry> is the number of entries.
+ *
+ * <uint32_t esize> is the size of each entry (of value 1, 2, 4, 8 for now)
+ *
+ *
+ * INTARRAY ENTRIES
+ * ================
+ *
+ * Every entry in the intarray is a simple integer of size specified in the
+ * header.
+ *
+ * RUNTIME
+ * =======
+ *
+ * Entry lookup takes O(log N) where N is the number of entries in the list. If
+ * the entry size are below a threshold (64-bytes for now), then a linear scan
+ * is performed instead of binary lookup.
+ *
+ * Insertion and removal of entries involve index-based lookup, as well as
+ * shifting data. So in additional to the considerations above, the amount of
+ * data being moved for updates will affect performance. Updates near the "fixed
+ * end" of the ziplist (currently the beginning) require moving more data and
+ * therefore will be slower. Overall, it is cheapest to perform updates at the
+ * end of the array due to zero data movement.
+ *
+ */
+
+#include <stdint.h>
+
+#define INTARRAY_HEADER_SIZE 8
+
+typedef uint8_t * intarray_p;
+
+typedef enum {
+    INTARRAY_OK,
+    INTARRAY_ENOTFOUND,  /* value not found error */
+    INTARRAY_EOOB,       /* out-of-bound error */
+    INTARRAY_EINVALID,   /* invalid data error */
+    INTARRAY_EDUP,       /* duplicate value found */
+    INTARRAY_ERROR,
+    INTARRAY_SENTINEL
+} intarray_rstatus_e;
+
+#define IA_NENTRY(_ia) (*((uint32_t *)(_ia)))
+#define IA_ESIZE(_ia) (*((uint32_t *)(_ia) + 1))
+
+static inline uint32_t
+intarray_nentry(const intarray_p ia)
+{
+    return IA_NENTRY(ia);
+}
+
+static inline uint32_t
+intarray_esize(const intarray_p ia)
+{
+    return IA_ESIZE(ia);
+}
+
+intarray_rstatus_e intarray_init(intarray_p ia, uint32_t esize);
+
+/* intarray APIs: seek */
+intarray_rstatus_e intarray_value(uint64_t *val, const intarray_p ia, uint32_t idx);
+intarray_rstatus_e intarray_index(uint32_t *idx, const intarray_p ia, uint64_t val);
+
+/* ziplist APIs: modify */
+intarray_rstatus_e intarray_insert(intarray_p ia, uint64_t val);
+intarray_rstatus_e intarray_remove(intarray_p ia, uint64_t val);
+
+/*
+ * if count is positive, remove count entries starting at the beginning
+ * if count is negative, remove -count entries starting at the end
+ */
+intarray_rstatus_e intarray_truncate(intarray_p ia, int64_t count);
+

--- a/src/storage/cuckoo/CMakeLists.txt
+++ b/src/storage/cuckoo/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(cuckoo cuckoo.c)
-target_link_libraries(cuckoo datapool)
+target_link_libraries(cuckoo datapool time)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,5 @@
 include_directories(${include_directories} CHECK_INCLUDES)
 
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-
 add_subdirectory(data_structure)
 add_subdirectory(protocol)
 add_subdirectory(hotkey)

--- a/test/data_structure/CMakeLists.txt
+++ b/test/data_structure/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(bitmap)
+add_subdirectory(intarray)
 add_subdirectory(ziplist)

--- a/test/data_structure/bitmap/CMakeLists.txt
+++ b/test/data_structure/bitmap/CMakeLists.txt
@@ -8,5 +8,4 @@ target_link_libraries(${test_name} ds_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/data_structure/intarray/CMakeLists.txt
+++ b/test/data_structure/intarray/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} ds_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/data_structure/intarray/CMakeLists.txt
+++ b/test/data_structure/intarray/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(suite intarray)
+set(test_name check_${suite})
+
+set(source check_${suite}.c)
+
+add_executable(${test_name} ${source})
+target_link_libraries(${test_name} ds_${suite})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
+
+add_dependencies(check ${test_name})
+add_test(${test_name} ${test_name})

--- a/test/data_structure/intarray/check_intarray.c
+++ b/test/data_structure/intarray/check_intarray.c
@@ -1,0 +1,63 @@
+#include <data_structure/intarray/intarrah.h>
+
+#include <cc_mm.h>
+#include <stdio.h>
+
+#include <check.h>
+
+/* define for each suite, local scope due to macro visibility rule */
+#define SUITE_NAME "intarray"
+#define DEBUG_LOG  SUITE_NAME ".log"
+
+#define BUF_SIZE 8200
+#define NENTRY   1024
+
+static char buf[BUF_SIZE];
+
+
+/*
+ * intarray tests
+ */
+
+START_TEST(test_intarray_create)
+{
+    ck_assert(intarray_init(buf, 1) == INTARRAY_OK);
+    ck_assert(intarray_init(buf, 2) == INTARRAY_OK);
+    ck_assert(intarray_init(buf, 4) == INTARRAY_OK);
+    ck_assert(intarray_init(buf, 8) == INTARRAY_OK);
+    ck_assert(intarray_init(buf, 16) == INTARRAY_EINVALID);
+    ck_assert(intarray_init(buf, 3) == INTARRAY_EINVALID);
+}
+END_TEST
+
+
+/*
+ * test suite
+ */
+static Suite *
+intarray_suite(void)
+{
+    Suite *s = suite_create(SUITE_NAME);
+
+    TCase *tc_intarray = tcase_create("intarray");
+    suite_add_tcase(s, tc_intarray);
+
+    tcase_add_test(tc_zipentry, test_intarray_create);
+
+    return s;
+}
+
+int
+main(void)
+{
+    int nfail;
+
+    Suite *suite = intarray_suite();
+    SRunner *srunner = srunner_create(suite);
+    srunner_set_log(srunner, DEBUG_LOG);
+    srunner_run_all(srunner, CK_ENV); /* set CK_VEBOSITY in ENV to customize */
+    nfail = srunner_ntests_failed(srunner);
+    srunner_free(srunner);
+
+    return (nfail == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/data_structure/intarray/check_intarray.c
+++ b/test/data_structure/intarray/check_intarray.c
@@ -22,7 +22,7 @@ static unsigned char buf[BUF_SIZE];
 
 START_TEST(test_intarray_create)
 {
-    ck_assert(intarray_init(buf, 1) == INTARRAY_OK);
+    ck_assert_int_eq(intarray_init(buf, 1), INTARRAY_OK);
     ck_assert(intarray_init(buf, 2) == INTARRAY_OK);
     ck_assert(intarray_init(buf, 4) == INTARRAY_OK);
     ck_assert(intarray_init(buf, 8) == INTARRAY_OK);

--- a/test/data_structure/intarray/check_intarray.c
+++ b/test/data_structure/intarray/check_intarray.c
@@ -1,7 +1,8 @@
-#include <data_structure/intarray/intarrah.h>
+#include <data_structure/intarray/intarray.h>
 
 #include <cc_mm.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <check.h>
 
@@ -12,7 +13,7 @@
 #define BUF_SIZE 8200
 #define NENTRY   1024
 
-static char buf[BUF_SIZE];
+static unsigned char buf[BUF_SIZE];
 
 
 /*
@@ -42,7 +43,7 @@ intarray_suite(void)
     TCase *tc_intarray = tcase_create("intarray");
     suite_add_tcase(s, tc_intarray);
 
-    tcase_add_test(tc_zipentry, test_intarray_create);
+    tcase_add_test(tc_intarray, test_intarray_create);
 
     return s;
 }

--- a/test/data_structure/intarray/check_intarray.c
+++ b/test/data_structure/intarray/check_intarray.c
@@ -23,11 +23,100 @@ static unsigned char buf[BUF_SIZE];
 START_TEST(test_intarray_create)
 {
     ck_assert_int_eq(intarray_init(buf, 1), INTARRAY_OK);
-    ck_assert(intarray_init(buf, 2) == INTARRAY_OK);
-    ck_assert(intarray_init(buf, 4) == INTARRAY_OK);
-    ck_assert(intarray_init(buf, 8) == INTARRAY_OK);
-    ck_assert(intarray_init(buf, 16) == INTARRAY_EINVALID);
-    ck_assert(intarray_init(buf, 3) == INTARRAY_EINVALID);
+    ck_assert_int_eq(intarray_init(buf, 2), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 0);
+    ck_assert_int_eq(intarray_init(buf, 4), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 0);
+    ck_assert_int_eq(intarray_init(buf, 8), INTARRAY_OK);
+    ck_assert_int_eq(intarray_init(buf, 16), INTARRAY_EINVALID);
+    ck_assert_int_eq(intarray_init(buf, 3), INTARRAY_EINVALID);
+}
+END_TEST
+
+
+START_TEST(test_intarray_insert_seek)
+{
+    uint32_t idx;
+    uint64_t val;
+
+    ck_assert_int_eq(intarray_init(buf, 1), INTARRAY_OK);
+    ck_assert_int_eq(intarray_insert(buf, 1), INTARRAY_OK);
+    ck_assert_int_eq(intarray_insert(buf, 3), INTARRAY_OK);
+    ck_assert_int_eq(intarray_insert(buf, 5), INTARRAY_OK);
+    ck_assert_int_eq(intarray_insert(buf, 12345), INTARRAY_EINVALID);
+    ck_assert_int_eq(intarray_nentry(buf), 3);
+    ck_assert_int_eq(intarray_value(&val, buf, 1), INTARRAY_OK);
+    ck_assert_int_eq(val, 3);
+    ck_assert_int_eq(intarray_index(&idx, buf, 3), INTARRAY_OK);
+    ck_assert_int_eq(idx, 1);
+    ck_assert_int_eq(intarray_index(&idx, buf, 2), INTARRAY_ENOTFOUND);
+
+    ck_assert_int_eq(intarray_init(buf, 8), INTARRAY_OK);
+    for (int i = 0; i < 50; ++i) { /* 0, 2, 4, ..., 98 */
+        ck_assert_int_eq(intarray_insert(buf, 1000 + i * 2), INTARRAY_OK);
+    }
+    ck_assert_int_eq(intarray_nentry(buf), 50);
+    ck_assert_int_eq(intarray_value(&val, buf, 10), INTARRAY_OK);
+    ck_assert_int_eq(val, 1020);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1020), INTARRAY_OK);
+    ck_assert_int_eq(idx, 10);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1000), INTARRAY_OK);
+    ck_assert_int_eq(idx, 0);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1098), INTARRAY_OK);
+    ck_assert_int_eq(idx, 49);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1), INTARRAY_ENOTFOUND);
+    ck_assert_int_eq(intarray_index(&idx, buf, 2000), INTARRAY_ENOTFOUND);
+}
+END_TEST
+
+START_TEST(test_intarray_remove)
+{
+    uint32_t idx;
+
+    intarray_init(buf, 1);
+    intarray_insert(buf, 1);
+    intarray_insert(buf, 3);
+    intarray_insert(buf, 5);
+    ck_assert_int_eq(intarray_remove(buf, 12345), INTARRAY_EINVALID);
+
+    intarray_init(buf, 8);
+    for (int i = 0; i < 50; ++i) { /* 0, 2, 4, ..., 98 */
+        intarray_insert(buf, 1000 + i * 2);
+    }
+    ck_assert_int_eq(intarray_nentry(buf), 50);
+    ck_assert_int_eq(intarray_remove(buf, 1020), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 49);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1020), INTARRAY_ENOTFOUND);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1022), INTARRAY_OK);
+    ck_assert_int_eq(idx, 10);
+    ck_assert_int_eq(intarray_remove(buf, 1000), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 48);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1000), INTARRAY_ENOTFOUND);
+    ck_assert_int_eq(intarray_remove(buf, 1098), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 47);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1098), INTARRAY_ENOTFOUND);
+}
+END_TEST
+
+START_TEST(test_intarray_truncate)
+{
+    uint32_t idx;
+
+    intarray_init(buf, 8);
+    for (int i = 0; i < 50; ++i) { /* 0, 2, 4, ..., 98 */
+        intarray_insert(buf, 1000 + i * 2);
+    }
+    ck_assert_int_eq(intarray_nentry(buf), 50);
+    ck_assert_int_eq(intarray_truncate(buf, -10), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 40);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1080), INTARRAY_ENOTFOUND);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1078), INTARRAY_OK);
+    ck_assert_int_eq(intarray_truncate(buf, 10), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 30);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1018), INTARRAY_ENOTFOUND);
+    ck_assert_int_eq(intarray_index(&idx, buf, 1020), INTARRAY_OK);
+    ck_assert_int_eq(intarray_truncate(buf, 31), INTARRAY_OK);
+    ck_assert_int_eq(intarray_nentry(buf), 0);
 }
 END_TEST
 
@@ -44,6 +133,9 @@ intarray_suite(void)
     suite_add_tcase(s, tc_intarray);
 
     tcase_add_test(tc_intarray, test_intarray_create);
+    tcase_add_test(tc_intarray, test_intarray_insert_seek);
+    tcase_add_test(tc_intarray, test_intarray_remove);
+    tcase_add_test(tc_intarray, test_intarray_truncate);
 
     return s;
 }

--- a/test/data_structure/ziplist/CMakeLists.txt
+++ b/test/data_structure/ziplist/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} ds_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/data_structure/ziplist/check_ziplist.c
+++ b/test/data_structure/ziplist/check_ziplist.c
@@ -558,7 +558,7 @@ END_TEST
  * test suite
  */
 static Suite *
-zipmap_suite(void)
+ziplist_suite(void)
 {
     Suite *s = suite_create(SUITE_NAME);
     int i;
@@ -608,7 +608,7 @@ main(void)
 {
     int nfail;
 
-    Suite *suite = zipmap_suite();
+    Suite *suite = ziplist_suite();
     SRunner *srunner = srunner_create(suite);
     srunner_set_log(srunner, DEBUG_LOG);
     srunner_run_all(srunner, CK_ENV); /* set CK_VEBOSITY in ENV to customize */

--- a/test/datapool/CMakeLists.txt
+++ b/test/datapool/CMakeLists.txt
@@ -8,5 +8,4 @@ target_link_libraries(${test_name} ${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} datapool)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/hotkey/kc_map/CMakeLists.txt
+++ b/test/hotkey/kc_map/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} hotkey)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/hotkey/key_window/CMakeLists.txt
+++ b/test/hotkey/key_window/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} hotkey)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/protocol/admin/CMakeLists.txt
+++ b/test/protocol/admin/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} protocol_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/protocol/data/memcache/CMakeLists.txt
+++ b/test/protocol/data/memcache/CMakeLists.txt
@@ -9,5 +9,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} protocol_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/protocol/data/redis/CMakeLists.txt
+++ b/test/protocol/data/redis/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} protocol_${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/storage/cuckoo/CMakeLists.txt
+++ b/test/storage/cuckoo/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${test_name} time)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/storage/slab/CMakeLists.txt
+++ b/test/storage/slab/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${test_name} time)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-#add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/storage/slab/CMakeLists.txt
+++ b/test/storage/slab/CMakeLists.txt
@@ -9,5 +9,5 @@ target_link_libraries(${test_name} time)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-add_dependencies(check ${test_name})
+#add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/time/CMakeLists.txt
+++ b/test/time/CMakeLists.txt
@@ -7,5 +7,4 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} ${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 
-#add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/time/CMakeLists.txt
+++ b/test/time/CMakeLists.txt
@@ -7,5 +7,5 @@ add_executable(${test_name} ${source})
 target_link_libraries(${test_name} ${suite})
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 
-add_dependencies(check ${test_name})
+#add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})


### PR DESCRIPTION
The intarray is designed for sorted array of integers of uniform but
configurable sizes, including 1-, 2-, 4-, 8-byte unsigned integers.

Because of the limitation on data type, intarray is both more memory-
efficient and faster for value lookups compared to a more generic data
structure such as ziplist. It is particularly useful if users intend to
keep a sorted list of numbers without duplication, such as an index of
numeric IDs.
