### PR TITLE
Speed up rust builds

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -15,6 +15,7 @@ export PATH=$HOME/.cargo/bin:$PATH
 cmake_cmd=(
   cmake
   -DBUILD_AND_INSTALL_CHECK=yes
+  -DCARGO_CI=yes
 )
 
 # Ensure that rust test failures have the full backtrace

--- a/deps/ccommon/cmake/CMakeCargo.cmake
+++ b/deps/ccommon/cmake/CMakeCargo.cmake
@@ -157,8 +157,6 @@ function(cargo_build)
         endif()
     endif()
 
-    message(STATUS TARGET_DIR: "${CARGO_TARGET_DIR}")
-
     if(CARGO_BIN AND CARGO_STATIC)
         message(
             FATAL_ERROR
@@ -370,7 +368,7 @@ function(cargo_build)
         # However, we still want to build the library, so define a custom command for that
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build.stamp
-            COMMAND ${CARGO_ENV_COMMAND} cargo build -v ${CRATE_ARGS}
+            COMMAND ${CARGO_ENV_COMMAND} cargo build ${CRATE_ARGS}
             COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/build.stamp
             DEPENDS ${CRATE_SOURCES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/deps/ccommon/cmake/CMakeCargo.cmake
+++ b/deps/ccommon/cmake/CMakeCargo.cmake
@@ -85,6 +85,10 @@ endfunction()
 #       can be consumed by other cmake targets.
 #   NO_TEST
 #       Disables generation of the test target.
+#   USE_CMAKE_LINK
+#       Pass link flags through from cmake through RUSTFLAGS. This
+#       is necessary if the build scripts for the rust code don't
+#       account for all the necessary linker dependencies.
 #
 # Notes:
 #   - If neither BIN or STATIC is defined then it is assumed
@@ -126,21 +130,34 @@ endfunction()
 function(cargo_build)
     cmake_parse_arguments(
         CARGO
-        "BIN;STATIC;NO_TEST"
+        "BIN;STATIC;NO_TEST;USE_CMAKE_LINK"
         "NAME;TARGET_DIR;COPY_TO"
         ""
         ${ARGN}
     )
 
+    set(CARGO_FORCE_CMAKE_LINK OFF CACHE BOOL "Pass link flags from cmake to cargo - this will slow down builds considerably")
+    set(CARGO_CI OFF CACHE BOOL "Optimize build for from-scratch build time instead of incremental rebuild")
+
+    mark_as_advanced(CARGO_FORCE_CMAKE_LINK CARGO_CI)
+
+    if(CARGO_FORCE_CMAKE_LINK)
+        set(${CARGO_USE_CMAKE_LINK} ON)
+    endif()
+
     string(REPLACE "-" "_" LIB_NAME ${CARGO_NAME})
 
-    if(NOT (DEFINED CARGO_TARGET_DIR))
-        if ($ENV{CI})
-            set(CARGO_TARGET_DIR ${CMAKE_BINARY_DIR}/target)
+    if(NOT DEFINED CARGO_TARGET_DIR)
+        if(NOT CARGO_USE_CMAKE_LINK AND NOT DEFINED CARGO_TARGET_DIR)
+            set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/target")
+        elseif(CARGO_CI)
+            set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/target")
         else()
-            set(CARGO_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR}/target)
+            set(CARGO_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/target")
         endif()
     endif()
+
+    message(STATUS TARGET_DIR: "${CARGO_TARGET_DIR}")
 
     if(CARGO_BIN AND CARGO_STATIC)
         message(
@@ -250,7 +267,7 @@ function(cargo_build)
     #
     # "Docs" for the expansion rules can be found here
     # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/Build-Rules
-    set(LINK_COMMAND "<CMAKE_COMMAND> -P ${FILE_LIST_DIR}/CargoLink.cmake 'TARGET=<TARGET>' 'LINK_FLAGS=<LINK_FLAGS>' 'LINK_LIBRARIES=<LINK_LIBRARIES>' 'FLAGS=${CRATE_ARGS_STR}' 'OUTPUT=${OUTPUT_FILE}' 'CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}' 'LINK_FLAGS_FILE=${LINK_FLAGS_FILE}' -- ")
+    set(LINK_COMMAND "<CMAKE_COMMAND> -P ${FILE_LIST_DIR}/CargoLink.cmake 'TARGET=<TARGET>' 'LINK_FLAGS=<LINK_FLAGS>' 'LINK_LIBRARIES=<LINK_LIBRARIES>' 'FLAGS=${CRATE_ARGS_STR}' 'OUTPUT=${OUTPUT_FILE}' 'CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}' 'LINK_FLAGS_FILE=${LINK_FLAGS_FILE}' 'USE_CMAKE_LINK=${USE_CMAKE_LINK}' -- ")
     
     foreach(VAR ${FORWARDED_VARS})
         string(APPEND LINK_COMMAND " ${VAR}")
@@ -353,7 +370,7 @@ function(cargo_build)
         # However, we still want to build the library, so define a custom command for that
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/build.stamp
-            COMMAND ${CARGO_ENV_COMMAND} cargo build ${CRATE_ARGS}
+            COMMAND ${CARGO_ENV_COMMAND} cargo build -v ${CRATE_ARGS}
             COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/build.stamp
             DEPENDS ${CRATE_SOURCES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -389,6 +406,7 @@ function(cargo_build)
                 "FLAGS=${TEST_ARGS_STR}"
                 "CMAKE_CURRENT_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
                 "CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+                "USE_CMAKE_LINK=${CARGO_USE_CMAKE_LINK}"
                 --
                 ${FORWARDED_VARS}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/deps/ccommon/cmake/CargoLink.cmake
+++ b/deps/ccommon/cmake/CargoLink.cmake
@@ -82,11 +82,21 @@ string(REPLACE " " ";" FLAGS "${FLAGS}")
 #             there a way to autodetect this properly?
 set(CARGO_COMMAND cargo build --color always ${FLAGS})
 
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} "RUSTFLAGS=${LINK_FLAGS}" ${CARGO_COMMAND}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    RESULT_VARIABLE STATUS
-)
+message(STATUS "Building with vars ${PASSTHROUGH_VARS}")
+if(USE_CMAKE_LINK)
+    message(STATUS "Building with rustflags ${LINK_FLAGS}")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} "RUSTFLAGS=${LINK_FLAGS}" ${CARGO_COMMAND}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE STATUS
+    )
+else()
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} ${CARGO_COMMAND}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        RESULT_VARIABLE STATUS
+    )
+endif()
 
 # Ensure that our script exits with the correct error code.
 # The only way to get a cmake script to exit with an error

