### PR TITLE
Fix pelikan scripts

### DIFF
--- a/scripts/load_testing/client_config.py
+++ b/scripts/load_testing/client_config.py
@@ -25,7 +25,7 @@ def generate_config(rate, connections, vsize, slab_mem, threads):
   config_str = '''
 [general]
 clients = {threads}
-tcp-nodelay = true
+tcp_nodelay = true
 poolsize = {connections} # this specifies number of connection per thread
 # runtime ~= windows x duration
 windows = 2

--- a/scripts/load_testing/server_config.py
+++ b/scripts/load_testing/server_config.py
@@ -89,7 +89,7 @@ slab_evict_opt: 1
 slab_prealloc: yes
 slab_hash_power: {hash_power}
 slab_mem: {slab_mem}
-slab_size: 1048756
+slab_size: 1048576
 slab_datapool_prefault: yes
 
 stats_intvl: 10000


### PR DESCRIPTION
- Rename rpc-perf parameter to tcp_nodelay

-  Fix value of slab_size to be equal exactly 1MiB