### PR TITLE
Update implementation of file-backed durable slab storage

### DIFF
--- a/benchmarks/bench_storage.c
+++ b/benchmarks/bench_storage.c
@@ -76,6 +76,7 @@ benchmark_create(struct benchmark *b, const char *config)
     nopts += bench_storage_config_nopts();
 
     b->options = cc_alloc(sizeof(struct option) * nopts);
+    ASSERT(b->options != NULL);
     b->options->benchmark = opts;
 
     bench_storage_config_init(b->options->engine);
@@ -84,6 +85,8 @@ benchmark_create(struct benchmark *b, const char *config)
         FILE *fp = fopen(config, "r");
         if (fp == NULL) {
             log_crit("failed to open the config file");
+            cc_free(b->options);
+
             return CC_EINVAL;
         }
         option_load_file(fp, (struct option *)b->options, nopts);
@@ -93,6 +96,7 @@ benchmark_create(struct benchmark *b, const char *config)
     if (O(b, entry_min_size) <= sizeof(benchmark_key_u)) {
         log_crit("entry_min_size must larger than %lu",
             sizeof(benchmark_key_u));
+        cc_free(b->options);
 
         return CC_EINVAL;
     }
@@ -305,6 +309,10 @@ benchmark_run(struct benchmark *b)
     duration_stop(&d);
 
     bench_storage_deinit();
+
+    array_destroy(&in);
+    array_destroy(&in2);
+    array_destroy(&out);
 
     return d;
 }

--- a/src/datapool/datapool_pmem.c
+++ b/src/datapool/datapool_pmem.c
@@ -141,14 +141,14 @@ datapool_initialize(struct datapool *pool, const char *user_name)
 }
 
 static void
-datapool_flag_set(struct datapool *pool, int flag)
+datapool_flag_set(struct datapool *pool, uint64_t flag)
 {
     pool->hdr->flags |= flag;
     datapool_sync_hdr(pool);
 }
 
 static void
-datapool_flag_clear(struct datapool *pool, int flag)
+datapool_flag_clear(struct datapool *pool, uint64_t flag)
 {
     pool->hdr->flags &= ~flag;
     datapool_sync_hdr(pool);

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -379,14 +379,16 @@ _slab_heapinfo_setup(void)
 static void
 _slab_heapinfo_teardown(void)
 {
-    struct slab_pool_metadata pool_metadata =
-    {
-        datapool_addr(pool_slab),
-        TAILQ_FIRST(&heapinfo.slab_lruq)
-    };
+    if (pool_slab) {
+        struct slab_pool_metadata pool_metadata =
+        {
+            datapool_addr(pool_slab),
+            TAILQ_FIRST(&heapinfo.slab_lruq)
+        };
 
-    datapool_set_user_data(pool_slab, &pool_metadata, sizeof(struct slab_pool_metadata));
-    datapool_close(pool_slab);
+        datapool_set_user_data(pool_slab, &pool_metadata, sizeof(struct slab_pool_metadata));
+        datapool_close(pool_slab);
+    }
 }
 
 static rstatus_i

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -163,6 +163,18 @@ _slab_put_item_into_freeq(struct item *it, uint8_t id)
 }
 
 /*
+ * Because a slab can have a reserved item (claimed but not linked), which is
+ * requested when a write command does not have the entirety of value in the
+ * buffer, eviction will fail if the slab has a non-zero refcount. True is
+ * returned if the slab got no reserved items, otherwise False.
+ */
+static inline bool
+_slab_check_no_refcount(struct slab *slab)
+{
+    return (slab->refcount == 0);
+}
+
+/*
  * Recreate items
  */
 static void
@@ -189,6 +201,11 @@ _slab_recreate_items(struct slab *slab)
             }
         } else if (it->in_freeq) {
             _slab_put_item_into_freeq(it, slab->id);
+        } else if (it->klen && !_slab_check_no_refcount(slab)) {
+           /* before reset, item could be only reserved
+            * ensure that slab has a reserved item(s)
+            */
+           item_release(&it);
         }
     }
 }
@@ -699,19 +716,6 @@ _slab_get_new(void)
     return slab;
 }
 
-
-/*
- * Because a slab can have a reserved item (claimed but not linked), which is
- * requested when a write command does not have the entirety of value in the
- * buffer, eviction will fail if the slab has a non-zero refcount. True is
- * returned if the slab is successfully evicted, False if eviction is denied.
- */
-static inline bool
-_slab_evict_ok(struct slab *slab)
-{
-    return (slab->refcount == 0);
-}
-
 /*
  * Evict a slab by evicting all the items within it. This means that the
  * items that are carved out of the slab must either be deleted from their
@@ -775,7 +779,7 @@ _slab_evict_rand(void)
 
     do {
         slab = _slab_table_rand();
-    } while (slab != NULL && ++i < TRIES_MAX && !_slab_evict_ok(slab));
+    } while (slab != NULL && ++i < TRIES_MAX && !_slab_check_no_refcount(slab));
 
     if (slab == NULL) {
         /* warning here because eviction failure should be rare. This can
@@ -800,7 +804,7 @@ _slab_evict_lru(int id)
     struct slab *slab = _slab_lruq_head();
     int i = 0;
 
-    while (slab != NULL && ++i < TRIES_MAX && !_slab_evict_ok(slab)) {
+    while (slab != NULL && ++i < TRIES_MAX && !_slab_check_no_refcount(slab)) {
         slab = TAILQ_NEXT(slab, s_tqe);
     };
 

--- a/test/storage/cuckoo_pmem/CMakeLists.txt
+++ b/test/storage/cuckoo_pmem/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${test_name} time)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/storage/slab_pmem/CMakeLists.txt
+++ b/test/storage/slab_pmem/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${test_name} time)
 target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES})
 target_link_libraries(${test_name} pthread m)
 
-add_dependencies(check ${test_name})
 add_test(${test_name} ${test_name})

--- a/test/storage/slab_pmem/check_slab_pmem.c
+++ b/test/storage/slab_pmem/check_slab_pmem.c
@@ -9,6 +9,7 @@
 #include <check.h>
 #include <stdio.h>
 #include <string.h>
+#include <sysexits.h>
 
 /* define for each suite, local scope due to macro visibility rule */
 #define SUITE_NAME "slab"
@@ -947,6 +948,19 @@ START_TEST(test_evict_refcount)
 }
 END_TEST
 
+START_TEST(test_setup_wrong_path)
+{
+#define DATAPOOL_PATH_WRONG "./"
+
+    option_load_default((struct option *)&options, OPTION_CARDINALITY(options));
+    options.slab_datapool.val.vstr = DATAPOOL_PATH_WRONG;
+
+    slab_setup(&options, &metrics);
+
+#undef DATAPOOL_PATH_WRONG
+}
+END_TEST
+
 /*
  * test suite
  */
@@ -979,6 +993,7 @@ slab_suite(void)
     tcase_add_test(tc_slab, test_evict_lru_basic);
     tcase_add_test(tc_slab, test_refcount);
     tcase_add_test(tc_slab, test_evict_refcount);
+    tcase_add_exit_test(tc_slab, test_setup_wrong_path, EX_CONFIG);
 
     return s;
 }


### PR DESCRIPTION
- Fix check related configuration for USE_PMEM continue of 14fcd34
- Corrects teardown when wrong pool was used:
In situations when pm pool creation failed, teardown process causes
SIGSEGV due to accessing empty datapool structure. Fail may be caused
by wrong size, path or file permissions. This commit skips heapinfo
teardown in such situation.
- Add reserved only items after reset to freeq
- Additional fixes for static analysis issue 