--- a/deps/ccommon/cmake/CargoLink.cmake
+++ b/deps/ccommon/cmake/CargoLink.cmake
@@ -82,9 +82,7 @@ string(REPLACE " " ";" FLAGS "${FLAGS}")
 #             there a way to autodetect this properly?
 set(CARGO_COMMAND cargo build --color always ${FLAGS})
 
-message(STATUS "Building with vars ${PASSTHROUGH_VARS}")
 if(USE_CMAKE_LINK)
-    message(STATUS "Building with rustflags ${LINK_FLAGS}")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} "RUSTFLAGS=${LINK_FLAGS}" ${CARGO_COMMAND}
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/deps/ccommon/cmake/CargoTest.cmake
+++ b/deps/ccommon/cmake/CargoTest.cmake
@@ -82,11 +82,19 @@ string(REPLACE " " ";" FLAGS "${FLAGS}")
 #             there a way to autodetect this properly?
 set(CARGO_COMMAND cargo test --color always ${FLAGS})
 
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} "RUSTFLAGS=${LINK_FLAGS}" ${CARGO_COMMAND}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    RESULT_VARIABLE STATUS
-)
+if (USE_CMAKE_LINK)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} "RUSTFLAGS=${LINK_FLAGS}" ${CARGO_COMMAND}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE STATUS
+    )
+else()
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E env ${PASSTHROUGH_VARS} ${CARGO_COMMAND}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE STATUS
+    )
+endif()
 
 # Ensure that our script exits with the correct error code.
 # The only way to get a cmake script to exit with an error

--- a/src/rust-util/pelikan-sys/Cargo.toml
+++ b/src/rust-util/pelikan-sys/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.0.0"
 authors = ["Sean Lynch <slynch@twitter.com>"]
 edition = "2018"
 
-# TODO(sean): Should we use the cmake config instead of cargo features?
+# Feature dependencies should mirror cmake library dependencies
 [features]
 cdb = [ "cdb_rs" ]
 client-network = []
 core = []
-cuckoo = []
+cuckoo = [ "datapool", "time" ]
 datapool = []
 ds_bitmap = []
 ds_sarray = []
@@ -20,7 +20,7 @@ protocol_resp_tw = []
 protocol_memcache = []
 protocol_ping = []
 protocol_admin = []
-slab = []
+slab = [ "datapool" ]
 time = []
 util = [ "time" ]
 

--- a/src/rust-util/pelikan-sys/build.rs
+++ b/src/rust-util/pelikan-sys/build.rs
@@ -79,6 +79,469 @@ fn dump_env() {
     }
 }
 
