### PR TITLE
Sorted map

### DIFF
--- a/src/data_structure/CMakeLists.txt
+++ b/src/data_structure/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(bitmap)
 add_subdirectory(sarray)
+add_subdirectory(smap)
 add_subdirectory(ziplist)

--- a/src/data_structure/sarray/sarray.c
+++ b/src/data_structure/sarray/sarray.c
@@ -3,11 +3,11 @@
 #include <cc_debug.h>
 
 
-#define SA_BODY(_sa) ((uint8_t *)(_sa) + SARRAY_HEADER_SIZE)
+#define SA_BODY(_sa) ((char *)(_sa) + SARRAY_HEADER_SIZE)
 #define SCAN_THRESHOLD 64
 
-static inline uint8_t *
-_position(uint8_t *body, uint32_t esize, uint32_t idx)
+static inline char *
+_position(char *body, uint32_t esize, uint32_t idx)
 {
     return body + esize * idx;
 }
@@ -33,7 +33,7 @@ _validate_range(uint32_t esize, uint64_t val)
 }
 
 static inline uint64_t
-_get_value(uint8_t *p, uint32_t esize)
+_get_value(char *p, uint32_t esize)
 {
     switch (esize) {
     case 8:
@@ -51,7 +51,7 @@ _get_value(uint8_t *p, uint32_t esize)
 }
 
 static inline void
-_set_value(uint8_t *p, uint32_t esize, uint64_t val)
+_set_value(char *p, uint32_t esize, uint64_t val)
 {
     switch (esize) {
     case 8:
@@ -81,7 +81,7 @@ _should_scan(uint32_t nentry, uint32_t esize) {
  * otherwise, idx contains the index of the insertion spot
  */
 static inline bool
-_linear_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+_linear_search(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize, uint64_t val)
 {
     uint32_t i;
 
@@ -106,7 +106,7 @@ _linear_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, ui
 }
 
 static inline bool
-_binary_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+_binary_search(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize, uint64_t val)
 {
     uint32_t id = 0, imin, imax;
     uint32_t curr;
@@ -155,7 +155,7 @@ _binary_search(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, ui
 }
 
 static inline bool
-_locate(uint32_t *idx, uint8_t *body, uint32_t nentry, uint32_t esize, uint64_t val)
+_locate(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize, uint64_t val)
 {
     /* optimize for inserting at the end, which is dominant in many use cases */
     if (nentry == 0 || _get_value(body + esize * (nentry - 1), esize) < val) {
@@ -251,7 +251,7 @@ sarray_rstatus_e
 sarray_insert(sarray_p sa, uint64_t val)
 {
     bool found;
-    uint8_t *body, *p;
+    char *body, *p;
     uint32_t idx, esize, nentry;
 
     if (sa == NULL) {
@@ -287,7 +287,7 @@ sarray_rstatus_e
 sarray_remove(sarray_p sa, uint64_t val)
 {
     bool found;
-    uint8_t *body, *p;
+    char *body, *p;
     uint32_t idx, esize, nentry;
 
     if (sa == NULL) {
@@ -321,7 +321,7 @@ sarray_remove(sarray_p sa, uint64_t val)
 sarray_rstatus_e
 sarray_truncate(sarray_p sa, int64_t count)
 {
-    uint8_t *body;
+    char *body;
     uint32_t esize, nentry;
 
     if (sa == NULL) {

--- a/src/data_structure/sarray/sarray.h
+++ b/src/data_structure/sarray/sarray.h
@@ -46,7 +46,7 @@
  * Insertion and removal of entries involve index-based lookup, as well as
  * shifting data. So in additional to the considerations above, the amount of
  * data being moved for updates will affect performance. Updates near the "fixed
- * end" of the ziplist (currently the beginning) require moving more data and
+ * end" of the array (currently the beginning) require moving more data and
  * therefore will be slower. Overall, it is cheapest to perform updates at the
  * end of the array due to zero data movement.
  *
@@ -56,7 +56,7 @@
 
 #define SARRAY_HEADER_SIZE 8
 
-typedef uint8_t * sarray_p;
+typedef char * sarray_p;
 
 typedef enum {
     SARRAY_OK,
@@ -96,7 +96,7 @@ sarray_rstatus_e sarray_init(sarray_p sa, uint32_t esize);
 sarray_rstatus_e sarray_value(uint64_t *val, const sarray_p sa, uint32_t idx);
 sarray_rstatus_e sarray_index(uint32_t *idx, const sarray_p sa, uint64_t val);
 
-/* ziplist APIs: modify */
+/* sarray APIs: modify */
 sarray_rstatus_e sarray_insert(sarray_p sa, uint64_t val);
 sarray_rstatus_e sarray_remove(sarray_p sa, uint64_t val);
 

--- a/src/data_structure/smap/CMakeLists.txt
+++ b/src/data_structure/smap/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(ds_smap smap.c)

--- a/src/data_structure/smap/smap.c
+++ b/src/data_structure/smap/smap.c
@@ -1,0 +1,380 @@
+#include "smap.h"
+
+#include <cc_debug.h>
+
+
+#define SM_BODY(_sm) ((char *)(_sm) + SMAP_HEADER_SIZE)
+#define SCAN_THRESHOLD 64
+
+static inline char *
+_position(char *body, uint32_t esize, uint32_t idx)
+{
+    return body + esize * idx;
+}
+
+
+/* false if key is out of range for entry size */
+static inline bool
+_validate_range(uint16_t ksize, uint64_t key)
+{
+    switch (ksize) {
+    case 8:
+        return true;
+    case 4:
+        return key <= UINT32_MAX;
+    case 2:
+        return key <= UINT16_MAX;
+    case 1:
+        return key <= UINT8_MAX;
+    default:
+        NOT_REACHED();
+        return false;
+    }
+}
+
+static inline uint64_t
+_get_key(char *p, uint16_t ksize)
+{
+    switch (ksize) {
+    case 8:
+        return *((uint64_t *)p);
+    case 4:
+        return *((uint32_t *)p);
+    case 2:
+        return *((uint16_t *)p);
+    case 1:
+        return *p;
+    default:
+        NOT_REACHED();
+        return 0;
+    }
+}
+
+static inline void
+_set_key(char *p, uint16_t ksize, uint64_t key)
+{
+    switch (ksize) {
+    case 8:
+        *((uint64_t *)p) = key;
+        break;
+    case 4:
+        *((uint32_t *)p) = key;
+        break;
+    case 2:
+        *((uint16_t *)p) = key;
+        break;
+    case 1:
+        *p = key;
+        break;
+    default:
+        NOT_REACHED();
+    }
+}
+
+static inline bool
+_should_scan(uint32_t nentry, uint32_t esize) {
+    return nentry * esize <= SCAN_THRESHOLD;
+}
+
+/* returns true if an exact match is found, false otherwise.
+ * If a match is found, the index of the element is stored in idx;
+ * otherwise, idx contains the index of the insertion spot
+ */
+static inline bool
+_linear_search(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize,
+        uint16_t ksize, uint64_t key)
+{
+    uint32_t i;
+
+    *idx = 0;
+
+    if (nentry == 0) {
+        return false;
+    }
+
+
+    for (i = 0; i < nentry; ++i, ++*idx) {
+        if (key <= _get_key(_position(body, esize, i), ksize)) {
+            break;
+        }
+    }
+
+    if (key == _get_key(_position(body, esize, *idx), ksize)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static inline bool
+_binary_search(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize,
+        uint16_t ksize, uint64_t key)
+{
+    uint32_t id = 0, imin, imax;
+    uint32_t curr;
+
+    *idx = 0;
+
+    if (nentry == 0) {
+        return false;
+    }
+
+    if (key == _get_key(_position(body, esize, 0), ksize)) {
+        return true;
+    }
+    if (key < _get_key(_position(body, esize, 0), ksize)) {
+        return false;
+    }
+    if (key > _get_key(_position(body, esize, nentry - 1), ksize)) {
+        *idx = nentry;
+        return false;
+    }
+
+    imin = 1;
+    imax = nentry - 1;
+    while (imin <= imax) {
+        id = (imin + imax) / 2;
+        curr = _get_key(_position(body, esize, id), ksize);
+        if (key == curr) {
+            *idx = id;
+            return true;
+        }
+
+        if (key > curr) {
+            imin = id + 1;
+        } else {
+            if (key <= _get_key(_position(body, esize, id - 1), ksize)) {
+                imax = id - 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    *idx = id;
+
+    return false;
+}
+
+static inline bool
+_locate(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize,
+        uint16_t ksize, uint64_t key)
+{
+    /* optimize for inserting at the end, which is dominant in many use cases */
+    if (nentry == 0 || _get_key(body + esize * (nentry - 1), esize) < key) {
+        *idx = nentry;
+
+        return false;
+    }
+
+    if (_should_scan(nentry, esize)) { /* linear scan */
+        return _linear_search(idx, body, nentry, esize, ksize, key);
+    } else { /* otherwise, binary search  */
+        return _binary_search(idx, body, nentry, esize, ksize, key);
+    }
+}
+
+
+smap_rstatus_e
+smap_init(smap_p sm, uint16_t ksize, uint16_t vsize)
+{
+    if (sm == NULL) {
+        log_debug("NULL pointer encountered for sm");
+
+        return SMAP_ERROR;
+    }
+
+    if (ksize != 1 && ksize != 2 && ksize != 4 && ksize != 8) {
+        log_debug("%"PRIu32" is not a valid key size", ksize);
+
+        return SMAP_EINVALID;
+    }
+
+    SM_NENTRY(sm) = 0;
+    SM_KSIZE(sm) = ksize;
+    SM_VSIZE(sm) = vsize;
+
+    return SMAP_OK;
+}
+
+
+smap_rstatus_e
+smap_keyval(uint64_t *key, struct bstring *val, const smap_p sm, uint32_t idx)
+{
+    uint32_t esize, ksize, nentry;
+    char *entry;
+
+    if (key == NULL || val == NULL || sm == NULL) {
+        log_debug("NULL pointer encountered for sm %p, key %p, or val %p", sm,
+                key, val);
+
+        return SMAP_ERROR;
+    }
+
+    nentry = smap_nentry(sm);
+    idx += (idx < 0) * nentry;
+    if (idx < 0 || idx >= nentry) {
+        return SMAP_EOOB;
+    }
+
+    esize = smap_esize(sm);
+    ksize = smap_ksize(sm);
+    entry = _position(SM_BODY(sm), esize, idx);
+
+    *key = _get_key(entry, ksize);
+    val->len = smap_vsize(sm);
+    val->data = entry + ksize;
+
+    return SMAP_OK;
+}
+
+/* caller should discard keys in idx if function returns ENOTFOUND */
+smap_rstatus_e
+smap_index(uint32_t *idx, const smap_p sm, uint64_t key)
+{
+    uint32_t esize;
+    uint16_t ksize;
+    bool found;
+
+    if (sm == NULL || idx == NULL) {
+        log_debug("NULL pointer encountered for sm %p or key %p", sm, key);
+
+        return SMAP_ERROR;
+    }
+
+    ksize = smap_ksize(sm);
+    if (!_validate_range(ksize, key)) {
+        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+                ksize);
+
+        return SMAP_EINVALID;
+    }
+
+    esize = smap_esize(sm);
+    found = _locate(idx, SM_BODY(sm), smap_nentry(sm), esize, ksize, key);
+    if (found) {
+        return SMAP_OK;
+    } else {
+        return SMAP_ENOTFOUND;
+    }
+}
+
+
+smap_rstatus_e
+smap_insert(smap_p sm, uint64_t key, const struct bstring *val)
+{
+    bool found;
+    char *body, *p;
+    uint16_t ksize, vsize;
+    uint32_t idx, esize, nentry;
+
+    if (sm == NULL) {
+        log_debug("NULL pointer encountered for sm");
+
+        return SMAP_ERROR;
+    }
+
+    ksize = smap_ksize(sm);
+    if (!_validate_range(ksize, key)) {
+        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+                ksize);
+
+        return SMAP_EINVALID;
+    }
+    vsize = smap_vsize(sm);
+    if (val->len != vsize) {
+        log_debug("value size %"PRIu16" is different for %"PRIu16" map initial",
+                val->len, vsize);
+
+        return SMAP_EINVALID;
+    }
+
+    body = SM_BODY(sm);
+    nentry = smap_nentry(sm);
+    esize = smap_esize(sm);
+    found = _locate(&idx, body, nentry, esize, ksize, key);
+    if (found) {
+        return SMAP_EDUP;
+    }
+
+    p = _position(body, esize, idx);
+    cc_memmove(p + esize, p, esize * (nentry - idx));
+    _set_key(p, ksize, key);
+    cc_memcpy(p + ksize, val->data, vsize); /* copy val */
+    SM_NENTRY(sm)++;
+
+    return SMAP_OK;
+}
+
+smap_rstatus_e
+smap_remove(smap_p sm, uint64_t key)
+{
+    bool found;
+    char *body, *p;
+    uint16_t ksize;
+    uint32_t idx, esize, nentry;
+
+    if (sm == NULL) {
+        log_debug("NULL pointer encountered for sm");
+
+        return SMAP_ERROR;
+    }
+
+    ksize = smap_ksize(sm);
+    if (!_validate_range(ksize, key)) {
+        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+                ksize);
+
+        return SMAP_EINVALID;
+    }
+
+    body = SM_BODY(sm);
+    nentry = smap_nentry(sm);
+    esize = smap_esize(sm);
+    found = _locate(&idx, body, nentry, esize, ksize, key);
+    if (found) {
+        p = _position(body, esize, idx);
+        cc_memmove(p, p + esize, esize * (nentry - idx - 1));
+        SM_NENTRY(sm)--;
+
+        return SMAP_OK;
+    }
+
+    return SMAP_ENOTFOUND;
+}
+
+smap_rstatus_e
+smap_truncate(smap_p sm, int64_t count)
+{
+    char *body;
+    uint32_t esize, nentry;
+
+    if (sm == NULL) {
+        log_debug("NULL pointer encountered for sm");
+
+        return SMAP_ERROR;
+    }
+
+    if (count == 0) {
+        return SMAP_OK;
+    }
+
+    body = SM_BODY(sm);
+    esize = smap_esize(sm);
+    nentry = smap_nentry(sm);
+    /* if abs(count) >= num entries in the array, remove all */
+    if (count >= nentry || -count >= nentry) {
+        SM_NENTRY(sm) = 0;
+
+        return SMAP_OK;
+    }
+
+    if (count > 0) { /* only need to move data if truncating from left */
+        cc_memmove(body, body + esize * count, esize * (nentry - count));
+        SM_NENTRY(sm) -= count;
+    } else {
+        SM_NENTRY(sm) += count;
+    }
+
+    return SMAP_OK;
+}

--- a/src/data_structure/smap/smap.c
+++ b/src/data_structure/smap/smap.c
@@ -43,7 +43,7 @@ _get_key(char *p, uint16_t ksize)
     case 2:
         return *((uint16_t *)p);
     case 1:
-        return *p;
+        return *((uint8_t *)p);
     default:
         NOT_REACHED();
         return 0;
@@ -64,7 +64,7 @@ _set_key(char *p, uint16_t ksize, uint64_t key)
         *((uint16_t *)p) = key;
         break;
     case 1:
-        *p = key;
+        *((uint8_t *)p) = key;
         break;
     default:
         NOT_REACHED();
@@ -161,7 +161,7 @@ _locate(uint32_t *idx, char *body, uint32_t nentry, uint32_t esize,
         uint16_t ksize, uint64_t key)
 {
     /* optimize for inserting at the end, which is dominant in many use cases */
-    if (nentry == 0 || _get_key(body + esize * (nentry - 1), esize) < key) {
+    if (nentry == 0 || _get_key(body + esize * (nentry - 1), ksize) < key) {
         *idx = nentry;
 
         return false;
@@ -244,7 +244,7 @@ smap_index(uint32_t *idx, const smap_p sm, uint64_t key)
 
     ksize = smap_ksize(sm);
     if (!_validate_range(ksize, key)) {
-        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+        log_debug("%"PRIu64" out of range for %"PRIu16" byte integer", key,
                 ksize);
 
         return SMAP_EINVALID;
@@ -276,7 +276,7 @@ smap_insert(smap_p sm, uint64_t key, const struct bstring *val)
 
     ksize = smap_ksize(sm);
     if (!_validate_range(ksize, key)) {
-        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+        log_debug("%"PRIu64" out of range for %"PRIu16" byte integer", key,
                 ksize);
 
         return SMAP_EINVALID;
@@ -322,7 +322,7 @@ smap_remove(smap_p sm, uint64_t key)
 
     ksize = smap_ksize(sm);
     if (!_validate_range(ksize, key)) {
-        log_debug("%"PRIu64" out of range for %"PRIu32" byte integer", key,
+        log_debug("%"PRIu64" out of range for %"PRIu16" byte integer", key,
                 ksize);
 
         return SMAP_EINVALID;

--- a/src/data_structure/smap/smap.h
+++ b/src/data_structure/smap/smap.h
@@ -1,0 +1,131 @@
+#pragma once
+
+/* The smap (sorted map) is designed for maps with uniform entry size and keyed
+ * on sorted integers. The size of both key and value are configurable upon
+ * creation.
+ * Currently we only implemented keys that are unsigned integers of width 1-,
+ * 2-, 4-, 8-byte. But it can be extended to byte strings as well. The values
+ * could be binary blobs of a fixed size up to 2**16 bytes. The map is stored in
+ * ASC order without duplicates. Once an array is created, these configurable
+ * attributes cannot be changed.
+ *
+ * TODO(yao): support variable size up to a max within the same map object
+ *
+ * Because of the limitation on data type, smap is both more memory-efficient
+ * and faster for key lookups compared to a more generic data structure such as
+ * ziplist. It is particularly useful if users intend to keep a sorted map of
+ * entries without duplication, such as key-val pairs indexed by numeric IDs.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * SMAP OVERALL LAYOUT
+ * =====================
+ *
+ * The general layout of the smap is as follows:
+ *                          entry
+ *                        ╭--------╮
+ * <nentry><ksize><vsize> <key><val> <key><val> ... <key><val>
+ * ╰--------------------╯ ╰----------------------------------╯
+ *         header                         body
+ *
+ * Overhead: 8 bytes
+ *
+ * <uint32_t nentry> is the number of entries.
+ *
+ * For each entry:
+ * <uint16_t ksize> is the size of key field in each entry (of value 1, 2, 4, 8
+ *   for now)
+ * <uint16_t vsize> is the size of val field in each entry
+ *
+ *
+ * SMAP ENTRIES
+ * ==============
+ *
+ * Every entry in the smap is a tuple of one integer and a byte array of sizes
+ * specified in the header.
+ *
+ * RUNTIME
+ * =======
+ *
+ * Entry lookup takes O(log N) where N is the number of entries in the list. If
+ * the entry size are below a threshold (64-bytes for now), then a linear scan
+ * is performed instead of binary lookup.
+ *
+ * Insertion and removal of entries involve index-based lookup, as well as
+ * shifting data. So in additional to the considerations above, the amount of
+ * data being moved for updates will affect performance. Updates near the "fixed
+ * end" of the ziplist (currently the beginning) require moving more data and
+ * therefore will be slower. Overall, it is cheapest to perform updates at the
+ * end of the array due to zero data movement.
+ *
+ */
+
+#include <cc_bstring.h>
+
+#include <stdint.h>
+
+#define SMAP_HEADER_SIZE 8
+
+typedef char * smap_p;
+
+typedef enum {
+    SMAP_OK,
+    SMAP_ENOTFOUND,  /* value not found error */
+    SMAP_EOOB,       /* out-of-bound error */
+    SMAP_EINVALID,   /* invalid data error */
+    SMAP_EDUP,       /* duplicate value found */
+    SMAP_ERROR,
+    SMAP_SENTINEL
+} smap_rstatus_e;
+
+#define SM_NENTRY(_sm) (*((uint32_t *)(_sm)))
+#define SM_KSIZE(_sm) (*((uint16_t *)((_sm) + sizeof(uint32_t))))
+#define SM_VSIZE(_sm) (*((uint16_t *)((_sm) + sizeof(uint32_t) + sizeof(uint16_t))))
+#define SM_ESIZE(_sm) ((uint32_t)SM_KSIZE(_sm) + (uint32_t)SM_VSIZE(_sm))
+
+static inline uint32_t
+smap_nentry(const smap_p sm)
+{
+    return SM_NENTRY(sm);
+}
+
+static inline uint16_t
+smap_ksize(const smap_p sm)
+{
+    return SM_KSIZE(sm);
+}
+
+static inline uint16_t
+smap_vsize(const smap_p sm)
+{
+    return SM_VSIZE(sm);
+}
+
+static inline uint32_t
+smap_esize(const smap_p sm)
+{
+    return SM_ESIZE(sm);
+}
+
+static inline uint32_t
+smap_size(const smap_p sm)
+{
+    return SMAP_HEADER_SIZE + SM_ESIZE(sm) * SM_NENTRY(sm);
+}
+
+/* initialize an smap of key size 1/2/4/8 bytes and vsize */
+smap_rstatus_e smap_init(smap_p sm, uint16_t ksize, uint16_t vsize);
+
+/* smap APIs: seek */
+smap_rstatus_e smap_keyval(uint64_t *key, struct bstring *val, const smap_p sm, uint32_t idx);
+smap_rstatus_e smap_index(uint32_t *idx, const smap_p sm, uint64_t key);
+
+/* smap APIs: modify */
+smap_rstatus_e smap_insert(smap_p sm, uint64_t key, const struct bstring *val);
+smap_rstatus_e smap_remove(smap_p sm, uint64_t key);
+
+/*
+ * if count is positive, remove count entries starting at the beginning
+ * if count is negative, remove -count entries starting at the end
+ */
+smap_rstatus_e smap_truncate(smap_p sm, int64_t count);

--- a/src/protocol/data/resp/cmd_smap.h
+++ b/src/protocol/data/resp/cmd_smap.h
@@ -9,7 +9,7 @@
 
 /**
  * create: create an empty map or integer width ESIZE & value width VSIZE
- * SMap.create KEY ESIZE VSIZE [WATERMARK_L] [WATERMARK_H]
+ * SMap.create KEY ISIZE VSIZE [WATERMARK_L] [WATERMARK_H]
  *
  * delete: delete an map
  * SMap.delete KEY
@@ -49,13 +49,12 @@
 typedef enum smap_elem {
     SMAP_VERB = 0,
     SMAP_KEY = 1,
-    SMAP_ESIZE = 2,
+    SMAP_ISIZE = 2,
+    SMAP_VSIZE = 3,
     SMAP_IKEY = 2,
     SMAP_IDX = 2,
     SMAP_CNT = 2,
-    SMAP_VSIZE = 3,
-    SMAP_VAL = 3,
     SMAP_ICNT = 3, /* when an index is also present */
-    SMAP_WML = 3,  /* watermark (low) */
-    SMAP_WMH = 4,  /* watermark (high) */
+    SMAP_WML = 4,  /* watermark (low) */
+    SMAP_WMH = 5,  /* watermark (high) */
 } smap_elem_e;

--- a/src/protocol/data/resp/cmd_smap.h
+++ b/src/protocol/data/resp/cmd_smap.h
@@ -1,0 +1,61 @@
+#pragma once
+
+/**
+ * KEY: key used to represet the sorted map
+ * IKEY: integer key that is used for sorting within a map
+ * VALUE: fixed width value that is associated with an IKEY
+ * COUNT: number of elements, can be negative which indicates right to left
+ */
+
+/**
+ * create: create an empty map or integer width ESIZE & value width VSIZE
+ * SMap.create KEY ESIZE VSIZE [WATERMARK_L] [WATERMARK_H]
+ *
+ * delete: delete an map
+ * SMap.delete KEY
+ *
+ * len: return number of entries in map
+ * SMap.len KEY
+ *
+ * find: find (rank of an ikey) in map
+ * SMap.find KEY IKEY
+ *
+ * get: get entry/entries at an index
+ * SMap.get KEY [INDEX [COUNT]]
+ *
+ * insert: insert ikey
+ * SMap.insert KEY IKEY VALUE [IKEY VALUE ...]
+ *
+ * remove: remove a particular ikey from map
+ * SMap.remove KEY IKEY [IKEY ...]
+ *
+ * truncate: truncate a map
+ * SMap.truncate KEY COUNT
+ *
+ */
+
+
+/*          type                string              #arg    #opt */
+#define REQ_SMAP(ACTION)                                            \
+    ACTION( REQ_SMAP_CREATE,    "SMap.create",      3,      2  )\
+    ACTION( REQ_SMAP_DELETE,    "SMap.delete",      2,      0  )\
+    ACTION( REQ_SMAP_LEN,       "SMap.len",         2,      0  )\
+    ACTION( REQ_SMAP_FIND,      "SMap.find",        3,      0  )\
+    ACTION( REQ_SMAP_GET,       "SMap.get",         2,      2  )\
+    ACTION( REQ_SMAP_INSERT,    "SMap.insert",      3,      -1 )\
+    ACTION( REQ_SMAP_REMOVE,    "SMap.remove",      3,      -1 )\
+    ACTION( REQ_SMAP_TRUNCATE,  "SMap.truncate",    3,      0  )
+
+typedef enum smap_elem {
+    SMAP_VERB = 0,
+    SMAP_KEY = 1,
+    SMAP_ESIZE = 2,
+    SMAP_IKEY = 2,
+    SMAP_IDX = 2,
+    SMAP_CNT = 2,
+    SMAP_VSIZE = 3,
+    SMAP_VAL = 3,
+    SMAP_ICNT = 3, /* when an index is also present */
+    SMAP_WML = 3,  /* watermark (low) */
+    SMAP_WMH = 4,  /* watermark (high) */
+} smap_elem_e;

--- a/src/protocol/data/resp/request.c
+++ b/src/protocol/data/resp/request.c
@@ -22,6 +22,7 @@ struct command command_table[REQ_SENTINEL] = {
     REQ_HASH(CMD_INIT)
     REQ_LIST(CMD_INIT)
     REQ_SARRAY(CMD_INIT)
+    REQ_SMAP(CMD_INIT)
     REQ_ZSET(CMD_INIT)
     REQ_MISC(CMD_INIT)
 };

--- a/src/protocol/data/resp/request.h
+++ b/src/protocol/data/resp/request.h
@@ -5,6 +5,7 @@
 #include "cmd_list.h"
 #include "cmd_misc.h"
 #include "cmd_sarray.h"
+#include "cmd_smap.h"
 #include "cmd_zset.h"
 #include "token.h"
 
@@ -49,6 +50,7 @@ typedef enum cmd_type {
     REQ_HASH(GET_TYPE)
     REQ_LIST(GET_TYPE)
     REQ_SARRAY(GET_TYPE)
+    REQ_SMAP(GET_TYPE)
     REQ_ZSET(GET_TYPE)
     REQ_MISC(GET_TYPE)
     REQ_SENTINEL

--- a/src/rust-util/pelikan-sys/build.rs
+++ b/src/rust-util/pelikan-sys/build.rs
@@ -636,6 +636,26 @@ fn main() {
     if cfg!(feature = "ds_sarray") {
         gen_ds_sarray();
     }
+    if cfg!(feature = "ds_smap") {
+        print_directives("ds_smap", "data_structure/smap");
+
+        let bindings = builder()
+            .header("../../data_structure/smap/smap.h")
+            .whitelist_type("smap_p")
+            .whitelist_type("smap_rstatus_e")
+            .whitelist_function("smap_.*")
+            .whitelist_recursively(false)
+            .derive_default(true)
+            .derive_copy(true)
+            .derive_debug(true)
+            .generate()
+            .expect("Unable to generate bindings");
+
+        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+        bindings
+            .write_to_file(out_path.join("ds_smap.rs"))
+            .expect("Couldn't write bindings");
+    }
     if cfg!(feature = "ds_ziplist") {
         gen_ds_ziplist();
     }

--- a/src/rust-util/pelikan-sys/build.rs
+++ b/src/rust-util/pelikan-sys/build.rs
@@ -270,16 +270,28 @@ fn gen_ds_sarray() {
         .whitelist_type("sarray_p")
         .whitelist_type("sarray_rstatus_e")
         .whitelist_function("sarray_.*")
-        .whitelist_recursively(false)
-        .derive_default(true)
-        .derive_copy(true)
-        .derive_debug(true)
         .generate()
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("ds_sarray.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_ds_smap() {
+    print_directives("ds_smap", "data_structure/smap");
+
+    let bindings = builder()
+        .header("../../data_structure/smap/smap.h")
+        .whitelist_type("smap_p")
+        .whitelist_type("smap_rstatus_e")
+        .whitelist_function("smap_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("ds_smap.rs"))
         .expect("Couldn't write bindings");
 }
 fn gen_ds_ziplist() {
@@ -396,6 +408,7 @@ fn gen_protocol_resp() {
         .whitelist_type("bitmap_elem(_e)?")
         .whitelist_type("list_elem(_e)?")
         .whitelist_type("sarray_elem(_e)?")
+        .whitelist_type("smap_elem(_e)?")
         .whitelist_type("compose_.*")
         .whitelist_function("compose_.*")
         .whitelist_type("parse_.*")
@@ -452,6 +465,7 @@ fn gen_protocol_resp_tw() {
         .whitelist_type("compose_(req|rsp)_metrics_st")
         .whitelist_var("OPT_UNLIMITED")
         .whitelist_type("sarray_elem(_e)?")
+        .whitelist_type("smap_elem(_e)?")
         .whitelist_type("list_elem(_e)?")
         .whitelist_type("bitmap_elem(_e)?")
         .generate()
@@ -637,24 +651,7 @@ fn main() {
         gen_ds_sarray();
     }
     if cfg!(feature = "ds_smap") {
-        print_directives("ds_smap", "data_structure/smap");
-
-        let bindings = builder()
-            .header("../../data_structure/smap/smap.h")
-            .whitelist_type("smap_p")
-            .whitelist_type("smap_rstatus_e")
-            .whitelist_function("smap_.*")
-            .whitelist_recursively(false)
-            .derive_default(true)
-            .derive_copy(true)
-            .derive_debug(true)
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("ds_smap.rs"))
-            .expect("Couldn't write bindings");
+        gen_ds_smap();
     }
     if cfg!(feature = "ds_ziplist") {
         gen_ds_ziplist();

--- a/src/rust-util/pelikan-sys/src/lib.rs
+++ b/src/rust-util/pelikan-sys/src/lib.rs
@@ -333,6 +333,11 @@ pub mod data_structure {
         include!(concat!(env!("OUT_DIR"), "/ds_sarray.rs"));
     }
 
+    #[cfg(feature = "ds_smap")]
+    pub mod smap{
+        include!(concat!(env!("OUT_DIR"), "/ds_smap.rs"));
+    }
+
     #[cfg(feature = "ds_ziplist")]
     pub mod ziplist {
         use super::{blob, bstring};

--- a/src/server/rds/CMakeLists.txt
+++ b/src/server/rds/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULES
     core
     ds_ziplist
     ds_sarray
+    ds_smap
     protocol_admin
     protocol_resp
     slab

--- a/src/server/rds/data/CMakeLists.txt
+++ b/src/server/rds/data/CMakeLists.txt
@@ -4,4 +4,5 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/cmd_misc.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cmd_list.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cmd_sarray.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmd_smap.c
     PARENT_SCOPE)

--- a/src/server/rds/data/cmd_smap.c
+++ b/src/server/rds/data/cmd_smap.c
@@ -1,7 +1,7 @@
 #include "process.h"
 #include "shared.h"
 
-#include "data_structure/sarray/sarray.h"
+#include "data_structure/smap/smap.h"
 #include "storage/slab/item.h"
 #include "storage/slab/slab.h"
 
@@ -11,10 +11,11 @@
 #include <cc_mm.h>
 
 #define WATERMARK_SIZE (sizeof(uint32_t) * 2)  /* <low, high> entries in u32 */
-/* TODO(yao): make MAX_NVAL configurable */
-#define MAX_NVAL 255  /* max no. of values to insert/remove in one request */
+/* TODO(yao): make MAX_NELEM configurable */
+#define MAX_NELEM 255  /* max no. of elements to insert/remove per request */
 
-static uint64_t vals[MAX_NVAL];
+static uint64_t ikeys[MAX_NELEM];
+static struct bstring *vals[MAX_NELEM];
 static struct bstring null_key = null_bstring;
 
 
@@ -39,7 +40,7 @@ _set_watermark(uint32_t *opt, uint32_t low, uint32_t high)
 }
 
 void
-cmd_sarray_create(struct response *rsp, const struct request *req,
+cmd_smap_create(struct response *rsp, const struct request *req,
         const struct command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
@@ -48,22 +49,28 @@ cmd_sarray_create(struct response *rsp, const struct request *req,
     item_rstatus_e istatus;
     uint32_t ntoken;
     bool bounded;
-    uint64_t esize, low, high;
+    uint64_t isize, vsize, low, high;
 
     ntoken = array_nelem(req->token);
     ASSERT(ntoken >= cmd->narg);
 
-    INCR(process_metrics, sarray_create);
+    INCR(process_metrics, smap_create);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_create_ex);
+        INCR(process_metrics, smap_create_ex);
 
         return;
     }
-    if (!req_get_uint(&esize, req, SARRAY_ESIZE)) {
+    if (!req_get_uint(&isize, req, SMAP_ISIZE)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_create_ex);
+        INCR(process_metrics, smap_create_ex);
+
+        return;
+    }
+    if (!req_get_uint(&vsize, req, SMAP_VSIZE)) {
+        compose_rsp_client_err(rsp, reply, cmd, key);
+        INCR(process_metrics, smap_create_ex);
 
         return;
     }
@@ -71,16 +78,16 @@ cmd_sarray_create(struct response *rsp, const struct request *req,
     bounded = (cmd->nopt > 0);
     if (bounded && cmd->nopt != 2) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_create_ex);
+        INCR(process_metrics, smap_create_ex);
 
         return;
     }
 
     /* get low & high watermarks */
-    if (cmd->nopt > 0 && (!req_get_uint(&low, req, SARRAY_WML) ||
-                !req_get_uint(&high, req, SARRAY_WMH))) {
+    if (cmd->nopt > 0 && (!req_get_uint(&low, req, SMAP_WML) ||
+                !req_get_uint(&high, req, SMAP_WMH))) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_create_ex);
+        INCR(process_metrics, smap_create_ex);
 
         return;
     }
@@ -89,24 +96,24 @@ cmd_sarray_create(struct response *rsp, const struct request *req,
     if (it != NULL) { /* do not add key if exists */
         rsp->type = reply->type = ELEM_ERR;
         reply->bstr = str2bstr(RSP_EXIST);
-        INCR(process_metrics, sarray_create_exist);
+        INCR(process_metrics, smap_create_exist);
 
         return;
     }
 
     /* TODO: figure out a TTL story here */
-    istatus = item_reserve(&it, key, NULL, SARRAY_HEADER_SIZE,
+    istatus = item_reserve(&it, key, NULL, SMAP_HEADER_SIZE,
             WATERMARK_SIZE * bounded, INT32_MAX);
     if (istatus != ITEM_OK) {
         compose_rsp_storage_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_create_ex);
+        INCR(process_metrics, smap_create_ex);
 
         return;
     }
 
     /* initialize data structure */
-    sarray_init((sarray_p)item_data(it), (uint32_t)esize);
-    it->vlen = SARRAY_HEADER_SIZE;
+    smap_init((smap_p)item_data(it), (uint16_t)isize, (uint16_t)vsize);
+    it->vlen = SMAP_HEADER_SIZE;
     if (bounded) {
         _set_watermark((uint32_t *)item_optional(it), low, high);
     }
@@ -114,11 +121,11 @@ cmd_sarray_create(struct response *rsp, const struct request *req,
     item_insert(it, key);
 
     compose_rsp_ok(rsp, reply, cmd, key);
-    INCR(process_metrics, sarray_create_ok);
+    INCR(process_metrics, smap_create_ok);
 }
 
 void
-cmd_sarray_delete(struct response *rsp, const struct request *req,
+cmd_smap_delete(struct response *rsp, const struct request *req,
         const struct command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
@@ -126,26 +133,26 @@ cmd_sarray_delete(struct response *rsp, const struct request *req,
 
     ASSERT(array_nelem(req->token) == cmd->narg);
 
-    INCR(process_metrics, sarray_delete);
+    INCR(process_metrics, smap_delete);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_delete_ex);
+        INCR(process_metrics, smap_delete_ex);
 
         return;
     }
 
     if (item_delete(key)) {
         compose_rsp_ok(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_delete_ok);
+        INCR(process_metrics, smap_delete_ok);
     } else {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_delete_notfound);
+        INCR(process_metrics, smap_delete_notfound);
     }
 }
 
 void
-cmd_sarray_len(struct response *rsp, const struct request *req,
+cmd_smap_len(struct response *rsp, const struct request *req,
         const struct command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
@@ -155,11 +162,11 @@ cmd_sarray_len(struct response *rsp, const struct request *req,
 
     ASSERT(array_nelem(req->token) == cmd->narg);
 
-    INCR(process_metrics, sarray_len);
+    INCR(process_metrics, smap_len);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_len_ex);
+        INCR(process_metrics, smap_len_ex);
 
         return;
     }
@@ -167,39 +174,39 @@ cmd_sarray_len(struct response *rsp, const struct request *req,
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_len_notfound);
+        INCR(process_metrics, smap_len_notfound);
 
         return;
     }
 
-    nentry = sarray_nentry((sarray_p)item_data(it));
+    nentry = smap_nentry((smap_p)item_data(it));
     compose_rsp_numeric(rsp, reply, cmd, key, (int64_t)nentry);
 }
 
 void
-cmd_sarray_find(struct response *rsp, const struct request *req, const struct
+cmd_smap_find(struct response *rsp, const struct request *req, const struct
         command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
     struct bstring *key = &null_key;
     struct item *it;
     uint32_t idx;
-    uint64_t val;
-    sarray_rstatus_e status;
+    uint64_t ikey;
+    smap_rstatus_e status;
 
     ASSERT(array_nelem(req->token) == cmd->narg);
 
-    INCR(process_metrics, sarray_find);
+    INCR(process_metrics, smap_find);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_find_ex);
+        INCR(process_metrics, smap_find_ex);
 
         return;
     }
-    if (!req_get_uint(&val, req, SARRAY_VAL)) {
+    if (!req_get_uint(&ikey, req, SMAP_IKEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_find_ex);
+        INCR(process_metrics, smap_find_ex);
 
         return;
     }
@@ -207,30 +214,30 @@ cmd_sarray_find(struct response *rsp, const struct request *req, const struct
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_find_notfound);
+        INCR(process_metrics, smap_find_notfound);
 
         return;
     }
 
-    status = sarray_index(&idx, (sarray_p)item_data(it), val);
+    status = smap_index(&idx, (smap_p)item_data(it), ikey);
     switch (status) {
-    case SARRAY_OK:
+    case SMAP_OK:
         rsp->type = reply->type = ELEM_INT;
         reply->num = (int64_t)idx;
-        log_verb("command '%.*s' '%.*s' succeeded, value %"PRIu64" at index "
-                PRIu32, cmd->bstr.len, cmd->bstr.data, key->len, key->data, val,
-                idx);
-        INCR(process_metrics, sarray_find_ok);
+        log_verb("command '%.*s' '%.*s' succeeded, ikey %"PRIu64" at index "
+                PRIu32, cmd->bstr.len, cmd->bstr.data, key->len, key->data,
+                ikey, idx);
+        INCR(process_metrics, smap_find_ok);
 
         break;
-    case SARRAY_ENOTFOUND:
+    case SMAP_ENOTFOUND:
         compose_rsp_nil(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_find_notamember);
+        INCR(process_metrics, smap_find_notamember);
 
         break;
-    case SARRAY_EINVALID:
+    case SMAP_EINVALID:
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_find_ex);
+        INCR(process_metrics, smap_find_ex);
 
         break;
     default:
@@ -240,26 +247,26 @@ cmd_sarray_find(struct response *rsp, const struct request *req, const struct
 }
 
 void
-cmd_sarray_get(struct response *rsp, const struct request *req, const struct
+cmd_smap_get(struct response *rsp, const struct request *req, const struct
         command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
     struct bstring *key = &null_key;
     struct item *it;
     int64_t idx = 0, cnt = 1;
-    uint64_t val;
+    int64_t *ikey;
     uint32_t narg, nentry, nreturned = 0;
     int32_t incr;
-    sarray_rstatus_e status;
+    smap_rstatus_e status;
 
     narg = array_nelem(req->token);
     ASSERT(narg >= cmd->narg);
 
-    INCR(process_metrics, sarray_get);
+    INCR(process_metrics, smap_get);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_get_ex);
+        INCR(process_metrics, smap_get_ex);
 
         return;
     }
@@ -267,16 +274,16 @@ cmd_sarray_get(struct response *rsp, const struct request *req, const struct
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_get_notfound);
+        INCR(process_metrics, smap_get_notfound);
 
         return;
     }
 
-    nentry = sarray_nentry((sarray_p)item_data(it));
+    nentry = smap_nentry((smap_p)item_data(it));
 
-    if (narg > cmd->narg && !req_get_int(&idx, req, SARRAY_IDX)) {
+    if (narg > cmd->narg && !req_get_int(&idx, req, SMAP_IDX)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_get_ex);
+        INCR(process_metrics, smap_get_ex);
 
         return;
     }
@@ -292,9 +299,9 @@ cmd_sarray_get(struct response *rsp, const struct request *req, const struct
         }
     }
 
-    if (narg > cmd->narg + 1 && !req_get_int(&cnt, req, SARRAY_ICNT)) {
+    if (narg > cmd->narg + 1 && !req_get_int(&cnt, req, SMAP_ICNT)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_get_ex);
+        INCR(process_metrics, smap_get_ex);
 
         return;
     }
@@ -310,39 +317,43 @@ cmd_sarray_get(struct response *rsp, const struct request *req, const struct
     /* write the array header */
     rsp->type = ELEM_ARRAY;
     for (; nreturned > 0; nreturned--, idx += incr) {
-        status = sarray_value(&val, (sarray_p)item_data(it), (uint32_t)idx);
-        ASSERT(status == SARRAY_OK);
         reply->type = ELEM_INT;
-        reply->num = val;
+        ikey = &(reply->num);
+        reply = (struct element *)array_push(rsp->token);
+        reply->type = ELEM_BULK;
+        status = smap_keyval((uint64_t *)ikey, &(reply->bstr), (smap_p)item_data(it),
+                (uint32_t)idx);
+        ASSERT(status == SMAP_OK);
         reply = (struct element *)array_push(rsp->token);
     }
     array_pop(rsp->token);
 
-    INCR(process_metrics, sarray_get_ok);
+    INCR(process_metrics, smap_get_ok);
     log_verb("command '%.*s' '%.*s' succeeded, returning %"PRIu32" elements",
             cmd->bstr.len, cmd->bstr.data, key->len, key->data, array_nelem(rsp->token));
 }
 
 void
-cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
+cmd_smap_insert(struct response *rsp, const struct request *req, const struct
         command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
     struct bstring *key = &null_key;
     struct item *it;
-    uint32_t nval = 0, esize;
+    uint16_t vsize;
+    uint32_t nelem = 0, ntotal, esize;
     int64_t delta, wml, wmh, nentry, ninserted = 0;
-    uint64_t val;
-    sarray_p sa;
-    sarray_rstatus_e status;
+    uint64_t ikey;
+    smap_p sm;
+    smap_rstatus_e status;
 
     ASSERT(array_nelem(req->token) >= cmd->narg);
 
-    INCR(process_metrics, sarray_insert);
+    INCR(process_metrics, smap_insert);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_insert_ex);
+        INCR(process_metrics, smap_insert_ex);
 
         return;
     }
@@ -350,21 +361,43 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_insert_notfound);
+        INCR(process_metrics, smap_insert_notfound);
 
         return;
     }
 
+    ntotal = (array_nelem(req->token) - SMAP_IKEY) + 1;
+    if (ntotal & 0x1) { /* odd number of tokens left */
+        compose_rsp_client_err(rsp, reply, cmd, key);
+        INCR(process_metrics, smap_insert_ex);
+
+        return;
+    } else {
+        ntotal = ntotal >> 1;
+    }
+
+    sm = (smap_p)item_data(it);
+    vsize = smap_vsize(sm);
     /* parse and store all values to be inserted in array vals */
-    for (uint32_t i = SARRAY_VAL; i < array_nelem(req->token); ++i, ++nval) {
-        if (!req_get_uint(&val, req, i)) {
-            log_debug("the value at offset %"PRIu32" is invalid", i);
+    for (uint32_t i = SMAP_IKEY; nelem < ntotal; i += 2, ++nelem) {
+        if (!req_get_uint(&ikey, req, i)) {
+            log_debug("the integer key at offset %"PRIu32" is invalid", i);
             compose_rsp_client_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_insert_ex);
+            INCR(process_metrics, smap_insert_ex);
 
             return;
-        } else {
-            vals[nval] = val;
+        }
+
+        ikeys[nelem] = ikey;
+        req_get_bstr(&vals[nelem], req, i + 1);
+        if (vals[nelem]->len != (uint32_t)vsize) {
+            log_debug("value size %"PRIu32" at offset %"PRIu32" is "
+                    "incompatible with current SMap config of %"PRIu16,
+                    vals[nelem]->len, i, vsize);
+            compose_rsp_client_err(rsp, reply, cmd, key);
+            INCR(process_metrics, smap_insert_ex);
+
+            return;
         }
     }
 
@@ -388,9 +421,8 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
      * batch sizes to ensure insertion at maximum array size stays within a
      * single slabclass.
      */
-    sa = (sarray_p)item_data(it);
-    esize = sarray_esize(sa);
-    delta = esize * nval;
+    esize = smap_esize(sm);
+    delta = esize * ntotal;
 
     /**
      * Attempt to extend an item by delta bytes. This is accomplished by first
@@ -407,7 +439,7 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
             log_debug("reallocate item for key '%.*s' failed", key->len,
                     key->data);
             compose_rsp_storage_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_insert_ex);
+            INCR(process_metrics, smap_insert_ex);
 
             return;
         }
@@ -423,20 +455,20 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
         item_insert(nit, key);
     }
 
-    sa = (sarray_p)item_data(it); /* item might have changed */
-    for (uint32_t i = 0; i < nval; ++i) {
-        status = sarray_insert(sa, vals[i]);
-        if (status == SARRAY_EINVALID) {
-            log_debug("value %"PRIu32" out of %"PRIu32" is invalid", i, nval);
+    sm = (smap_p)item_data(it); /* item might have changed */
+    for (uint32_t i = 0; i < ntotal; ++i) {
+        status = smap_insert(sm, ikeys[i], vals[i]);
+        if (status == SMAP_EINVALID) {
+            log_debug("value %"PRIu32" out of %"PRIu32" is invalid", i, ntotal);
             compose_rsp_client_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_insert_ex);
+            INCR(process_metrics, smap_insert_ex);
             return;
         }
 
-        if (status == SARRAY_EDUP) {
-            INCR(process_metrics, sarray_insert_noop);
+        if (status == SMAP_EDUP) {
+            INCR(process_metrics, smap_insert_noop);
         } else {
-            INCR(process_metrics, sarray_insert_ok);
+            INCR(process_metrics, smap_insert_ok);
             ninserted++;
             it->vlen += esize;
         }
@@ -445,12 +477,12 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
     if (it->olen > 0) {
         wml = _watermark_low((uint32_t *)item_optional(it));
         wmh = _watermark_high((uint32_t *)item_optional(it));
-        nentry = sarray_nentry(sa);
+        nentry = smap_nentry(sm);
         if (nentry > wmh) {
             log_verb("truncating '%.*s' from %"PRIu32" down to %"PRIu32" elements",
                 key->len, key->data, nentry, wml);
-            INCR(process_metrics, sarray_insert_trim);
-            sarray_truncate(sa, nentry - wml);
+            INCR(process_metrics, smap_insert_trim);
+            smap_truncate(sm, nentry - wml);
             it->vlen -= esize * (nentry - wml);
         }
     }
@@ -459,24 +491,24 @@ cmd_sarray_insert(struct response *rsp, const struct request *req, const struct
 }
 
 void
-cmd_sarray_remove(struct response *rsp, const struct request *req, const struct
+cmd_smap_remove(struct response *rsp, const struct request *req, const struct
         command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
     struct bstring *key = &null_key;
     struct item *it;
-    uint32_t nval = 0, nremoved = 0, esize;
-    int64_t val;
-    sarray_p sa;
-    sarray_rstatus_e status;
+    uint32_t nelem = 0, nremoved = 0, esize;
+    int64_t ikey;
+    smap_p sm;
+    smap_rstatus_e status;
 
     ASSERT(array_nelem(req->token) == cmd->narg);
 
-    INCR(process_metrics, sarray_insert);
+    INCR(process_metrics, smap_insert);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_remove_ex);
+        INCR(process_metrics, smap_remove_ex);
 
         return;
     }
@@ -484,51 +516,51 @@ cmd_sarray_remove(struct response *rsp, const struct request *req, const struct
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_remove_notfound);
+        INCR(process_metrics, smap_remove_notfound);
 
         return;
     }
 
-    /* parse and store all values to be removed in array vals */
-    for (uint32_t i = SARRAY_VAL; i < array_nelem(req->token); ++i) {
-        if (!req_get_int(&val, req, i)) {
+    /* parse and store all ikeys to be removed in array ikeys */
+    for (uint32_t i = SMAP_IKEY; i < array_nelem(req->token); ++i) {
+        if (!req_get_int(&ikey, req, i)) {
             compose_rsp_client_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_remove_ex);
+            INCR(process_metrics, smap_remove_ex);
 
             return;
-        } else {
-            vals[nval] = (uint64_t)val;
-            nval++;
         }
-    }
-    /* TODO: should we try to "fit" to a smaller item here? */
 
-    sa = (sarray_p)item_data(it);
-    esize = sarray_esize(sa);
-    for (uint32_t i = 0; i < nval; ++i) {
-        status = sarray_remove(sa, vals[i]);
+        ikeys[nelem] = (uint64_t)ikey;
+        nelem++;
+    }
+
+    /* TODO: should we try to "fit" to a smaller item here? */
+    sm = (smap_p)item_data(it);
+    esize = smap_esize(sm);
+    for (uint32_t i = 0; i < nelem; ++i) {
+        status = smap_remove(sm, ikeys[i]);
         switch (status) {
-        case SARRAY_OK:
+        case SMAP_OK:
             nremoved++;
             it->vlen -= esize;
-            INCR(process_metrics, sarray_remove_ok);
+            INCR(process_metrics, smap_remove_ok);
 
             break;
-        case SARRAY_ENOTFOUND:
+        case SMAP_ENOTFOUND:
             compose_rsp_noop(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_remove_noop);
+            INCR(process_metrics, smap_remove_noop);
 
             break;
-        case SARRAY_EINVALID:
+        case SMAP_EINVALID:
             /* client error, bad argument */
-            log_debug("value %"PRIu32" out of %"PRIu32" is invalid", i, nval);
+            log_debug("value %"PRIu32" out of %"PRIu32" is invalid", i, nelem);
             compose_rsp_client_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_remove_ex);
+            INCR(process_metrics, smap_remove_ex);
 
             return;
         default:
             compose_rsp_server_err(rsp, reply, cmd, key);
-            INCR(process_metrics, sarray_remove_ex);
+            INCR(process_metrics, smap_remove_ex);
             NOT_REACHED();
             return;
         }
@@ -538,29 +570,29 @@ cmd_sarray_remove(struct response *rsp, const struct request *req, const struct
 }
 
 void
-cmd_sarray_truncate(struct response *rsp, const struct request *req, const
+cmd_smap_truncate(struct response *rsp, const struct request *req, const
         struct command *cmd)
 {
     struct element *reply = (struct element *)array_push(rsp->token);
     struct bstring *key = &null_key;
     struct item *it;
     int64_t cnt;
-    sarray_p sa;
-    sarray_rstatus_e status;
+    smap_p sm;
+    smap_rstatus_e status;
 
     ASSERT(array_nelem(req->token) == cmd->narg);
 
-    INCR(process_metrics, sarray_truncate);
+    INCR(process_metrics, smap_truncate);
 
-    if (!req_get_bstr(&key, req, SARRAY_KEY)) {
+    if (!req_get_bstr(&key, req, SMAP_KEY)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_truncate_ex);
+        INCR(process_metrics, smap_truncate_ex);
 
         return;
     }
-    if (!req_get_int(&cnt, req, SARRAY_IDX)) {
+    if (!req_get_int(&cnt, req, SMAP_IDX)) {
         compose_rsp_client_err(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_truncate_ex);
+        INCR(process_metrics, smap_truncate_ex);
 
         return;
     }
@@ -568,18 +600,18 @@ cmd_sarray_truncate(struct response *rsp, const struct request *req, const
     it = item_get(key);
     if (it == NULL) {
         compose_rsp_notfound(rsp, reply, cmd, key);
-        INCR(process_metrics, sarray_truncate_notfound);
+        INCR(process_metrics, smap_truncate_notfound);
 
         return;
     }
 
-    sa = (sarray_p)item_data(it);
-    status = sarray_truncate(sa, cnt);
-    if (status != SARRAY_OK) {
+    sm = (smap_p)item_data(it);
+    status = smap_truncate(sm, cnt);
+    if (status != SMAP_OK) {
         compose_rsp_server_err(rsp, reply, cmd, key);
     }
 
-    it->vlen = SARRAY_HEADER_SIZE + sarray_esize(sa) * sarray_nentry(sa);
+    it->vlen = SMAP_HEADER_SIZE + smap_esize(sm) * smap_nentry(sm);
     compose_rsp_ok(rsp, reply, cmd, key);
-    INCR(process_metrics, sarray_truncate_ok);
+    INCR(process_metrics, smap_truncate_ok);
 }

--- a/src/server/rds/data/cmd_smap.h
+++ b/src/server/rds/data/cmd_smap.h
@@ -1,0 +1,55 @@
+#pragma once
+
+/*          name                    type            description */
+#define PROCESS_SMAP_METRIC(ACTION)                                                 \
+    ACTION( smap_create,            METRIC_COUNTER, "# smap create requests"       )\
+    ACTION( smap_create_exist,      METRIC_COUNTER, "# smap already exist"         )\
+    ACTION( smap_create_ok,         METRIC_COUNTER, "# smap stored"                )\
+    ACTION( smap_create_ex,         METRIC_COUNTER, "# smap create exceptions"     )\
+    ACTION( smap_delete,            METRIC_COUNTER, "# smap delete requests"       )\
+    ACTION( smap_delete_ok,         METRIC_COUNTER, "# smap delete success"        )\
+    ACTION( smap_delete_notfound,   METRIC_COUNTER, "# smap delete miss"           )\
+    ACTION( smap_delete_ex,         METRIC_COUNTER, "# smap delete exceptions"     )\
+    ACTION( smap_len,               METRIC_COUNTER, "# smap length requests"       )\
+    ACTION( smap_len_ok,            METRIC_COUNTER, "# smap length success"        )\
+    ACTION( smap_len_notfound,      METRIC_COUNTER, "# smap length miss"           )\
+    ACTION( smap_len_ex,            METRIC_COUNTER, "# smap len exceptions"        )\
+    ACTION( smap_find,              METRIC_COUNTER, "# smap find requests"         )\
+    ACTION( smap_find_ok,           METRIC_COUNTER, "# smap find success"          )\
+    ACTION( smap_find_notfound,     METRIC_COUNTER, "# smap find miss"             )\
+    ACTION( smap_find_notamember,   METRIC_COUNTER, "# smap find not present"      )\
+    ACTION( smap_find_ex,           METRIC_COUNTER, "# smap find exceptions"       )\
+    ACTION( smap_get,               METRIC_COUNTER, "# smap get requests"          )\
+    ACTION( smap_get_ok,            METRIC_COUNTER, "# smap get success"           )\
+    ACTION( smap_get_notfound,      METRIC_COUNTER, "# smap get miss"              )\
+    ACTION( smap_get_oob,           METRIC_COUNTER, "# smap get out of bound"      )\
+    ACTION( smap_get_ex,            METRIC_COUNTER, "# smap get exceptions"        )\
+    ACTION( smap_insert,            METRIC_COUNTER, "# smap insert requests"       )\
+    ACTION( smap_insert_ok,         METRIC_COUNTER, "# smap insert success"        )\
+    ACTION( smap_insert_notfound,   METRIC_COUNTER, "# smap insert miss"           )\
+    ACTION( smap_insert_noop,       METRIC_COUNTER, "# smap insert no action"      )\
+    ACTION( smap_insert_trim,       METRIC_COUNTER, "# smap insert lead to trim"   )\
+    ACTION( smap_insert_ex,         METRIC_COUNTER, "# smap insert exceptions"     )\
+    ACTION( smap_remove,            METRIC_COUNTER, "# smap remove requests"       )\
+    ACTION( smap_remove_ok,         METRIC_COUNTER, "# smap remove success"        )\
+    ACTION( smap_remove_notfound,   METRIC_COUNTER, "# smap remove miss"           )\
+    ACTION( smap_remove_noop,       METRIC_COUNTER, "# smap remove no-op"          )\
+    ACTION( smap_remove_ex,         METRIC_COUNTER, "# smap remove exceptions"     )\
+    ACTION( smap_truncate,          METRIC_COUNTER, "# smap truncate requests"     )\
+    ACTION( smap_truncate_ok,       METRIC_COUNTER, "# smap truncate success"      )\
+    ACTION( smap_truncate_notfound, METRIC_COUNTER, "# smap truncate miss"         )\
+    ACTION( smap_truncate_ex,       METRIC_COUNTER, "# smap truncate exceptions"   )
+
+struct request;
+struct response;
+struct command;
+
+/* cmd_* functions must be command_fn (process.c) compatible */
+void cmd_smap_create(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_delete(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_truncate(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_len(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_find(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_get(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_insert(struct response *rsp, const struct request *req, const struct command *cmd);
+void cmd_smap_remove(struct response *rsp, const struct request *req, const struct command *cmd);

--- a/src/server/rds/data/process.c
+++ b/src/server/rds/data/process.c
@@ -55,6 +55,15 @@ process_setup(process_options_st *options, process_metrics_st *metrics)
     command_registry[REQ_SARRAY_INSERT] = cmd_sarray_insert;
     command_registry[REQ_SARRAY_REMOVE] = cmd_sarray_remove;
 
+    command_registry[REQ_SMAP_CREATE] = cmd_smap_create;
+    command_registry[REQ_SMAP_DELETE] = cmd_smap_delete;
+    command_registry[REQ_SMAP_TRUNCATE] = cmd_smap_truncate;
+    command_registry[REQ_SMAP_LEN] = cmd_smap_len;
+    command_registry[REQ_SMAP_FIND] = cmd_smap_find;
+    command_registry[REQ_SMAP_GET] = cmd_smap_get;
+    command_registry[REQ_SMAP_INSERT] = cmd_smap_insert;
+    command_registry[REQ_SMAP_REMOVE] = cmd_smap_remove;
+
     command_registry[REQ_PING] = cmd_ping;
 
     process_init = true;

--- a/src/server/rds/data/process.h
+++ b/src/server/rds/data/process.h
@@ -3,6 +3,7 @@
 #include "cmd_misc.h"
 #include "cmd_list.h"
 #include "cmd_sarray.h"
+#include "cmd_smap.h"
 
 #include <buffer/cc_buf.h>
 #include <cc_metric.h>
@@ -29,6 +30,7 @@ typedef struct {
     PROCESS_METRIC(METRIC_DECLARE)
     PROCESS_LIST_METRIC(METRIC_DECLARE)
     PROCESS_SARRAY_METRIC(METRIC_DECLARE)
+    PROCESS_SMAP_METRIC(METRIC_DECLARE)
     PROCESS_MISC_METRIC(METRIC_DECLARE)
 } process_metrics_st;
 

--- a/test/data_structure/CMakeLists.txt
+++ b/test/data_structure/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(bitmap)
 add_subdirectory(sarray)
+add_subdirectory(smap)
 add_subdirectory(ziplist)

--- a/test/data_structure/sarray/check_sarray.c
+++ b/test/data_structure/sarray/check_sarray.c
@@ -7,7 +7,7 @@
 #include <check.h>
 
 /* define for each suite, local scope due to macro visibility rule */
-#define SUITE_NAME "intarray"
+#define SUITE_NAME "sarray"
 #define DEBUG_LOG  SUITE_NAME ".log"
 
 #define BUF_SIZE 8200
@@ -17,7 +17,7 @@ static char buf[BUF_SIZE];
 
 
 /*
- * intarray tests
+ * sarray tests
  */
 
 START_TEST(test_sarray_create)
@@ -131,13 +131,13 @@ sarray_suite(void)
 {
     Suite *s = suite_create(SUITE_NAME);
 
-    TCase *tc_intarray = tcase_create("intarray");
-    suite_add_tcase(s, tc_intarray);
+    TCase *tc_sarray = tcase_create("sarray");
+    suite_add_tcase(s, tc_sarray);
 
-    tcase_add_test(tc_intarray, test_sarray_create);
-    tcase_add_test(tc_intarray, test_sarray_insert_seek);
-    tcase_add_test(tc_intarray, test_sarray_remove);
-    tcase_add_test(tc_intarray, test_sarray_truncate);
+    tcase_add_test(tc_sarray, test_sarray_create);
+    tcase_add_test(tc_sarray, test_sarray_insert_seek);
+    tcase_add_test(tc_sarray, test_sarray_remove);
+    tcase_add_test(tc_sarray, test_sarray_truncate);
 
     return s;
 }

--- a/test/data_structure/sarray/check_sarray.c
+++ b/test/data_structure/sarray/check_sarray.c
@@ -13,7 +13,7 @@
 #define BUF_SIZE 8200
 #define NENTRY   1024
 
-static unsigned char buf[BUF_SIZE];
+static char buf[BUF_SIZE];
 
 
 /*

--- a/test/data_structure/smap/CMakeLists.txt
+++ b/test/data_structure/smap/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(suite smap)
+set(test_name check_${suite})
+
+set(source check_${suite}.c)
+
+add_executable(${test_name} ${source})
+target_link_libraries(${test_name} ds_${suite})
+target_link_libraries(${test_name} ccommon-static ${CHECK_LIBRARIES} pthread m)
+
+add_test(${test_name} ${test_name})

--- a/test/data_structure/smap/check_smap.c
+++ b/test/data_structure/smap/check_smap.c
@@ -19,6 +19,7 @@
 
 static char buf[BUF_SIZE];
 static struct bstring val = str2bstr(VALUE);
+static struct bstring val_read;
 
 
 /*
@@ -50,7 +51,6 @@ START_TEST(test_smap_insert_seek)
 {
     uint32_t idx;
     uint64_t key;
-    struct bstring val_read;
 
     ck_assert_int_eq(smap_init(buf, 1, VLEN), SMAP_OK);
     ck_assert_int_eq(smap_insert(buf, 3, &val), SMAP_OK);  /* [(3, val)] */
@@ -137,6 +137,26 @@ START_TEST(test_smap_truncate)
 END_TEST
 
 
+START_TEST(test_smap_value)
+{
+    smap_init(buf, 8, 1);
+    ck_assert_int_eq(smap_esize(buf), 16);
+    smap_init(buf, 4, 1);
+    ck_assert_int_eq(smap_esize(buf), 8);
+    smap_init(buf, 2, 1);
+    ck_assert_int_eq(smap_esize(buf), 4);
+    smap_init(buf, 1, 1);
+    ck_assert_int_eq(smap_esize(buf), 2);
+
+    smap_init(buf, 8, 7);
+    ck_assert_int_eq(smap_insert(buf, 3, &val), SMAP_EINVALID);
+    ck_assert_int_eq(smap_insert(buf, 3, &str2bstr("abcdefg")), SMAP_OK);
+    ck_assert_int_eq(smap_insert(buf, 1, &str2bstr("abc")), SMAP_EINVALID);
+    ck_assert_int_eq(smap_insert(buf, 5, &str2bstr("hijklmn")), SMAP_OK);
+}
+END_TEST
+
+
 /*
  * test suite
  */
@@ -152,6 +172,7 @@ smap_suite(void)
     tcase_add_test(tc_smap, test_smap_insert_seek);
     tcase_add_test(tc_smap, test_smap_remove);
     tcase_add_test(tc_smap, test_smap_truncate);
+    tcase_add_test(tc_smap, test_smap_value);
 
     return s;
 }

--- a/test/data_structure/smap/check_smap.c
+++ b/test/data_structure/smap/check_smap.c
@@ -1,0 +1,172 @@
+#include <data_structure/smap/smap.h>
+
+#include <cc_bstring.h>
+#include <cc_mm.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <check.h>
+
+/* define for each suite, local scope due to macro visibility rule */
+#define SUITE_NAME "smap"
+#define DEBUG_LOG  SUITE_NAME ".log"
+
+#define NENTRY   1024
+#define VLEN 16
+#define VALUE "0123456789abcdef"
+
+#define BUF_SIZE (NENTRY * (8 + VLEN) + SMAP_HEADER_SIZE)
+
+static char buf[BUF_SIZE];
+static struct bstring val = str2bstr(VALUE);
+
+
+/*
+ * intarray tests
+ */
+
+START_TEST(test_smap_create)
+{
+    ck_assert_int_eq(smap_init(buf, 1, VLEN), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 17);
+    ck_assert_int_eq(smap_nentry(buf), 0);
+    ck_assert_int_eq(smap_init(buf, 2, VLEN), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 18);
+    ck_assert_int_eq(smap_init(buf, 4, VLEN), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 20);
+    ck_assert_int_eq(smap_init(buf, 8, VLEN), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 24);
+    ck_assert_int_eq(smap_init(buf, 16, VLEN), SMAP_EINVALID);
+    ck_assert_int_eq(smap_init(buf, 3, VLEN), SMAP_EINVALID);
+    ck_assert_int_eq(smap_init(buf, 8, 7), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 16);
+    ck_assert_int_eq(smap_init(buf, 4, 2), SMAP_OK);
+    ck_assert_int_eq(smap_esize(buf), 8);
+}
+END_TEST
+
+
+START_TEST(test_smap_insert_seek)
+{
+    uint32_t idx;
+    uint64_t key;
+    struct bstring val_read;
+
+    ck_assert_int_eq(smap_init(buf, 1, VLEN), SMAP_OK);
+    ck_assert_int_eq(smap_insert(buf, 3, &val), SMAP_OK);  /* [(3, val)] */
+    ck_assert_int_eq(smap_insert(buf, 1, &val), SMAP_OK);  /* [(1, val), (3, val)] */
+    ck_assert_int_eq(smap_insert(buf, 5, &val), SMAP_OK);  /* [(1, val), (3, val)], (5, val)] */
+    ck_assert_int_eq(smap_insert(buf, 12345, &val), SMAP_EINVALID);
+    ck_assert_int_eq(smap_nentry(buf), 3);
+    ck_assert_int_eq(smap_keyval(&key, &val_read, buf, 1), SMAP_OK);
+    ck_assert_int_eq(key, 3);
+    ck_assert_int_eq(bstring_compare(&val, &val_read), 0);
+    ck_assert_int_eq(smap_index(&idx, buf, 3), SMAP_OK);
+    ck_assert_int_eq(idx, 1);
+    ck_assert_int_eq(smap_index(&idx, buf, 2), SMAP_ENOTFOUND);
+
+    ck_assert_int_eq(smap_init(buf, 8, VLEN), SMAP_OK);
+    for (int i = 49; i >= 0; --i) {
+        ck_assert_int_eq(smap_insert(buf, 1000 + i * 2, &val), SMAP_OK);
+    }
+    ck_assert_int_eq(smap_nentry(buf), 50);
+    ck_assert_int_eq(smap_keyval(&key, &val_read, buf, 0), SMAP_OK);
+    ck_assert_int_eq(key, 1000);
+    ck_assert_int_eq(smap_keyval(&key, &val_read, buf, 10), SMAP_OK);
+    ck_assert_int_eq(key, 1020);
+    ck_assert_int_eq(smap_index(&idx, buf, 1020), SMAP_OK);
+    ck_assert_int_eq(idx, 10);
+    ck_assert_int_eq(smap_index(&idx, buf, 1000), SMAP_OK);
+    ck_assert_int_eq(idx, 0);
+    ck_assert_int_eq(smap_index(&idx, buf, 1098), SMAP_OK);
+    ck_assert_int_eq(idx, 49);
+    ck_assert_int_eq(smap_index(&idx, buf, 1), SMAP_ENOTFOUND);
+    ck_assert_int_eq(smap_index(&idx, buf, 2000), SMAP_ENOTFOUND);
+}
+END_TEST
+
+START_TEST(test_smap_remove)
+{
+    uint32_t idx;
+
+    smap_init(buf, 1, VLEN);
+    smap_insert(buf, 1, &val);
+    smap_insert(buf, 3, &val);
+    smap_insert(buf, 5, &val);
+    ck_assert_int_eq(smap_remove(buf, 12345), SMAP_EINVALID);
+
+    smap_init(buf, 8, VLEN);
+    for (int i = 0; i < 50; ++i) { /* key: 0, 2, 4, ..., 98 */
+        smap_insert(buf, 1000 + i * 2, &val);
+    }
+    ck_assert_int_eq(smap_nentry(buf), 50);
+    ck_assert_int_eq(smap_remove(buf, 1020), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 49);
+    ck_assert_int_eq(smap_index(&idx, buf, 1020), SMAP_ENOTFOUND);
+    ck_assert_int_eq(smap_index(&idx, buf, 1022), SMAP_OK);
+    ck_assert_int_eq(idx, 10);
+    ck_assert_int_eq(smap_remove(buf, 1000), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 48);
+    ck_assert_int_eq(smap_index(&idx, buf, 1000), SMAP_ENOTFOUND);
+    ck_assert_int_eq(smap_remove(buf, 1098), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 47);
+    ck_assert_int_eq(smap_index(&idx, buf, 1098), SMAP_ENOTFOUND);
+}
+END_TEST
+
+START_TEST(test_smap_truncate)
+{
+    uint32_t idx;
+
+    smap_init(buf, 8, VLEN);
+    for (int i = 0; i < 50; ++i) { /* 0, 2, 4, ..., 98 */
+        smap_insert(buf, 1000 + i * 2, &val);
+    }
+    ck_assert_int_eq(smap_nentry(buf), 50);
+    ck_assert_int_eq(smap_truncate(buf, -10), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 40);
+    ck_assert_int_eq(smap_index(&idx, buf, 1080), SMAP_ENOTFOUND);
+    ck_assert_int_eq(smap_index(&idx, buf, 1078), SMAP_OK);
+    ck_assert_int_eq(smap_truncate(buf, 10), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 30);
+    ck_assert_int_eq(smap_index(&idx, buf, 1018), SMAP_ENOTFOUND);
+    ck_assert_int_eq(smap_index(&idx, buf, 1020), SMAP_OK);
+    ck_assert_int_eq(smap_truncate(buf, 31), SMAP_OK);
+    ck_assert_int_eq(smap_nentry(buf), 0);
+}
+END_TEST
+
+
+/*
+ * test suite
+ */
+static Suite *
+smap_suite(void)
+{
+    Suite *s = suite_create(SUITE_NAME);
+
+    TCase *tc_smap = tcase_create("smap");
+    suite_add_tcase(s, tc_smap);
+
+    tcase_add_test(tc_smap, test_smap_create);
+    tcase_add_test(tc_smap, test_smap_insert_seek);
+    tcase_add_test(tc_smap, test_smap_remove);
+    tcase_add_test(tc_smap, test_smap_truncate);
+
+    return s;
+}
+
+int
+main(void)
+{
+    int nfail;
+
+    Suite *suite = smap_suite();
+    SRunner *srunner = srunner_create(suite);
+    srunner_set_log(srunner, DEBUG_LOG);
+    srunner_run_all(srunner, CK_ENV); /* set CK_VEBOSITY in ENV to customize */
+    nfail = srunner_ntests_failed(srunner);
+    srunner_free(srunner);
+
+    return (nfail == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -8,39 +8,59 @@ DEFAULT_SERVER = ('localhost', 12321)
 DEFAULT_ADMIN = ('localhost', 9999)
 
 class GenericTest(unittest.TestCase):
-    def setUp(self):
-        self.server = PelikanServer('pelikan_twemcache')
-        self.server.ready()
-        self.data_client = DataClient(DEFAULT_SERVER)
-        self.admin_client = AdminClient(DEFAULT_ADMIN)
-        self.stats = self.admin_client.stats()
+  def __init__(self, binary_name):
+    """initialize based on what server to run the tests against"""
 
-    def tearDown(self):
-        self.data_client.close()
-        self.admin_client.close()
-        self.server.stop()
+    if binary_name not in PelikanServer.SUPPORTED_SERVER:
+      raise ValueError('{} is not a valid server binary'.format({binary_name}))
+    super(GenericTest, self).__init__()
+    self.name = binary_name
 
-    def load(self, fname):
-        """loading a test sequence from a file"""
-        self.seq = load_seq(fname)
 
-    def assertResponse(self, expected):
-        """receive and verify response (a list) matches expectation"""
-        if len(expected) > 0:
-            rsp = self.data_client.response()
-            self.assertEqual(rsp, expected)
+  def setUp(self):
+    print('setting up {}'.format(self.name))
+    self.server = PelikanServer(self.name)
+    self.server.ready()
+    self.data_client = DataClient(DEFAULT_SERVER)
+    self.admin_client = AdminClient(DEFAULT_ADMIN)
+    self.stats = self.admin_client.stats()
 
-    def assertStats(self, delta):
-        """delta, a dict, captures the expected change in a subset of metrics"""
-        stats = self.admin_client.stats()
-        for k in delta:
-            self.assertEqual(int(stats[k]) - int(self.stats[k]), delta[k],
-                "expecting '{}' to change by {}, previously {}, currently {}"\
-                    .format(k, delta[k], self.stats[k], stats[k]))
-        self.stats = stats
 
-    def runTest(self):
-        for d in self.seq:
-            self.data_client.request(d['req'])
-            self.assertResponse(d['rsp'])
-            self.assertStats(d['stat'])
+  def tearDown(self):
+    print('tearing down {}'.format(self.name))
+    self.data_client.close()
+    self.admin_client.close()
+    self.server.stop()
+
+
+  def load(self, fname):
+    """loading a test sequence from a file"""
+
+    print('loading tests from {}'.format(fname))
+    self.seq = load_seq(fname)
+
+
+  def assertResponse(self, expected):
+    """receive and verify response (a list) matches expectation"""
+
+    if len(expected) > 0:
+      rsp = self.data_client.response()
+      self.assertEqual(rsp, expected, "expecting response '{}', received '{}'".format(expectd, rsp))
+
+
+  def assertStats(self, delta):
+    """delta, a dict, captures the expected change in a subset of metrics"""
+
+    stats = self.admin_client.stats()
+    for k in delta:
+      self.assertEqual(int(stats[k]) - int(self.stats[k]), delta[k],
+        "expecting '{}' to change by {}, previously {}, currently {}"\
+        .format(k, delta[k], self.stats[k], stats[k]))
+    self.stats = stats
+
+
+  def runTest(self):
+    for d in self.seq:
+      self.data_client.request(d['req'])
+      self.assertResponse(d['rsp'])
+      self.assertStats(d['stat'])

--- a/test/integration/base.py
+++ b/test/integration/base.py
@@ -45,7 +45,7 @@ class GenericTest(unittest.TestCase):
 
     if len(expected) > 0:
       rsp = self.data_client.response()
-      self.assertEqual(rsp, expected, "expecting response '{}', received '{}'".format(expectd, rsp))
+      self.assertEqual(rsp, expected, "expecting response '{}', received '{}'".format(expected, rsp))
 
 
   def assertStats(self, delta):

--- a/test/integration/client.py
+++ b/test/integration/client.py
@@ -5,109 +5,115 @@ import unittest
 # implementation based on pymemcache: https://pypi.python.org/pypi/pymemcache
 
 class TCPClient(object):
-    DEFAULT_TIMEOUT = 1.0
-    RECV_SIZE = 1024 * 1024
-
-    def __init__(self,
-                 server,
-                 connect_timeout=DEFAULT_TIMEOUT,
-                 request_timeout=DEFAULT_TIMEOUT,
-                 recv_size=RECV_SIZE):
-        """Constructor: setting and connecting to the remote."""
-        self.server = server
-        self.connect_timeout = connect_timeout
-        self.request_timeout = request_timeout
-        self.recv_size = recv_size
-        self.connect()
-
-    def connect(self):
-        """Connect to a TCP host:port endpoint, return socket"""
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(self.connect_timeout)
-        sock.connect(self.server)
-        sock.settimeout(self.request_timeout)
-        self.sock = sock
-
-    def close(self):
-        """Close the socket"""
-        if self.sock is not None:
-            try:
-                self.sock.close()
-            except Exception:
-                pass
-            self.sock = None
+  DEFAULT_TIMEOUT = 1.0
+  RECV_SIZE = 1024 * 1024
 
 
-    def recvall(self):
-        """recv until no data outstanding on the socket"""
-        self.sock.setblocking(False)
-        data = ''
-        while True:
-            try:
-                seg = self.sock.recv(self.recv_size)
-                if seg == '':
-                    self.close()
-                else:
-                    data += seg
-            except (IOError, socket.error) as e:
-                err = e.args[0]
-                if err == errno.EINTR:
-                    continue
-                if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
-                    if len(data) == 0:
-                        continue
-                    else:
-                        break
-                else:
-                    raise
-        self.sock.setblocking(True)
-        return data
+  def __init__(self,
+               server,
+               connect_timeout=DEFAULT_TIMEOUT,
+               request_timeout=DEFAULT_TIMEOUT,
+               recv_size=RECV_SIZE):
+    """Constructor: setting and connecting to the remote."""
+    self.server = server
+    self.connect_timeout = connect_timeout
+    self.request_timeout = request_timeout
+    self.recv_size = recv_size
+    self.connect()
 
-    def send(self, data):
-        """send req until all data is sent, or an error occurs"""
-        if not self.sock:
-            self.connect()
-        try:
-            self.sock.sendall(data)
-        except Exception:
-            self.close()
-            raise
+
+  def connect(self):
+    """Connect to a TCP host:port endpoint, return socket"""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(self.connect_timeout)
+    sock.connect(self.server)
+    sock.settimeout(self.request_timeout)
+    self.sock = sock
+
+
+  def close(self):
+    """Close the socket"""
+    if self.sock is not None:
+      try:
+        self.sock.close()
+      except Exception:
+        pass
+      self.sock = None
+
+
+  def recvall(self):
+    """recv until no data outstanding on the socket"""
+    self.sock.setblocking(False)
+    data = ''
+    while True:
+      try:
+        seg = self.sock.recv(self.recv_size)
+        if seg == '':
+          self.close()
+        else:
+          data += seg
+      except (IOError, socket.error) as e:
+        err = e.args[0]
+        if err == errno.EINTR:
+          continue
+        if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
+          if len(data) == 0:
+            continue
+          else:
+            break
+        else:
+          raise
+    self.sock.setblocking(True)
+    return data
+
+
+  def send(self, data):
+    """send req until all data is sent, or an error occurs"""
+    if not self.sock:
+      self.connect()
+    try:
+      self.sock.sendall(data)
+    except Exception:
+      self.close()
+      raise
 
 
 class DataClient(TCPClient):
     DELIM = '\r\n'
 
     def request(self, req):
-        """send a (multi-line) request, req should be of a sequence type"""
-        for line in req:
-            self.send(line + DataClient.DELIM)
+      """send a (multi-line) request, req should be of a sequence type"""
+      for line in req:
+        self.send(line + DataClient.DELIM)
+
 
     def response(self):
-        """receive a response, which will be split by delimiter (retained)"""
-        buf = self.recvall()
-        rsp = buf.split(DataClient.DELIM)
-        if rsp[-1] == '':
-            rsp.pop()
-        else:
-            raise Exception("response not terminated by " + DataClient.DELIM)
-        return rsp
+      """receive a response, which will be split by delimiter (retained)"""
+      buf = self.recvall()
+      rsp = buf.split(DataClient.DELIM)
+      if rsp[-1] == '':
+        rsp.pop()
+      else:
+        raise Exception("response not terminated by " + DataClient.DELIM)
+      return rsp
 
 
 class AdminClient(TCPClient):
-    DELIM = '\r\n'
-    STATS_CMD = 'stats'
+  DELIM = '\r\n'
+  STATS_CMD = 'stats'
 
-    def stats(self):
-        self.send(AdminClient.STATS_CMD + AdminClient.DELIM)
-        buf = self.recvall()
-        rsp = buf.split(AdminClient.DELIM)
-        if rsp[-1] == '':
-            rsp.pop()
-        else:
-            raise Exception("response not terminated by " + DataClient.DELIM)
-        if rsp[-1] == 'END':
-            rsp.pop()
-        else:
-            raise Exception('ending not detected, found {} instead'.format(rsp[-1]))
 
-        return dict(line.split(' ')[1:] for line in rsp)
+  def stats(self):
+    self.send(AdminClient.STATS_CMD + AdminClient.DELIM)
+    buf = self.recvall()
+    rsp = buf.split(AdminClient.DELIM)
+    if rsp[-1] == '':
+      rsp.pop()
+    else:
+      raise Exception("response not terminated by " + DataClient.DELIM)
+    if rsp[-1] == 'END':
+      rsp.pop()
+    else:
+      raise Exception('ending not detected, found {} instead'.format(rsp[-1]))
+
+    return dict(line.split(' ')[1:] for line in rsp)

--- a/test/integration/loader.py
+++ b/test/integration/loader.py
@@ -11,49 +11,49 @@ re_stat = re.compile("^\+\+\+ (.+)$")
 
 
 def split_metrics(line):
-    """split a line of metric deltas into a dict, for example:
+  """split a line of metric deltas into a dict, for example:
 
-    'get +1, get_hit +1' -> {'get':1, 'get_hit':1}
-    'request_free -1, request_parse +1' -> {'request_free':-1, 'request_parse':1}
-    """
-    metrics = line.split(',')
-    d = {}
-    for m in metrics:
-        name,delta = m.strip().split(' ')
-        d[name.strip()] = int(delta)
+  'get +1, get_hit +1' -> {'get':1, 'get_hit':1}
+  'request_free -1, request_parse +1' -> {'request_free':-1, 'request_parse':1}
+  """
+  metrics = line.split(',')
+  d = {}
+  for m in metrics:
+    name,delta = m.strip().split(' ')
+    d[name.strip()] = int(delta)
 
-    return d
+  return d
 
 
 def load_seq(fname):
-    """Load the test (a sequence of commands and asserts) from a file.
+  """Load the test (a sequence of commands and asserts) from a file.
 
-    Each command contains one or more lines of request, leading with '>>> ', and
-    one or more lines of response, leading with '<<< '. Commands are separated
-    by an empty line.
-    """
-    lines = open(fname).readlines()
-    if not re_empty.match(lines[-1]):  # ensure an empty line at the end
-      lines.append('\n')
+  Each command contains one or more lines of request, leading with '>>> ', and
+  one or more lines of response, leading with '<<< '. Commands are separated
+  by an empty line.
+  """
+  lines = open(fname).readlines()
+  if not re_empty.match(lines[-1]):  # ensure an empty line at the end
+    lines.append('\n')
 
-    seq = []
-    req = []
-    rsp = []
-    stat = {}
-    for line in lines:
-        if (re_empty.match(line)):  # reset
-            if len(req) > 0:  # rsp and stat can be empty
-                seq.append({'req': req, 'rsp':rsp, 'stat':stat})
-            req = []
-            rsp = []
-            stat = {}
-        elif re_req.match(line):
-            req.append(re_req.match(line).group(1))
-        elif re_rsp.match(line):
-            rsp.append(re_rsp.match(line).group(1))
-        elif re_stat.match(line):
-            stat.update(split_metrics(re_stat.match(line).group(1)))
-        else:
-            print("unrecognized line")
+  seq = []
+  req = []
+  rsp = []
+  stat = {}
+  for line in lines:
+    if (re_empty.match(line)):  # reset
+      if len(req) > 0:  # rsp and stat can be empty
+        seq.append({'req': req, 'rsp':rsp, 'stat':stat})
+      req = []
+      rsp = []
+      stat = {}
+    elif re_req.match(line):
+      req.append(re_req.match(line).group(1))
+    elif re_rsp.match(line):
+      rsp.append(re_rsp.match(line).group(1))
+    elif re_stat.match(line):
+      stat.update(split_metrics(re_stat.match(line).group(1)))
+    else:
+      print("unrecognized line")
 
-    return seq
+  return seq

--- a/test/integration/server.py
+++ b/test/integration/server.py
@@ -4,49 +4,57 @@ import subprocess
 
 
 class PelikanServer(object):
-    SUPPORTED_SERVER = [
-        'pelikan_pingserver',
-        'pelikan_redis',
-        'pelikan_slimcache',
-        'pelikan_twemcache' ]
+  SUPPORTED_SERVER = [
+    'pelikan_pingserver',
+    'pelikan_rds',
+    'pelikan_slimcache',
+    'pelikan_twemcache' ]
 
-    @staticmethod
-    def default_path():
-        return os.path.realpath(os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            '../../_build/_bin'
-        ))
 
-    def __init__(self, executable, config=None):
-        if executable not in PelikanServer.SUPPORTED_SERVER:
-            raise Exception('executable not supported')
-        self.executable = executable
-        self.config = config
-        if config:  # server different from default
-            # TODO: find out server info from config
-            pass
-        self.start(config)
+  @staticmethod
+  def default_path():
+    return os.path.realpath(os.path.join(
+      os.path.dirname(os.path.abspath(__file__)),
+      '../../_build/_bin'
+    ))
 
-    def start(self, config):
-        executable = os.path.join(
-            os.getenv('PELIKAN_BIN_PATH', PelikanServer.default_path()),
-            self.executable
-        )
-        exec_tup = (executable, self.config) if self.config else (executable)
 
-        self.server = subprocess.Popen(exec_tup,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+  def __init__(self, executable, config=None):
+    if executable not in PelikanServer.SUPPORTED_SERVER:
+      raise Exception('executable not supported')
+    self.executable = executable
+    self.config = config
+    if config:  # server different from default
+      # TODO: find out server info from config
+      pass
+    self.start(config)
 
-    def ready(self):
-        # wait for the port to be listening; no great "ready" output present
-        # but it lists all configs, so this must exist
-        if not self.server:
-            raise Exception('server is not started')
-        while 'name: server_port' not in self.server.stdout.readline():
-            pass
 
-    def stop(self):
-        self.server.kill()
+  def start(self, config):
+    executable = os.path.join(
+      os.getenv('PELIKAN_BIN_PATH', PelikanServer.default_path()),
+      self.executable
+    )
+    print(executable)
+    exec_tup = (executable, self.config) if self.config else (executable)
+
+    self.server = subprocess.Popen(exec_tup,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+    )
+
+
+  def ready(self):
+    # wait for the port to be listening; no great "ready" output present
+    # but it lists all configs, so this must exist
+    if not self.server:
+      raise Exception('server is not started')
+    line = self.server.stdout.readline()
+    while not line.decode('UTF-8').startswith(u'name: server_port'):
+      line = self.server.stdout.readline()
+      #pass
+
+
+  def stop(self):
+    self.server.kill()

--- a/test/integration/server.py
+++ b/test/integration/server.py
@@ -35,7 +35,6 @@ class PelikanServer(object):
       os.getenv('PELIKAN_BIN_PATH', PelikanServer.default_path()),
       self.executable
     )
-    print(executable)
     exec_tup = (executable, self.config) if self.config else (executable)
 
     self.server = subprocess.Popen(exec_tup,
@@ -54,6 +53,7 @@ class PelikanServer(object):
     while not line.decode('UTF-8').startswith(u'name: server_port'):
       line = self.server.stdout.readline()
       #pass
+    print("server is up and running")
 
 
   def stop(self):

--- a/test/integration/test_twemcache.py
+++ b/test/integration/test_twemcache.py
@@ -6,17 +6,17 @@ import unittest
 
 
 def twemcache():
-    suite = unittest.TestSuite()
-    for fname in listdir('twemcache'):
-        test = GenericTest()
-        test.load('twemcache/' + fname)
-        suite.addTest(test)
+  suite = unittest.TestSuite()
+  for fname in listdir('twemcache'):
+    test = GenericTest('pelikan_twemcache')
+    test.load('twemcache/' + fname)
+    suite.addTest(test)
 
-    return suite
+  return suite
 
 
 if __name__ == '__main__':
-    result = unittest.TextTestRunner(verbosity=2).run(twemcache())
-    if result.wasSuccessful():
-        sys.exit(0)
-    sys.exit(1)
+  result = unittest.TextTestRunner(verbosity=2).run(twemcache())
+  if result.wasSuccessful():
+    sys.exit(0)
+  sys.exit(1)


### PR DESCRIPTION
Generalizing sorted array a bit to allow fixed size values associated with (numeric) keys. Other than changing the signature of three APIs, and small changes to internal implementations, it looks and works very similar to sorted array.

Once this is merged I'm gonna start adding higher level APIs for SortedMap. Since we can use zero value size as a special case to get sorted array behavior with sorted map, I will probably port the sorted array APIs to use sorted map, and drop the sorted array data structure entirely.