+fn gen_client_network() {
+    print_directives("client-network", "client/network");
+
+    let bindings = builder()
+        .header("../../client/network/cli_network.h")
+        .whitelist_type("cli_network")
+        .whitelist_type("cli_network_e")
+        .whitelist_type("network_config")
+        .whitelist_var("tcp_handler")
+        .whitelist_var("network_config")
+        .whitelist_function("cli_connect")
+        .whitelist_function("cli_disconnect")
+        .whitelist_function("cli_reconnect")
+        .whitelist_var("PROMPT_FMT_OFFLINE")
+        .whitelist_var("PROMPT_FMT_LOCAL")
+        .whitelist_var("PROMPT_FMT_REMOTE")
+        .whitelist_var("SEND_ERROR")
+        .whitelist_var("RECV_ERROR")
+        .whitelist_var("RECV_HUP")
+        .whitelist_var("DISCONNECT_MSG")
+        .whitelist_var("RECONNECT_MSG")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("client-network.rs"))
+        .expect("Couldn't write bindings");
+}
+
+fn gen_util() {
+    print_directives("util", "util");
+
+    let bindings = builder()
+        .header("../../util/util.h")
+        .header("../../util/procinfo.h")
+        // procinfo
+        .whitelist_type("procinfo_metrics_st")
+        .whitelist_function("procinfo_setup")
+        .whitelist_function("procinfo_teardown")
+        .whitelist_function("procinfo_update")
+        // util
+        .whitelist_function("daemonize")
+        .whitelist_function("show_version")
+        .whitelist_function("getaddr")
+        .whitelist_function("create_pidfile")
+        .whitelist_function("remove_pidfile")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("util.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_time() {
+    print_directives("time", "time");
+
+    let bindings = builder()
+        .header("../../time/time.h")
+        .whitelist_type("proc_time_i")
+        .whitelist_type("proc_time_fine_i")
+        .whitelist_type("delta_time_i")
+        .whitelist_type("delta_time_fine_i")
+        .whitelist_type("unix_time_u")
+        .whitelist_type("unix_time_fine_u")
+        .whitelist_type("memcache_time_u")
+        .whitelist_type("memcache_time_fine_u")
+        .whitelist_type("time_i")
+        .whitelist_type("time_fine_i")
+        .whitelist_var("TIME_.*")
+        .whitelist_type("time_options_st")
+        .whitelist_var("time_start")
+        .whitelist_var("proc_sec")
+        .whitelist_var("proc_ms")
+        .whitelist_var("proc_us")
+        .whitelist_var("proc_ns")
+        .whitelist_var("time_type")
+        .whitelist_var("NSEC_PER_USEC")
+        .whitelist_var("USEC_PER_SEC")
+        .whitelist_var("MSEC_PER_SEC")
+        .whitelist_function("time_update")
+        .whitelist_function("time_setup")
+        .whitelist_function("time_teardown")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("time.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_core() {
+    print_directives("core", "core");
+
+    let bindings = builder()
+        .header("../../core/core.h")
+        .blacklist_item("ADMIN_PORT")
+        .blacklist_item("SERVER_PORT")
+        .whitelist_function("core_.*")
+        .whitelist_var("ADMIN_.*")
+        .whitelist_type("event_base")
+        .whitelist_type("context")
+        .whitelist_var("admin_init")
+        .whitelist_var("server_init")
+        .whitelist_var("worker_init")
+        .whitelist_type("admin_options_st")
+        .whitelist_var("pipe_new")
+        .whitelist_var("pipe_term")
+        .whitelist_var("conn_new")
+        .whitelist_var("conn_term")
+        .whitelist_var("SERVER_.*")
+        .whitelist_type("server_options_st")
+        .whitelist_type("server_metrics_st")
+        .whitelist_var("WORKER_.*")
+        .whitelist_type("worker_options_st")
+        .whitelist_type("worker_metrics_st")
+        .whitelist_type("data_processor")
+        .whitelist_type("data_fn")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("core.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_hotkey() {
+    print_directives("hotkey", "hotkey");
+
+    let bindings = builder()
+        .header("../../hotkey/hotkey.h")
+        .header("../../hotkey/key_window.h")
+        .header("../../hotkey/kc_map.h")
+        .header("../../hotkey/constant.h")
+        .whitelist_function("key_window_.*")
+        .whitelist_function("kc_map_.*")
+        .whitelist_function("hotkey_.*")
+        .whitelist_type("hotkey_.*")
+        .whitelist_var("HOTKEY_.*")
+        .whitelist_var("MAX_KEY_LEN")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("hotkey.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_datapool() {
+    print_directives("datapool", "datapool");
+
+    let bindings = builder()
+        .header("../../datapool/datapool.h")
+        .whitelist_type("datapool")
+        .whitelist_function("datapool_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("datapool.rs"))
+        .expect("Couldn't write bindings");
+}
+
+fn gen_ds_bitmap() {
+    print_directives("ds_bitmap", "data_structure/bitmap");
+
+    let bindings = builder()
+        .header("../../data_structure/bitmap/bitset.h")
+        .whitelist_var("BITSET_COL_MAX")
+        .whitelist_type("bitset")
+        .whitelist_function("bitset_init")
+        .whitelist_function("bitset_get")
+        .whitelist_function("bitset_set")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("ds_bitmap.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_ds_sarray() {
+    print_directives("ds_sarray", "data_structure/sarray");
+
+    let bindings = builder()
+        .header("../../data_structure/sarray/sarray.h")
+        .whitelist_type("sarray_p")
+        .whitelist_type("sarray_rstatus_e")
+        .whitelist_function("sarray_.*")
+        .whitelist_recursively(false)
+        .derive_default(true)
+        .derive_copy(true)
+        .derive_debug(true)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("ds_sarray.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_ds_ziplist() {
+    print_directives("ds_ziplist", "data_structure/ziplist");
+
+    let bindings = builder()
+        .header("../../data_structure/ziplist/ziplist.h")
+        .blacklist_item("blob")
+        .whitelist_type("ziplist_.*")
+        .whitelist_type("zipentry_p")
+        .whitelist_function("ziplist_.*")
+        .whitelist_function("zipentry_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("ds_ziplist.rs"))
+        .expect("Couldn't write bindings");
+}
+
+fn gen_cuckoo() {
+    print_directives("cuckoo", "storage/cuckoo");
+
+    let bindings = builder()
+        .header("../../storage/cuckoo/cuckoo.h")
+        .blacklist_item("delta_time_i")
+        .blacklist_item("proc_time_i")
+        .whitelist_var("CUCKOO_.*")
+        .whitelist_type("cuckoo_.*")
+        .whitelist_function("cuckoo_.*")
+        .whitelist_var("cas_enabled")
+        .whitelist_var("cas_val")
+        .whitelist_var("max_ttl")
+        .whitelist_type("val_type")
+        .whitelist_type("val_type_t")
+        .whitelist_type("val")
+        .whitelist_type("item")
+        .whitelist_var("KEY_MAXLEN")
+        .whitelist_var("CAS_VAL_MIN")
+        .whitelist_var("CAS_LEN")
+        .whitelist_var("MIN_ITEM_CHUNK_SIZE")
+        .whitelist_var("ITEM_HDR_SIZE")
+        .whitelist_var("ITEM_CAS_POS")
+        .whitelist_var("ITEM_KEY_POS")
+        .whitelist_var("ITEM_VAL_POS")
+        .whitelist_var("ITEM_OVERHEAD")
+        .whitelist_function("item_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("cuckoo.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_slab() {
+    print_directives("slab", "storage/slab");
+
+    let bindings = builder()
+        .header("../../storage/slab/slab.h")
+        .blacklist_type("proc_time_i")
+        .whitelist_var("SLAB_.*")
+        .whitelist_var("ITEM_.*")
+        .whitelist_var("EVICT_.*")
+        .whitelist_type("slab_.*")
+        .whitelist_type("slab")
+        .whitelist_type("slab_tqh")
+        .whitelist_var("hash_table")
+        .whitelist_var("slab_size")
+        .whitelist_var("slab_metrics")
+        .whitelist_function("slab_.*")
+        .whitelist_type("item")
+        .whitelist_type("item_.*")
+        .whitelist_var("use_cas")
+        .whitelist_var("cas_id")
+        .whitelist_var("slab_profile")
+        .whitelist_function("item_.*")
+        .whitelist_type("hash_table")
+        .whitelist_function("hashtable_.*")
+        .whitelist_type("slabclass")
+        .whitelist_var("SLABCLASS_.*")
+        .whitelist_var("slabclass")
+        .whitelist_var("perslab")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("slab.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_cdb() {
+    // No dependencies since the CDB backend is in rust.
+
+    let bindings = builder()
+        .header("../../storage/cdb/cdb_rs.h")
+        .whitelist_type("cdb_.*")
+        .whitelist_function("cdb_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("cdb.rs"))
+        .expect("Couldn't write bindings");
+}
+
+fn gen_protocol_resp() {
+    print_directives("protocol_resp", "protocol/data/resp");
+
+    let bindings = builder()
+        .header("../../protocol/data/resp_include.h")
+        .whitelist_type("bitmap_elem(_e)?")
+        .whitelist_type("list_elem(_e)?")
+        .whitelist_type("sarray_elem(_e)?")
+        .whitelist_type("compose_.*")
+        .whitelist_function("compose_.*")
+        .whitelist_type("parse_.*")
+        .whitelist_function("parse_.*")
+        .whitelist_function("process_request")
+        .whitelist_type("response_.*")
+        .whitelist_var("RSP_.*")
+        .whitelist_type("response")
+        .whitelist_type("response_.*")
+        .whitelist_type("element")
+        .whitelist_type("element_type(_e)?")
+        .whitelist_function("token_.*")
+        .whitelist_type("request")
+        .whitelist_type("request_.*")
+        .whitelist_var("REQ_.*")
+        .whitelist_var("KEY_MAXLEN")
+        .whitelist_type("command")
+        .whitelist_var("command_table")
+        .whitelist_type("cmd_type(_e)?")
+        .whitelist_function("request_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = env::var("OUT_DIR").map(PathBuf::from).unwrap();
+    bindings
+        .write_to_file(out_path.join("protocol_resp.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_protocol_resp_tw() {
+    // TODO: This protocol doesn't even exist in pelikan yet
+    print_directives("protocol_resp_tw", "protocol/data/resp_tw");
+
+    let bindings = builder()
+        .header("../../protocol/data/resp_tw_include.h")
+        .whitelist_type("parse_rstatus(_e)?")
+        .whitelist_type("compose_rstatus(_e)?")
+        .whitelist_type("element_type(_e)?")
+        .whitelist_type("element")
+        .whitelist_function("token_.*")
+        .whitelist_function("parse_.*")
+        .whitelist_function("compose_.*")
+        .whitelist_type("response_(options|metrics)_st")
+        .whitelist_var("RSP_.*")
+        .whitelist_type("attribuet_entry")
+        .whitelist_type("response")
+        .whitelist_function("response_.*")
+        .whitelist_type("request_(options|metrics)_st")
+        .whitelist_type("cmd_type(_e)?")
+        .whitelist_type("command")
+        .whitelist_var("command_table")
+        .whitelist_type("request")
+        .whitelist_function("request_.*")
+        .whitelist_type("parse_(req|rsp)_metrics_st")
+        .whitelist_type("compose_(req|rsp)_metrics_st")
+        .whitelist_var("OPT_UNLIMITED")
+        .whitelist_type("sarray_elem(_e)?")
+        .whitelist_type("list_elem(_e)?")
+        .whitelist_type("bitmap_elem(_e)?")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("protocol_resp_tw.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_protocol_ping() {
+    print_directives("protocol_ping", "protocol/data/ping");
+
+    let bindings = builder()
+        .header("../../protocol/data/ping_include.h")
+        .whitelist_var("RESPONSE")
+        .whitelist_var("RSP_LEN")
+        .whitelist_var("REQUEST")
+        .whitelist_var("REQ_LEN")
+        .whitelist_type("compose_.*")
+        .whitelist_function("compose_.*")
+        .whitelist_type("parse_.*")
+        .whitelist_function("parse_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("protocol_ping.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_protocol_memcache() {
+    print_directives("protocol_memcache", "protocol/data/memcache");
+
+    let bindings = builder()
+        .header("../../protocol/data/memcache_include.h")
+        .whitelist_type("response_.*")
+        .whitelist_var("rsp_strings")
+        .whitelist_type("response")
+        .whitelist_function("response_.*")
+        .whitelist_type("request_.*")
+        .whitelist_type("request")
+        .whitelist_function("request_.*")
+        .whitelist_type("process_request")
+        .whitelist_type("parse_.*")
+        .whitelist_function("parse_.*")
+        .whitelist_var("KLOG_.*")
+        .whitelist_type("klog_.*")
+        .whitelist_var("klog_enabled")
+        .whitelist_function("klog_.*")
+        .whitelist_function("_klog_write")
+        .whitelist_var("MAX_.*")
+        .whitelist_var("DATAFLAG_SIZE")
+        .whitelist_type("compose_.*")
+        .whitelist_function("compose_.*")
+        .whitelist_function("REQ_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("protocol_memcache.rs"))
+        .expect("Couldn't write bindings");
+}
+fn gen_protocol_admin() {
+    print_directives("protocol_admin", "protocol/admin");
+
+    let bindings = builder()
+        .header("../../protocol/admin/admin_include.h")
+        .whitelist_type("response")
+        .whitelist_type("response_.*")
+        .whitelist_function("admin_.*")
+        .whitelist_type("request_.*")
+        .whitelist_type("request")
+        .whitelist_type("parse_.*")
+        .whitelist_var("METRIC_.*")
+        .whitelist_var("VERSION_PRINTED")
+        .whitelist_function("print_stats")
+        .whitelist_function("compose_.*")
+        .whitelist_var("COMPOSE_.*")
+        .whitelist_type("compose_.*")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("protocol_admin.rs"))
+        .expect("Couldn't write bindings");
+}
+
 fn main() {
     dump_env();
 
@@ -148,465 +611,61 @@ fn main() {
     }
 
     if cfg!(feature = "client-network") {
-        print_directives("client-network", "client/network");
-
-        let bindings = builder()
-            .header("../../client/network/cli_network.h")
-            .whitelist_type("cli_network")
-            .whitelist_type("cli_network_e")
-            .whitelist_type("network_config")
-            .whitelist_var("tcp_handler")
-            .whitelist_var("network_config")
-            .whitelist_function("cli_connect")
-            .whitelist_function("cli_disconnect")
-            .whitelist_function("cli_reconnect")
-            .whitelist_var("PROMPT_FMT_OFFLINE")
-            .whitelist_var("PROMPT_FMT_LOCAL")
-            .whitelist_var("PROMPT_FMT_REMOTE")
-            .whitelist_var("SEND_ERROR")
-            .whitelist_var("RECV_ERROR")
-            .whitelist_var("RECV_HUP")
-            .whitelist_var("DISCONNECT_MSG")
-            .whitelist_var("RECONNECT_MSG")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("client-network.rs"))
-            .expect("Couldn't write bindings");
+        gen_client_network();
     }
     if cfg!(feature = "util") {
-        print_directives("util", "util");
-
-        let bindings = builder()
-            .header("../../util/util.h")
-            .header("../../util/procinfo.h")
-            // procinfo
-            .whitelist_type("procinfo_metrics_st")
-            .whitelist_function("procinfo_setup")
-            .whitelist_function("procinfo_teardown")
-            .whitelist_function("procinfo_update")
-            // util
-            .whitelist_function("daemonize")
-            .whitelist_function("show_version")
-            .whitelist_function("getaddr")
-            .whitelist_function("create_pidfile")
-            .whitelist_function("remove_pidfile")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("util.rs"))
-            .expect("Couldn't write bindings");
+        gen_util();
     }
     if cfg!(feature = "time") {
-        print_directives("time", "time");
-
-        let bindings = builder()
-            .header("../../time/time.h")
-            .whitelist_type("proc_time_i")
-            .whitelist_type("proc_time_fine_i")
-            .whitelist_type("delta_time_i")
-            .whitelist_type("delta_time_fine_i")
-            .whitelist_type("unix_time_u")
-            .whitelist_type("unix_time_fine_u")
-            .whitelist_type("memcache_time_u")
-            .whitelist_type("memcache_time_fine_u")
-            .whitelist_type("time_i")
-            .whitelist_type("time_fine_i")
-            .whitelist_var("TIME_.*")
-            .whitelist_type("time_options_st")
-            .whitelist_var("time_start")
-            .whitelist_var("proc_sec")
-            .whitelist_var("proc_ms")
-            .whitelist_var("proc_us")
-            .whitelist_var("proc_ns")
-            .whitelist_var("time_type")
-            .whitelist_var("NSEC_PER_USEC")
-            .whitelist_var("USEC_PER_SEC")
-            .whitelist_var("MSEC_PER_SEC")
-            .whitelist_function("time_update")
-            .whitelist_function("time_setup")
-            .whitelist_function("time_teardown")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("time.rs"))
-            .expect("Couldn't write bindings");
+        gen_time();
     }
     if cfg!(feature = "core") {
-        print_directives("core", "core");
-
-        let bindings = builder()
-            .header("../../core/core.h")
-            .blacklist_item("ADMIN_PORT")
-            .blacklist_item("SERVER_PORT")
-            .whitelist_function("core_.*")
-            .whitelist_var("ADMIN_.*")
-            .whitelist_type("event_base")
-            .whitelist_type("context")
-            .whitelist_var("admin_init")
-            .whitelist_var("server_init")
-            .whitelist_var("worker_init")
-            .whitelist_type("admin_options_st")
-            .whitelist_var("pipe_new")
-            .whitelist_var("pipe_term")
-            .whitelist_var("conn_new")
-            .whitelist_var("conn_term")
-            .whitelist_var("SERVER_.*")
-            .whitelist_type("server_options_st")
-            .whitelist_type("server_metrics_st")
-            .whitelist_var("WORKER_.*")
-            .whitelist_type("worker_options_st")
-            .whitelist_type("worker_metrics_st")
-            .whitelist_type("data_processor")
-            .whitelist_type("data_fn")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("core.rs"))
-            .expect("Couldn't write bindings");
+        gen_core();
     }
     if cfg!(feature = "hotkey") {
-        print_directives("hotkey", "hotkey");
-
-        let bindings = builder()
-            .header("../../hotkey/hotkey.h")
-            .header("../../hotkey/key_window.h")
-            .header("../../hotkey/kc_map.h")
-            .header("../../hotkey/constant.h")
-            .whitelist_function("key_window_.*")
-            .whitelist_function("kc_map_.*")
-            .whitelist_function("hotkey_.*")
-            .whitelist_type("hotkey_.*")
-            .whitelist_var("HOTKEY_.*")
-            .whitelist_var("MAX_KEY_LEN")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("hotkey.rs"))
-            .expect("Couldn't write bindings");
+        gen_hotkey();
     }
     if cfg!(feature = "datapool") {
-        print_directives("datapool", "datapool");
-
-        let bindings = builder()
-            .header("../../datapool/datapool.h")
-            .whitelist_type("datapool")
-            .whitelist_function("datapool_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("datapool.rs"))
-            .expect("Couldn't write bindings");
+        gen_datapool();
     }
 
     // Data Strucutures
     if cfg!(feature = "ds_bitmap") {
-        print_directives("ds_bitmap", "data_structure/bitmap");
-
-        let bindings = builder()
-            .header("../../data_structure/bitmap/bitset.h")
-            .whitelist_var("BITSET_COL_MAX")
-            .whitelist_type("bitset")
-            .whitelist_function("bitset_init")
-            .whitelist_function("bitset_get")
-            .whitelist_function("bitset_set")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("ds_bitmap.rs"))
-            .expect("Couldn't write bindings");
+        gen_ds_bitmap();
     }
     if cfg!(feature = "ds_sarray") {
-        print_directives("ds_sarray", "data_structure/sarray");
-
-        let bindings = builder()
-            .header("../../data_structure/sarray/sarray.h")
-            .whitelist_type("sarray_p")
-            .whitelist_type("sarray_rstatus_e")
-            .whitelist_function("sarray_.*")
-            .whitelist_recursively(false)
-            .derive_default(true)
-            .derive_copy(true)
-            .derive_debug(true)
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("ds_sarray.rs"))
-            .expect("Couldn't write bindings");
+        gen_ds_sarray();
     }
     if cfg!(feature = "ds_ziplist") {
-        print_directives("ds_ziplist", "data_structure/ziplist");
-
-        let bindings = builder()
-            .header("../../data_structure/ziplist/ziplist.h")
-            .blacklist_item("blob")
-            .whitelist_type("ziplist_.*")
-            .whitelist_type("zipentry_p")
-            .whitelist_function("ziplist_.*")
-            .whitelist_function("zipentry_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("ds_ziplist.rs"))
-            .expect("Couldn't write bindings");
+        gen_ds_ziplist();
     }
 
     // Storages
     if cfg!(feature = "cuckoo") {
-        print_directives("cuckoo", "storage/cuckoo");
-
-        let bindings = builder()
-            .header("../../storage/cuckoo/cuckoo.h")
-            .blacklist_item("delta_time_i")
-            .blacklist_item("proc_time_i")
-            .whitelist_var("CUCKOO_.*")
-            .whitelist_type("cuckoo_.*")
-            .whitelist_function("cuckoo_.*")
-            .whitelist_var("cas_enabled")
-            .whitelist_var("cas_val")
-            .whitelist_var("max_ttl")
-            .whitelist_type("val_type")
-            .whitelist_type("val_type_t")
-            .whitelist_type("val")
-            .whitelist_type("item")
-            .whitelist_var("KEY_MAXLEN")
-            .whitelist_var("CAS_VAL_MIN")
-            .whitelist_var("CAS_LEN")
-            .whitelist_var("MIN_ITEM_CHUNK_SIZE")
-            .whitelist_var("ITEM_HDR_SIZE")
-            .whitelist_var("ITEM_CAS_POS")
-            .whitelist_var("ITEM_KEY_POS")
-            .whitelist_var("ITEM_VAL_POS")
-            .whitelist_var("ITEM_OVERHEAD")
-            .whitelist_function("item_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("cuckoo.rs"))
-            .expect("Couldn't write bindings");
+        gen_cuckoo();
     }
     if cfg!(feature = "slab") {
-        print_directives("slab", "storage/slab");
-
-        let bindings = builder()
-            .header("../../storage/slab/slab.h")
-            .blacklist_type("proc_time_i")
-            .whitelist_var("SLAB_.*")
-            .whitelist_var("ITEM_.*")
-            .whitelist_var("EVICT_.*")
-            .whitelist_type("slab_.*")
-            .whitelist_type("slab")
-            .whitelist_type("slab_tqh")
-            .whitelist_var("hash_table")
-            .whitelist_var("slab_size")
-            .whitelist_var("slab_metrics")
-            .whitelist_function("slab_.*")
-            .whitelist_type("item")
-            .whitelist_type("item_.*")
-            .whitelist_var("use_cas")
-            .whitelist_var("cas_id")
-            .whitelist_var("slab_profile")
-            .whitelist_function("item_.*")
-            .whitelist_type("hash_table")
-            .whitelist_function("hashtable_.*")
-            .whitelist_type("slabclass")
-            .whitelist_var("SLABCLASS_.*")
-            .whitelist_var("slabclass")
-            .whitelist_var("perslab")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("slab.rs"))
-            .expect("Couldn't write bindings");
+        gen_slab();
     }
     if cfg!(feature = "cdb") {
-        let bindings = builder()
-            .header("../../storage/cdb/cdb_rs.h")
-            .whitelist_type("cdb_.*")
-            .whitelist_function("cdb_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("cdb.rs"))
-            .expect("Couldn't write bindings");
+        gen_cdb();
     }
 
     // Protocols
     if cfg!(feature = "protocol_resp") {
-        print_directives("protocol_resp", "protocol/data/resp");
-
-        let bindings = builder()
-            .header("../../protocol/data/resp_include.h")
-            .whitelist_type("bitmap_elem(_e)?")
-            .whitelist_type("list_elem(_e)?")
-            .whitelist_type("sarray_elem(_e)?")
-            .whitelist_type("compose_.*")
-            .whitelist_function("compose_.*")
-            .whitelist_type("parse_.*")
-            .whitelist_function("parse_.*")
-            .whitelist_function("process_request")
-            .whitelist_type("response_.*")
-            .whitelist_var("RSP_.*")
-            .whitelist_type("response")
-            .whitelist_type("response_.*")
-            .whitelist_type("element")
-            .whitelist_type("element_type(_e)?")
-            .whitelist_function("token_.*")
-            .whitelist_type("request")
-            .whitelist_type("request_.*")
-            .whitelist_var("REQ_.*")
-            .whitelist_var("KEY_MAXLEN")
-            .whitelist_type("command")
-            .whitelist_var("command_table")
-            .whitelist_type("cmd_type(_e)?")
-            .whitelist_function("request_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = env::var("OUT_DIR").map(PathBuf::from).unwrap();
-        bindings
-            .write_to_file(out_path.join("protocol_resp.rs"))
-            .expect("Couldn't write bindings");
+        gen_protocol_resp();
     }
     if cfg!(feature = "protocol_resp_tw") {
-        print_directives("protocol_resp_tw", "protocol/data/resp_tw");
-
-        let bindings = builder()
-            .header("../../protocol/data/resp_tw_include.h")
-            .whitelist_type("parse_rstatus(_e)?")
-            .whitelist_type("compose_rstatus(_e)?")
-            .whitelist_type("element_type(_e)?")
-            .whitelist_type("element")
-            .whitelist_function("token_.*")
-            .whitelist_function("parse_.*")
-            .whitelist_function("compose_.*")
-            .whitelist_type("response_(options|metrics)_st")
-            .whitelist_var("RSP_.*")
-            .whitelist_type("attribuet_entry")
-            .whitelist_type("response")
-            .whitelist_function("response_.*")
-            .whitelist_type("request_(options|metrics)_st")
-            .whitelist_type("cmd_type(_e)?")
-            .whitelist_type("command")
-            .whitelist_var("command_table")
-            .whitelist_type("request")
-            .whitelist_function("request_.*")
-            .whitelist_type("parse_(req|rsp)_metrics_st")
-            .whitelist_type("compose_(req|rsp)_metrics_st")
-            .whitelist_var("OPT_UNLIMITED")
-            .whitelist_type("sarray_elem(_e)?")
-            .whitelist_type("list_elem(_e)?")
-            .whitelist_type("bitmap_elem(_e)?")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("protocol_resp_tw.rs"))
-            .expect("Couldn't write bindings");
+        gen_protocol_resp_tw();
     }
     if cfg!(feature = "protocol_ping") {
-        print_directives("protocol_ping", "protocol/data/ping");
-
-        let bindings = builder()
-            .header("../../protocol/data/ping_include.h")
-            .whitelist_var("RESPONSE")
-            .whitelist_var("RSP_LEN")
-            .whitelist_var("REQUEST")
-            .whitelist_var("REQ_LEN")
-            .whitelist_type("compose_.*")
-            .whitelist_function("compose_.*")
-            .whitelist_type("parse_.*")
-            .whitelist_function("parse_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("protocol_ping.rs"))
-            .expect("Couldn't write bindings");
+        gen_protocol_ping();
     }
     if cfg!(feature = "protocol_memcache") {
-        print_directives("protocol_memcache", "protocol/data/memcache");
-
-        let bindings = builder()
-            .header("../../protocol/data/memcache_include.h")
-            .whitelist_type("response_.*")
-            .whitelist_var("rsp_strings")
-            .whitelist_type("response")
-            .whitelist_function("response_.*")
-            .whitelist_type("request_.*")
-            .whitelist_type("request")
-            .whitelist_function("request_.*")
-            .whitelist_type("process_request")
-            .whitelist_type("parse_.*")
-            .whitelist_function("parse_.*")
-            .whitelist_var("KLOG_.*")
-            .whitelist_type("klog_.*")
-            .whitelist_var("klog_enabled")
-            .whitelist_function("klog_.*")
-            .whitelist_function("_klog_write")
-            .whitelist_var("MAX_.*")
-            .whitelist_var("DATAFLAG_SIZE")
-            .whitelist_type("compose_.*")
-            .whitelist_function("compose_.*")
-            .whitelist_function("REQ_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("protocol_memcache.rs"))
-            .expect("Couldn't write bindings");
+        gen_protocol_memcache();
     }
     if cfg!(feature = "protocol_admin") {
-        print_directives("protocol_admin", "protocol/admin");
-
-        let bindings = builder()
-            .header("../../protocol/admin/admin_include.h")
-            .whitelist_type("response")
-            .whitelist_type("response_.*")
-            .whitelist_function("admin_.*")
-            .whitelist_type("request_.*")
-            .whitelist_type("request")
-            .whitelist_type("parse_.*")
-            .whitelist_var("METRIC_.*")
-            .whitelist_var("VERSION_PRINTED")
-            .whitelist_function("print_stats")
-            .whitelist_function("compose_.*")
-            .whitelist_var("COMPOSE_.*")
-            .whitelist_type("compose_.*")
-            .generate()
-            .expect("Unable to generate bindings");
-
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        bindings
-            .write_to_file(out_path.join("protocol_admin.rs"))
-            .expect("Couldn't write bindings");
+        gen_protocol_admin();
     }
 
     // Note: need to specify linker flags for this after linking all the

--- a/src/rust-util/pelikan/src/core/admin.rs
+++ b/src/rust-util/pelikan/src/core/admin.rs
@@ -97,6 +97,7 @@ unsafe fn call_process_request<H: AdminHandler>(data: *mut (), rsp: *mut (), req
 }
 
 #[no_mangle]
+#[allow(improper_ctypes)]
 unsafe extern "C" fn admin_process_request(req: *mut (), rsp: *mut ()) {
     let admin = match ADMIN {
         Some(ref admin) => admin,


### PR DESCRIPTION
This reduces unnecessary rebuilds by not specifying RUSTFLAGS when not needed.

It also adds an override flag `CARGO_FORCE_CMAKE_LINK` to force all crates to use cmake-supplied linker flags in case that's necessary in some configurations. Note that if a crate actually needs this it should pass `USE_CMAKE_LINK` to `cargo_build` within the configuration file.

The CI build is still slow (and it appears that some crates are still rebuilt redundantly) but this seems to shorten it by about 10 mins.

This PR contains changes to ccommon, those will be backported in a separate PR.
