### PR TITLE
Add httpencode library to pelikan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,11 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +101,17 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +136,14 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -247,6 +271,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
@@ -423,6 +545,30 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "httpencode"
+version = "0.1.0"
+dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +583,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -486,6 +645,9 @@ dependencies = [
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memmap"
@@ -568,6 +730,15 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -787,6 +958,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +1018,14 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -877,6 +1095,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1129,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "shlex"
@@ -1005,6 +1256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1315,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1129,6 +1399,7 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
@@ -1137,16 +1408,27 @@ dependencies = [
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bytes 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c85319f157e4e26c703678e68e26ab71a46c0199286fa670b21cc9fec13d895"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
+"checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
+"checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+"checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+"checksum crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+"checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+"checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
+"checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
@@ -1167,8 +1449,12 @@ dependencies = [
 "checksum gag 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8cc0b9f53275dc5fada808f1d2f82e3688a6c14d735633d1590b7be8eb2307b5"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum httpdate 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
@@ -1184,6 +1470,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
+"checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 "checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
@@ -1205,9 +1492,14 @@ dependencies = [
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+"checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
+"checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
+"checksum rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd"
+"checksum rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
@@ -1215,10 +1507,14 @@ dependencies = [
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
+"checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
+"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
@@ -1232,6 +1528,7 @@ dependencies = [
 "checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
 "checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6444180bb8d0144cbdd9c67875b968635fb2ed2e93b0a43f3f560dc20491583d"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
@@ -1239,6 +1536,7 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "src/server/pingserver-rs",
     "src/storage/cdb/cdbgen",
     "src/storage/cdb/cdb_rs",
+    "src/rust-util/httpencode",
     "src/rust-util/pelikan",
     "src/rust-util/pelikan-sys",
     "src/rustcore",

--- a/src/rust-util/CMakeLists.txt
+++ b/src/rust-util/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(pelikan-sys)
 add_subdirectory(pelikan)
+add_subdirectory(httpencode)

--- a/src/rust-util/httpencode/CMakeLists.txt
+++ b/src/rust-util/httpencode/CMakeLists.txt
@@ -1,0 +1,1 @@
+cargo_build(NAME httpencode)

--- a/src/rust-util/httpencode/Cargo.toml
+++ b/src/rust-util/httpencode/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "httpencode"
+version = "0.1.0"
+authors = ["Sean Lynch <slynch@twitter.com>"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+
+[features]
+std = [ "bytes/std", "arrayvec/std", "httpdate" ]
+default = [ "std" ]
+
+[dependencies]
+bytes = { version="0.5.1", default-features = false }
+memchr = "2.2.1"
+
+[dependencies.arrayvec]
+version="0.5.1"
+default-features=false
+features = [ "array-sizes-33-128" ]
+
+[dependencies.httpdate]
+version = "0.3.2"
+optional = true
+
+[dev-dependencies]
+criterion = "0.3.0"
+
+[[bench]]
+name = "compose"
+harness = false

--- a/src/rust-util/httpencode/benches/compose.rs
+++ b/src/rust-util/httpencode/benches/compose.rs
@@ -1,0 +1,109 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use httpencode::{HttpBuilder, Method, Uri, Version};
+
+fn build_req_long(b: &mut Bencher) {
+    let mut buf = Vec::new();
+    buf.reserve(1 << 14);
+
+    b.iter(|| -> Result<_, _> {
+        buf.clear();
+
+        let mut req = HttpBuilder::request(
+            &mut buf,
+            Method::Get,
+            Version::Http11,
+            Uri::new(b"/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg")
+        )?;
+
+        req.header("Host", "www.kittyhell.com")?;
+        req.header("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9")?;
+        req.header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")?;
+        req.header("Accept-Language", "ja,en-us;q=0.7,en;q=0.3")?;
+        req.header("Accept-Encoding", "gzip,deflate")?;
+        req.header("Accept-Charset", "Shift_JIS,utf-8;q=0.7,*;q=0.7")?;
+        req.header("Keep-Alive", "115")?;
+        req.header("Connection", "keep-alive")?;
+        req.header("Cookie", "wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256")?;
+
+        req.finish().map(|_| ())
+    });
+}
+
+fn build_req_long_unsafe(b: &mut Bencher) {
+    let mut buf = Vec::new();
+    buf.reserve(1 << 14);
+
+    b.iter(|| -> Result<_, _> {
+        unsafe {
+            buf.clear();
+
+            let mut req = HttpBuilder::request(
+                &mut buf,
+                Method::Get,
+                Version::Http11,
+                Uri::escaped_unchecked(b"/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg")
+            )?;
+
+            req.header_unchecked("Host", "www.kittyhell.com")?;
+            req.header_unchecked("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9")?;
+            req.header_unchecked("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")?;
+            req.header_unchecked("Accept-Language", "ja,en-us;q=0.7,en;q=0.3")?;
+            req.header_unchecked("Accept-Encoding", "gzip,deflate")?;
+            req.header_unchecked("Accept-Charset", "Shift_JIS,utf-8;q=0.7,*;q=0.7")?;
+            req.header_unchecked("Keep-Alive", "115")?;
+            req.header_unchecked("Connection", "keep-alive")?;
+            req.header_unchecked("Cookie", "wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256")?;
+
+            req.finish().map(|_| ())
+        }
+    });
+}
+
+fn build_req_short(b: &mut Bencher) {
+    let mut buf = Vec::new();
+    buf.reserve(1 << 14);
+
+    b.iter(|| -> Result<_, _> {
+        buf.clear();
+
+        let mut req = HttpBuilder::request(&mut buf, Method::Get, Version::Http11, Uri::new(b"/"))?;
+
+        req.header("Host", "example.com")?;
+        req.header("Cookie", "session=60; user_id=1")?;
+
+        req.finish().map(|_| ())
+    });
+}
+
+fn build_req_short_unsafe(b: &mut Bencher) {
+    let mut buf = Vec::new();
+    buf.reserve(1 << 14);
+
+    b.iter(|| -> Result<_, _> {
+        unsafe {
+            buf.clear();
+
+            let mut req = HttpBuilder::request(
+                &mut buf,
+                Method::Get,
+                Version::Http11,
+                Uri::escaped_unchecked(b"/"),
+            )?;
+
+            req.header_unchecked("Host", "example.com")?;
+            req.header_unchecked("Cookie", "session=60; user_id=1")?;
+
+            req.finish().map(|_| ())
+        }
+    });
+}
+
+pub fn benches(c: &mut Criterion) {
+    c.bench_function("build_req_long", build_req_long);
+    c.bench_function("build_req_long_unsafe", build_req_long_unsafe);
+    c.bench_function("build_req_short", build_req_short);
+    c.bench_function("build_req_short_unsafe", build_req_short_unsafe);
+}
+
+criterion_group!(group, benches);
+criterion_main!(group);

--- a/src/rust-util/httpencode/src/error.rs
+++ b/src/rust-util/httpencode/src/error.rs
@@ -1,0 +1,48 @@
+use core::fmt::{self, Display, Formatter};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Empty {}
+
+/// Error types.
+///
+/// # Note
+/// This enum is non-exhaustive, adding new variants is not
+/// considered a breaking change.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Error {
+    /// Ran out of buffer space
+    OutOfBuffer,
+    /// A custom method contained invalid characters
+    InvalidMethod,
+    /// The URI contained invalid characters
+    InvalidUri,
+    /// A custom version contains invalid characters
+    InvalidVersion,
+    /// A header key contained invalid characters
+    InvalidHeaderKey,
+    /// A header value contained invalid characters
+    InvalidHeaderValue,
+
+    #[doc(hidden)]
+    __Nonexhaustive(Empty),
+}
+
+impl Display for Error {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        use self::Error::*;
+
+        fmt.write_str(match self {
+            OutOfBuffer => "Out of buffer space",
+            InvalidMethod => "Invalid HTTP method",
+            InvalidUri => "Invalid HTTP Uri",
+            InvalidVersion => "Invalid HTTP Version",
+            InvalidHeaderKey => "Invalid header key",
+            InvalidHeaderValue => "Invalid header value",
+
+            &__Nonexhaustive(empty) => match empty {},
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/src/rust-util/httpencode/src/error.rs
+++ b/src/rust-util/httpencode/src/error.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use core::fmt::{self, Display, Formatter};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]

--- a/src/rust-util/httpencode/src/http.rs
+++ b/src/rust-util/httpencode/src/http.rs
@@ -1,0 +1,154 @@
+use bytes::{Buf, BufMut};
+
+use crate::util::{
+    lookup_status_line, validate_header_name, write_request_line, write_status_line,
+};
+use crate::{Error, HeaderValue, Method, Result, Status, Uri, Version};
+
+/// Builder for HTTP requests.
+#[derive(Debug)]
+pub struct HttpBuilder<B: BufMut> {
+    buf: B,
+}
+
+impl<B: BufMut> HttpBuilder<B> {
+    /// Create a new request with the provided header line.
+    ///
+    /// # Note
+    /// If this method fails it may be partially-written into the buffer.
+    /// It is necessary to reset the buffer back externally if that happens.
+    #[inline]
+    pub fn request(mut buf: B, method: Method, version: Version, uri: Uri) -> Result<Self> {
+        write_request_line(&mut buf, method, uri, version)?;
+
+        Ok(Self { buf })
+    }
+
+    /// Create a new response from the provided status line.
+    #[inline]
+    pub fn response(buf: B, version: Version, status: Status) -> Result<Self> {
+        Self::response_with_reason(
+            buf,
+            version,
+            status,
+            lookup_status_line(status).unwrap_or(" "),
+        )
+    }
+
+    /// Create a new response from the provided status line.
+    #[inline]
+    pub fn response_with_reason(
+        mut buf: B,
+        version: Version,
+        status: Status,
+        reason: &str,
+    ) -> Result<Self> {
+        write_status_line(&mut buf, version, status, reason)?;
+
+        Ok(Self { buf })
+    }
+
+    /// Add a new header to the request. This method does not check
+    /// whether the given header has already been specified and whether
+    /// it is valid to do so.
+    ///
+    /// # Note
+    /// This method is atomic - if it fails then nothing will be written
+    /// to the buffer.
+    #[inline]
+    pub fn header(&mut self, key: impl AsRef<[u8]>, val: impl HeaderValue) -> Result<&mut Self> {
+        let key = key.as_ref();
+
+        if !validate_header_name(key) {
+            return Err(Error::InvalidHeaderKey);
+        }
+        if !val.validate() {
+            return Err(Error::InvalidHeaderValue);
+        }
+
+        unsafe { self.header_unchecked(key, val) }
+    }
+
+    /// Add a new header to the request without checking to ensure that it's
+    /// valid.
+    ///
+    /// # Note
+    /// This method is atomic - if it fails then nothing will be written
+    /// to the buffer.
+    #[inline]
+    pub unsafe fn header_unchecked(
+        &mut self,
+        key: impl AsRef<[u8]>,
+        val: impl HeaderValue,
+    ) -> Result<&mut Self> {
+        let key = key.as_ref();
+
+        if key.is_empty() {
+            return Err(Error::InvalidHeaderKey);
+        }
+
+        let est_required = key.len() + val.est_len().unwrap_or(0) + b": \r\n".len();
+        if self.buf.remaining_mut() < est_required {
+            return Err(Error::OutOfBuffer);
+        }
+
+        self.buf.put_slice(key);
+        self.buf.put_slice(b": ");
+        val.put(&mut self.buf)?;
+        self.buf.put_slice(b"\r\n");
+
+        Ok(self)
+    }
+
+    /// Complete the HTTP header and return the underlying buffer.
+    #[inline]
+    pub fn finish(mut self) -> Result<B> {
+        if self.buf.remaining_mut() < b"\r\n".len() {
+            return Err(Error::OutOfBuffer);
+        }
+
+        self.buf.put_slice(b"\r\n");
+
+        Ok(self.buf)
+    }
+
+    /// Complete the HTTP header and return the underlying buffer.
+    pub fn body<I: Buf>(mut self, buf: &mut I) -> Result<B> {
+        let len = buf.remaining();
+
+        if self.buf.remaining_mut() < len + b"\r\n".len() {
+            return Err(Error::OutOfBuffer);
+        }
+
+        self.buf.put_slice(b"\r\n");
+
+        while buf.has_remaining() {
+            let bytes = buf.bytes();
+            self.buf.put_slice(bytes);
+
+            let len = bytes.len();
+            buf.advance(len);
+        }
+
+        Ok(self.buf)
+    }
+
+    /// Get the underlying buffer for this request object.
+    pub fn into_buf(self) -> B {
+        self.buf
+    }
+
+    /// Create a request from the underlying buffer.
+    ///
+    /// # Safety
+    /// This function is unsafe since you can use it to create a syntactically
+    /// invalid request.
+    pub unsafe fn from_buf(buf: B) -> Self {
+        Self { buf }
+    }
+
+    /// Get the number of remaining bytes within the underlying buffer.
+    pub fn remaining(&self) -> usize {
+        self.buf.remaining_mut()
+    }
+}

--- a/src/rust-util/httpencode/src/http.rs
+++ b/src/rust-util/httpencode/src/http.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::{Buf, BufMut};
 
 use crate::util::{

--- a/src/rust-util/httpencode/src/lib.rs
+++ b/src/rust-util/httpencode/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Zero-allocation HTTP encoding.
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]

--- a/src/rust-util/httpencode/src/lib.rs
+++ b/src/rust-util/httpencode/src/lib.rs
@@ -1,0 +1,187 @@
+//! Zero-allocation HTTP encoding.
+
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+
+mod error;
+mod http;
+mod traits;
+mod util;
+
+pub mod request;
+pub mod response;
+
+pub use self::error::Error;
+pub use self::http::HttpBuilder;
+pub use self::traits::{HeaderValue, OutOfBufferError};
+
+#[cfg(feature = "httpdate")]
+pub use httpdate::HttpDate;
+
+#[cfg(test)]
+mod tests;
+
+/// HTTP method.
+#[derive(Copy, Clone, Debug)]
+pub enum Method<'a> {
+    Options,
+    Get,
+    Head,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Trace,
+    Connect,
+    Custom(&'a str),
+}
+
+/// HTTP version.
+#[derive(Copy, Clone, Debug)]
+pub enum Version<'a> {
+    Http10,
+    Http11,
+    Custom(&'a str),
+}
+
+#[derive(Copy, Clone)]
+enum UriData<'a> {
+    Escaped(&'a [u8]),
+    Unescaped(&'a [u8]),
+}
+
+/// HTTP resource identifier.
+#[derive(Copy, Clone)]
+pub struct Uri<'a> {
+    data: UriData<'a>,
+}
+
+/// HTTP Status code.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Status {
+    code: u16,
+}
+
+type Result<T> = core::result::Result<T, Error>;
+
+impl Status {
+    /// Create a new status from the provided status code.
+    ///
+    /// # Panics
+    /// Panics if the code is greater than `1000`.
+    pub fn new(code: u16) -> Self {
+        assert!(code < 1000);
+
+        Self { code }
+    }
+
+    /// Get the status line associated with this status code.
+    pub fn status_line(&self) -> Option<&'static str> {
+        crate::util::lookup_status_line(*self)
+    }
+}
+
+impl<'a> Uri<'a> {
+    pub fn new(uri: &'a [u8]) -> Self {
+        Self {
+            data: UriData::Unescaped(uri.as_ref()),
+        }
+    }
+
+    pub unsafe fn escaped_unchecked(uri: &'a [u8]) -> Self {
+        Self {
+            data: UriData::Escaped(uri),
+        }
+    }
+
+    pub fn as_bytes(&self) -> &'a [u8] {
+        match self.data {
+            UriData::Escaped(s) => s,
+            UriData::Unescaped(s) => s,
+        }
+    }
+}
+
+macro_rules! statuses {
+    {
+        $( $status:expr => $name:ident; )*
+    } => {
+        impl Status {
+            $(
+                pub const $name: Status = Status { code: $status };
+            )*
+        }
+    }
+}
+
+statuses! {
+    100 => CONTINUE;
+    101 => SWITCHING_PROTOCOLS;
+    102 => PROCESSING;
+    103 => EARLY_HINTS;
+
+    200 => OK;
+    201 => CREATED;
+    202 => ACCEPTED;
+    203 => NON_AUTHORATATIVE_INFORMATION;
+    204 => NO_CONTENT;
+    205 => RESET_CONTENT;
+    206 => PARTIAL_CONTENT;
+    207 => MULTI_STATUS;
+    208 => ALREADY_REPORTED;
+    226 => IM_USED;
+
+    300 => MULTIPLE_CHOICES;
+    301 => MOVED_PERMANENTLY;
+    302 => FOUND;
+    303 => SEE_OTHER;
+    304 => NOT_MODIFIED;
+    305 => USE_PROXY;
+    // 306 is obsolete
+    307 => TEMPORARY_REDIRECT;
+    308 => PERMANENT_REDIRECT;
+
+    400 => BAD_REQUEST;
+    401 => UNAUTHORIZED;
+    402 => PAYMENT_REQUIRED;
+    403 => FORBIDDEN;
+    404 => NOT_FOUND;
+    405 => METHOD_NOT_ALLOWED;
+    406 => NOT_ACCEPTABLE;
+    407 => PROXY_AUTHENTICATION_TIMEOUT;
+    408 => REQUEST_TIMEOUT;
+    409 => CONFLICT;
+    410 => GONE;
+    411 => LENGTH_REQUIRED;
+    412 => PRECONDITION_FAILED;
+    413 => REQUEST_ENTITY_TOO_LARGE;
+    414 => REQUEST_URI_TOO_LARGE;
+    415 => UNSUPPORTED_MEDIA_TYPE;
+    416 => REQUESTED_RANGE_NOT_SATISFIABLE;
+    417 => EXPECTATION_FAILED;
+    418 => IM_A_TEAPOT;
+    421 => MISDIRECTED_REQUEST;
+    422 => UNPROCESSABLE_ENTITY;
+    423 => LOCKED;
+    424 => FAILED_DEPENDENCY;
+    425 => TOO_EARLY;
+    426 => UPGRADE_REQUIRED;
+    428 => PRECONDITION_REQUIRED;
+    429 => TOO_MANY_REQUESTS;
+    451 => UNAVAILABLE_FOR_LEGAL_REASONS;
+
+    500 => INTERNAL_SERVER_ERROR;
+    501 => NOT_IMPLEMENTED;
+    502 => BAD_GATEWAY;
+    503 => SERVICE_UNAVAILABLE;
+    504 => GATEWAY_TIME_OUT;
+    505 => HTTP_VERSION_NOT_SUPPORTED;
+    506 => VARIANT_ALSO_NEGOTIATES;
+    507 => INSUFFICIENT_STORAGE;
+    508 => LOOP_DETECTED;
+}
+
+impl From<OutOfBufferError> for Error {
+    fn from(_: OutOfBufferError) -> Self {
+        Self::OutOfBuffer
+    }
+}

--- a/src/rust-util/httpencode/src/request.rs
+++ b/src/rust-util/httpencode/src/request.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{HttpBuilder, Method, Result, Uri, Version};
 use bytes::BufMut;
 

--- a/src/rust-util/httpencode/src/request.rs
+++ b/src/rust-util/httpencode/src/request.rs
@@ -1,0 +1,34 @@
+use crate::{HttpBuilder, Method, Result, Uri, Version};
+use bytes::BufMut;
+
+pub fn get<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Get, Version::Http11, path)
+}
+
+pub fn post<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Post, Version::Http11, path)
+}
+
+pub fn put<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Put, Version::Http11, path)
+}
+
+pub fn head<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Head, Version::Http11, path)
+}
+
+pub fn options<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Options, Version::Http11, path)
+}
+
+pub fn patch<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Patch, Version::Http11, path)
+}
+
+pub fn delete<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Delete, Version::Http11, path)
+}
+
+pub fn trace<B: BufMut>(buf: B, path: Uri) -> Result<HttpBuilder<B>> {
+    HttpBuilder::request(buf, Method::Trace, Version::Http11, path)
+}

--- a/src/rust-util/httpencode/src/response.rs
+++ b/src/rust-util/httpencode/src/response.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{HttpBuilder, Result, Status, Version};
 use bytes::BufMut;
 

--- a/src/rust-util/httpencode/src/response.rs
+++ b/src/rust-util/httpencode/src/response.rs
@@ -1,0 +1,85 @@
+use crate::{HttpBuilder, Result, Status, Version};
+use bytes::BufMut;
+
+macro_rules! status_builder {
+    {
+        $( $status:expr => $fn:ident; )*
+    } => {
+        $(
+            pub fn $fn<B: BufMut>(buf: B) -> Result<HttpBuilder<B>> {
+                HttpBuilder::response(
+                    buf,
+                    Version::Http11,
+                    Status { code: $status }
+                )
+            }
+        )*
+    }
+}
+
+status_builder! {
+    100 => r#continue;
+    101 => switching_protocols;
+    102 => processing;
+    103 => early_hints;
+
+    200 => ok;
+    201 => created;
+    202 => accepted;
+    203 => non_authoritative_information;
+    204 => no_content;
+    205 => reset_content;
+    206 => partial_content;
+    207 => multi_status;
+    208 => already_reported;
+    226 => im_used;
+
+    300 => multiple_choices;
+    301 => moved_permanently;
+    302 => found;
+    303 => see_other;
+    304 => not_modified;
+    305 => use_proxy;
+    // 306 is obsolete
+    307 => temporary_redirect;
+    308 => permanent_redirect;
+
+    400 => bad_request;
+    401 => unauthorized;
+    402 => payment_required;
+    403 => forbidden;
+    404 => not_found;
+    405 => method_not_allowed;
+    406 => not_acceptable;
+    407 => proxy_authentication_timeout;
+    408 => request_timeout;
+    409 => conflict;
+    410 => gone;
+    411 => length_required;
+    412 => precondition_failed;
+    413 => request_entity_too_large;
+    414 => request_uri_too_large;
+    415 => unsupported_media_type;
+    416 => request_range_not_satisfiable;
+    417 => expectation_failed;
+    418 => im_a_teapot;
+    421 => misdirected_request;
+    422 => unprocessable_entity;
+    423 => locked;
+    424 => failed_dependency;
+    425 => too_early;
+    426 => upgrade_required;
+    428 => precondition_required;
+    429 => too_many_requests;
+    451 => unavailable_for_legal_reasons;
+
+    500 => internal_server_error;
+    501 => not_implemented;
+    502 => bad_gateway;
+    503 => service_unavailable;
+    504 => gateway_time_out;
+    505 => http_version_not_supported;
+    506 => variant_also_negotiates;
+    507 => insufficient_storage;
+    508 => loop_detected;
+}

--- a/src/rust-util/httpencode/src/tests.rs
+++ b/src/rust-util/httpencode/src/tests.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::util::*;
 use crate::*;
 

--- a/src/rust-util/httpencode/src/tests.rs
+++ b/src/rust-util/httpencode/src/tests.rs
@@ -1,0 +1,264 @@
+use crate::util::*;
+use crate::*;
+
+use std::borrow::Cow;
+
+fn escaped(bytes: &[u8]) -> Cow<str> {
+    if bytes.iter().copied().all(|c| c.is_ascii()) {
+        Cow::Borrowed(std::str::from_utf8(bytes).unwrap())
+    } else {
+        let string = bytes
+            .iter()
+            .copied()
+            .flat_map(std::ascii::escape_default)
+            .map(|c| c as char)
+            .collect();
+
+        Cow::Owned(string)
+    }
+}
+
+#[test]
+fn test_write_uri() {
+    let mut out = vec![];
+    let uri = Uri::new(b"/test uri");
+    write_uri(&mut out, uri).unwrap();
+    assert_eq!(escaped(&out), escaped(b"/test%20uri"));
+
+    out.clear();
+    let uri = unsafe { Uri::escaped_unchecked(b"/test uri") };
+    write_uri(&mut out, uri).unwrap();
+    assert_eq!(escaped(&out), escaped(b"/test uri"));
+
+    out.clear();
+    let uri = Uri::new(b"");
+    assert_eq!(write_uri(&mut out, uri), Err(Error::InvalidUri));
+
+    let mut out = [0u8; 5];
+    let uri = Uri::new(b"/6char");
+    assert_eq!(write_uri(&mut &mut out[..], uri), Err(Error::OutOfBuffer));
+}
+
+#[test]
+fn test_write_version() {
+    let mut out = vec![];
+    write_version(&mut out, Version::Http10).unwrap();
+    assert_eq!(escaped(&out), escaped(b"HTTP/1.0"));
+
+    let mut out = vec![];
+    write_version(&mut out, Version::Http11).unwrap();
+    assert_eq!(escaped(&out), escaped(b"HTTP/1.1"));
+
+    let mut out = vec![];
+    write_version(&mut out, Version::Custom("MY-PROTOCOL/1.0")).unwrap();
+    assert_eq!(escaped(&out), escaped(b"MY-PROTOCOL/1.0"));
+
+    let mut out = vec![];
+    assert_eq!(
+        write_version(&mut out, Version::Custom("BAD VERSION")),
+        Err(Error::InvalidVersion)
+    );
+
+    let mut bytes = [0u8; 5];
+    assert_eq!(
+        write_version(&mut &mut bytes[..], Version::Custom("6CHARS")),
+        Err(Error::OutOfBuffer)
+    );
+}
+
+#[test]
+fn test_write_method() {
+    let mut out = vec![];
+    write_method(&mut out, Method::Get).unwrap();
+    assert_eq!(escaped(&out), escaped(b"GET"));
+
+    out.clear();
+    write_method(&mut out, Method::Post).unwrap();
+    assert_eq!(escaped(&out), escaped(b"POST"));
+
+    out.clear();
+    write_method(&mut out, Method::Delete).unwrap();
+    assert_eq!(escaped(&out), escaped(b"DELETE"));
+
+    out.clear();
+    assert_eq!(
+        write_method(&mut out, Method::Custom("CUSTOM METHOD")),
+        Err(Error::InvalidMethod)
+    );
+
+    out.clear();
+    let test_case = "LOOOOOOOOOOOOOOOOOOONG";
+    write_method(&mut out, Method::Custom(test_case)).unwrap();
+    assert_eq!(escaped(&out), test_case);
+
+    let mut out = [0; 5];
+    assert_eq!(
+        write_method(&mut &mut out[..], Method::Delete),
+        Err(Error::OutOfBuffer)
+    );
+}
+
+#[test]
+fn test_write_status() {
+    let mut out = Vec::new();
+    write_status(&mut out, Status::OK).unwrap();
+    assert_eq!(escaped(&out), "200");
+
+    out.clear();
+    write_status(&mut out, Status::IM_A_TEAPOT).unwrap();
+    assert_eq!(escaped(&out), "418");
+}
+
+#[test]
+fn test_write_request_line() {
+    let mut out = Vec::new();
+
+    let method = Method::Post;
+    let version = Version::Http11;
+    let uri = Uri::new(b"/foo/bar/test/uri");
+
+    write_request_line(&mut out, method, uri, version).unwrap();
+    assert_eq!(escaped(&out), "POST /foo/bar/test/uri HTTP/1.1\r\n");
+}
+
+#[test]
+fn test_write_status_line() {
+    let mut out = Vec::new();
+
+    let version = Version::Http11;
+    let status = Status::INTERNAL_SERVER_ERROR;
+
+    write_status_line(&mut out, version, status, "Internal Server Error").unwrap();
+
+    assert_eq!(escaped(&out), "HTTP/1.1 500 Internal Server Error\r\n");
+}
+
+#[test]
+fn test_headers() {
+    let mut out = Vec::new();
+
+    let mut rsp = HttpBuilder::response(&mut out, Version::Http11, Status::OK).unwrap();
+
+    rsp.header("Test", "Blargh").unwrap();
+    rsp.header("Server", "Test-Server-Foo").unwrap();
+    rsp.header("X", "").unwrap();
+
+    assert_eq!(
+        rsp.header("Invalid With Spaces", "Foo").unwrap_err(),
+        Error::InvalidHeaderKey
+    );
+    assert_eq!(rsp.header("", "Test").unwrap_err(), Error::InvalidHeaderKey);
+    assert_eq!(
+        rsp.header("X", "Invalid With LWS\r\n\r\nTest").unwrap_err(),
+        Error::InvalidHeaderValue
+    );
+
+    #[rustfmt::skip]
+    let expected = "\
+        HTTP/1.1 200 OK\r\n\
+        Test: Blargh\r\n\
+        Server: Test-Server-Foo\r\n\
+        X: \r\n\
+        \r\n\
+    ";
+
+    rsp.finish().unwrap();
+
+    assert_eq!(escaped(&out), expected);
+}
+
+#[test]
+fn req_short() -> Result<()> {
+    #[rustfmt::skip]
+    let req_short = "\
+        GET / HTTP/1.0\r\n\
+        Host: example.com\r\n\
+        Cookie: session=60; user_id=1\r\n\r\n\
+    ";
+
+    let mut buf = Vec::new();
+    let mut req = HttpBuilder::request(&mut buf, Method::Get, Version::Http10, Uri::new(b"/"))?;
+
+    req.header("Host", "example.com")?;
+    req.header("Cookie", "session=60; user_id=1")?;
+    req.finish()?;
+
+    assert_eq!(escaped(&buf), req_short);
+
+    Ok(())
+}
+
+#[test]
+fn req_long() -> Result<()> {
+    #[rustfmt::skip]
+    let req_short = "\
+        GET /wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg HTTP/1.1\r\n\
+        Host: www.kittyhell.com\r\n\
+        User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9\r\n\
+        Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n\
+        Accept-Language: ja,en-us;q=0.7,en;q=0.3\r\n\
+        Accept-Encoding: gzip,deflate\r\n\
+        Accept-Charset: Shift_JIS,utf-8;q=0.7,*;q=0.7\r\n\
+        Keep-Alive: 115\r\n\
+        Connection: keep-alive\r\n\
+        Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256\r\n\r\n\
+    ";
+
+    let mut buf = Vec::new();
+    let mut req = HttpBuilder::request(
+        &mut buf,
+        Method::Get,
+        Version::Http11,
+        Uri::new(b"/wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg"),
+    )?;
+
+    req.header("Host", "www.kittyhell.com")?;
+    req.header("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9")?;
+    req.header(
+        "Accept",
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    )?;
+    req.header("Accept-Language", "ja,en-us;q=0.7,en;q=0.3")?;
+    req.header("Accept-Encoding", "gzip,deflate")?;
+    req.header("Accept-Charset", "Shift_JIS,utf-8;q=0.7,*;q=0.7")?;
+    req.header("Keep-Alive", "115")?;
+    req.header("Connection", "keep-alive")?;
+    req.header("Cookie", "wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256")?;
+
+    req.finish()?;
+
+    assert_eq!(escaped(&buf), req_short);
+
+    Ok(())
+}
+
+#[test]
+fn positive_numerical_header() -> Result<()> {
+    #[rustfmt::skip]
+    let header = "\
+        GET / HTTP/1.1\r\n\
+        Content-Length: 10\r\n\
+        \r\n\
+    ";
+
+    let mut buf = Vec::new();
+    let mut req = HttpBuilder::request(&mut buf, Method::Get, Version::Http11, Uri::new(b"/"))?;
+
+    req.header("Content-Length", 10u128)?;
+    req.finish()?;
+
+    assert_eq!(escaped(&buf), header);
+
+    Ok(())
+}
+
+#[test]
+fn test_body_doesnt_bail() -> Result<()> {
+    let mut buf = Vec::new();
+    let req = HttpBuilder::response(&mut buf, Version::Http11, Status::OK)?;
+
+    let mut body: &[u8] = b"TEST_STRING";
+    req.body(&mut body)?;
+
+    Ok(())
+}

--- a/src/rust-util/httpencode/src/traits.rs
+++ b/src/rust-util/httpencode/src/traits.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use arrayvec::ArrayVec;
 use bytes::BufMut;
 

--- a/src/rust-util/httpencode/src/traits.rs
+++ b/src/rust-util/httpencode/src/traits.rs
@@ -1,0 +1,236 @@
+use arrayvec::ArrayVec;
+use bytes::BufMut;
+
+use core::fmt;
+
+pub struct OutOfBufferError;
+
+pub trait HeaderValue {
+    fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError>;
+
+    fn validate(&self) -> bool {
+        true
+    }
+
+    fn est_len(&self) -> Option<usize> {
+        None
+    }
+}
+
+impl HeaderValue for &'_ [u8] {
+    fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError> {
+        if buf.remaining_mut() < self.len() {
+            return Err(OutOfBufferError);
+        }
+
+        buf.put_slice(self);
+
+        Ok(())
+    }
+
+    fn validate(&self) -> bool {
+        crate::util::validate_header_field(self)
+    }
+
+    fn est_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl HeaderValue for &'_ str {
+    fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError> {
+        self.as_bytes().put(buf)
+    }
+
+    fn validate(&self) -> bool {
+        self.as_bytes().validate()
+    }
+
+    fn est_len(&self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+const fn base10_digits<T>(signed: bool) -> usize {
+    (std::mem::size_of::<T>() * 8 + 2) / 3 + (signed as usize)
+}
+
+fn reverse_in_place<T>(mut slice: &mut [T]) {
+    while slice.len() > 1 {
+        let (first, rest) = slice.split_first_mut().unwrap();
+        let (last, rest) = rest.split_last_mut().unwrap();
+        slice = rest;
+
+        std::mem::swap(first, last);
+    }
+}
+
+macro_rules! impl_unsigned {
+    ( $( $ty:ident ),* ) => {
+        $(
+            impl HeaderValue for $ty {
+                fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError> {
+                    let mut digits = ArrayVec::<[u8; base10_digits::<$ty>(false)]>::new();
+                    let mut value = *self;
+
+                    if value == 0 {
+                        digits.push(b'0');
+                    }
+
+                    while value != 0 {
+                        digits.push((value % 10) as u8 + b'0');
+                        value /= 10;
+                    }
+
+                    if buf.remaining_mut() < digits.len() {
+                        return Err(OutOfBufferError);
+                    }
+
+                    reverse_in_place(digits.as_mut_slice());
+
+                    buf.put_slice(digits.as_slice());
+
+                    Ok(())
+                }
+            }
+        )*
+    }
+}
+
+macro_rules! impl_signed {
+    ( $( $ty:ident ),* ) => {
+        $(
+            impl HeaderValue for $ty {
+                fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError> {
+                    let mut digits = ArrayVec::<[u8; base10_digits::<$ty>(true)]>::new();
+                    let mut value = *self;
+
+                    if value == 0 {
+                        digits.push(b'0');
+                    }
+
+                    if value < 0 {
+                        digits.push(b'-');
+                        digits.push(10 - value.rem_euclid(10) as u8 + b'0');
+
+                        value = -(value / 10);
+                    }
+
+                    while value != 0 {
+                        digits.push((value % 10) as u8 + b'0');
+                        value /= 10;
+                    }
+
+                    if buf.remaining_mut() < digits.len() {
+                        return Err(OutOfBufferError);
+                    }
+
+                    let start = match digits.get(0) {
+                        Some(b'-') => 1,
+                        _ => 0,
+                    };
+                    reverse_in_place(&mut digits.as_mut_slice()[start..]);
+                    buf.put_slice(digits.as_slice());
+
+                    Ok(())
+                }
+            }
+        )*
+    }
+}
+
+impl_unsigned!(usize, u8, u16, u32, u64, u128);
+impl_signed!(isize, i8, i16, i32, i64, i128);
+
+pub(crate) struct BufferFmt<'b, B: BufMut>(pub &'b mut B);
+
+impl<'b, B: BufMut> fmt::Write for BufferFmt<'b, B> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        s.put(self.0).map_err(|_| fmt::Error)
+    }
+}
+
+#[cfg(feature = "httpdate")]
+mod httpdate {
+    use super::*;
+    use crate::HttpDate;
+
+    use std::fmt::Write;
+
+    impl HeaderValue for HttpDate {
+        fn put<B: BufMut>(&self, buf: &mut B) -> Result<(), OutOfBufferError> {
+            write!(&mut BufferFmt(buf), "{}", self).map_err(|_| OutOfBufferError)
+        }
+
+        fn est_len(&self) -> Option<usize> {
+            Some(30)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    fn escaped(bytes: &[u8]) -> Cow<str> {
+        if bytes.iter().copied().all(|c| c.is_ascii()) {
+            Cow::Borrowed(std::str::from_utf8(bytes).unwrap())
+        } else {
+            let string = bytes
+                .iter()
+                .copied()
+                .flat_map(std::ascii::escape_default)
+                .map(|c| c as char)
+                .collect();
+
+            Cow::Owned(string)
+        }
+    }
+
+    macro_rules! test_put {
+        ($value:expr) => {
+            let res = std::panic::catch_unwind(|| {
+                let value = $value;
+                let expected = format!("{}", value);
+                let mut buf = Vec::new();
+                if let Err(_) = value.put(&mut buf) {
+                    panic!("Not enough buffer in test for {}", stringify!($value));
+                }
+
+                assert_eq!(
+                    &escaped(&buf),
+                    &*expected,
+                    "test for {} failed",
+                    stringify!($value)
+                );
+            });
+
+            if let Err(e) = res {
+                eprintln!("While running test for {}", stringify!($value));
+                std::panic::resume_unwind(e);
+            }
+        };
+    }
+
+    macro_rules! standard_tests {
+        ($( $ty:ident ),*) => {
+            $(
+                test_put!(std::$ty::MAX);
+                test_put!(std::$ty::MIN);
+                test_put!(0 as $ty);
+            )*
+        }
+    }
+
+    #[test]
+    fn serialize_tests() {
+        standard_tests!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+    }
+
+    #[test]
+    fn test_base10_digits() {
+        assert!(base10_digits::<u8>(false) >= 3);
+        assert!(base10_digits::<i8>(true) >= 4);
+    }
+}

--- a/src/rust-util/httpencode/src/util.rs
+++ b/src/rust-util/httpencode/src/util.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2019 Twitter, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::BufMut;
 
 use crate::{Error, Method, Result, Status, Uri, UriData, Version};

--- a/src/rust-util/httpencode/src/util.rs
+++ b/src/rust-util/httpencode/src/util.rs
@@ -1,0 +1,518 @@
+use bytes::BufMut;
+
+use crate::{Error, Method, Result, Status, Uri, UriData, Version};
+
+pub(crate) const OPTIONS: &[u8] = b"OPTIONS";
+pub(crate) const GET: &[u8] = b"GET";
+pub(crate) const HEAD: &[u8] = b"HEAD";
+pub(crate) const POST: &[u8] = b"POST";
+pub(crate) const PATCH: &[u8] = b"PATCH";
+pub(crate) const PUT: &[u8] = b"PUT";
+pub(crate) const DELETE: &[u8] = b"DELETE";
+pub(crate) const TRACE: &[u8] = b"TRACE";
+pub(crate) const CONNECT: &[u8] = b"CONNECT";
+
+pub(crate) const HTTP_1_0: &[u8] = b"HTTP/1.0";
+pub(crate) const HTTP_1_1: &[u8] = b"HTTP/1.1";
+
+pub(crate) fn try_write<B: BufMut>(buf: &mut B, bytes: &[u8]) -> Result<()> {
+    if buf.remaining_mut() < bytes.len() {
+        return Err(Error::OutOfBuffer);
+    }
+
+    buf.put_slice(bytes);
+    Ok(())
+}
+
+// Write out a HTTP method as determined by RFC2616.
+//
+// > 5.1.1 Method
+// >
+// > The Method  token indicates the method to be performed on the
+// > resource identified by the Request-URI. The method is case-sensitive.
+// >
+// >     Method         = "OPTIONS"                ; Section 9.2
+// >                    | "GET"                    ; Section 9.3
+// >                    | "HEAD"                   ; Section 9.4
+// >                    | "POST"                   ; Section 9.5
+// >                    | "PUT"                    ; Section 9.6
+// >                    | "DELETE"                 ; Section 9.7
+// >                    | "TRACE"                  ; Section 9.8
+// >                    | "CONNECT"                ; Section 9.9
+// >                    | extension-method
+// >     extension-method = token
+// >
+// > The list of methods allowed by a resource can be specified in an
+// > Allow header field (section 14.7). The return code of the response
+// > always notifies the client whether a method is currently allowed on a
+// > resource, since the set of allowed methods can change dynamically. An
+// > origin server SHOULD return the status code 405 (Method Not Allowed)
+// > if the method is known by the origin server but not allowed for the
+// > requested resource, and 501 (Not Implemented) if the method is
+// > unrecognized or not implemented by the origin server. The methods GET
+// > and HEAD MUST be supported by all general-purpose servers. All other
+// > methods are OPTIONAL; however, if the above methods are implemented,
+// > they MUST be implemented with the same semantics as those specified
+// > in section 9.
+pub(crate) fn write_method<B: BufMut>(buf: &mut B, method: Method) -> Result<()> {
+    match method {
+        Method::Options => try_write(buf, OPTIONS),
+        Method::Get => try_write(buf, GET),
+        Method::Head => try_write(buf, HEAD),
+        Method::Post => try_write(buf, POST),
+        Method::Put => try_write(buf, PUT),
+        Method::Patch => try_write(buf, PATCH),
+        Method::Delete => try_write(buf, DELETE),
+        Method::Trace => try_write(buf, TRACE),
+        Method::Connect => try_write(buf, CONNECT),
+        Method::Custom(method) => {
+            if validate_method(method) {
+                try_write(buf, method.as_bytes())
+            } else {
+                Err(Error::InvalidMethod)
+            }
+        }
+    }
+}
+
+// Write out a request URI as determined by RFC2616.
+//
+// > 5.1.2 Request-URI
+// >
+// > The Request-URI is a Uniform Resource Identifier (section 3.2) and
+// > identifies the resource upon which to apply the request.
+// >
+// >     Request-URI    = "*" | absoluteURI | abs_path | authority
+//
+// `absoluteURI`, `abs_path`, and `authority` are defined in RC2396.
+//
+// > 3\. URI Syntactic Components
+// >
+// > The URI syntax is dependent upon the scheme.  In general, absolute
+// > URI are written as follows:
+// >
+// >     <scheme>:<scheme-specific-part>
+// >
+// > An absolute URI contains the name of the scheme being used (<scheme>)
+// > followed by a colon (":") and then a string (the <scheme-specific-
+// > part>) whose interpretation depends on the scheme.
+// >
+// > The URI syntax does not require that the scheme-specific-part have
+// > any general structure or set of semantics which is common among all
+// > URI.  However, a subset of URI do share a common syntax for
+// > representing hierarchical relationships within the namespace.  This
+// > "generic URI" syntax consists of a sequence of four main components:
+// >
+// >     <scheme>://<authority><path>?<query>
+// >
+// > each of which, except <scheme>, may be absent from a particular URI.
+// > For example, some URI schemes do not allow an <authority> component,
+// > and others do not use a <query> component.
+//
+// Where `unreserved` is defined as
+//
+// > 2.3. Unreserved Characters
+// >
+// > Data characters that are allowed in a URI but do not have a reserved
+// > purpose are called unreserved.  These include upper and lower case
+// > letters, decimal digits, and a limited set of punctuation marks and
+// > symbols.
+// >
+// >     unreserved  = alphanum | mark
+// >     mark        = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
+// >
+// > Unreserved characters can be escaped without changing the semantics
+// > of the URI, but this should not be done unless the URI is being used
+// > in a context that does not allow the unescaped character to appear.
+//
+// and `escaped` is defined as
+//
+// > 2.4.1. Escaped Encoding
+// >
+// > An escaped octet is encoded as a character triplet, consisting of the
+// > percent character "%" followed by the two hexadecimal digits
+// > representing the octet code. For example, "%20" is the escaped
+// > encoding for the US-ASCII space character.
+// >
+// >     escaped     = "%" hex hex
+// >     hex         = digit | "A" | "B" | "C" | "D" | "E" | "F" |
+// >                           "a" | "b" | "c" | "d" | "e" | "f"
+pub(crate) fn write_uri<B: BufMut>(buf: &mut B, uri: Uri) -> Result<()> {
+    pub(crate) fn is_valid(byte: u8) -> bool {
+        // Bit-packed lookup table of valid unescaped characters.
+        //
+        // This corresponds to the characters as defined by
+        // RFC2396 section 2.
+        //
+        // Note that no byte above 128 is valid in a URI.
+        const LOOKUP: u128 = 0x47FFFFFE87FFFFFF2FFFFFD200000000;
+
+        return (byte < 128) & (((LOOKUP.wrapping_shr(byte as u32)) & 1) != 0);
+    }
+
+    match uri.data {
+        UriData::Unescaped(path) => {
+            if path.is_empty() {
+                return Err(Error::InvalidUri);
+            }
+
+            write_percent_escaped(buf, path, is_valid)
+        }
+        UriData::Escaped(path) => try_write(buf, path),
+    }
+}
+
+// Write out a string and percent-escape any invalid characters within.
+fn write_percent_escaped<B, F>(buf: &mut B, path: &[u8], is_valid: F) -> Result<()>
+where
+    B: BufMut,
+    F: Fn(u8) -> bool,
+{
+    fn next_invalid<F: Fn(u8) -> bool>(bytes: &[u8], is_valid: &F) -> Option<(usize, u8)> {
+        for i in 0..bytes.len() {
+            let b = unsafe { *bytes.get_unchecked(i) };
+
+            if !is_valid(b) {
+                return Some((i, b));
+            }
+        }
+
+        None
+    }
+
+    fn hex_encode(byte: u8) -> u8 {
+        let byte = byte & 0xF;
+        match byte {
+            0x0..=0x9 => b'0' + byte,
+            0xA..=0xF => b'A' + byte - 0xA,
+            _ => unreachable!(),
+        }
+    }
+
+    fn percent_encode<B: BufMut>(buf: &mut B, byte: u8) -> Result<()> {
+        let slice = [b'%', hex_encode(byte >> 4), hex_encode(byte)];
+
+        try_write(buf, &slice)
+    }
+
+    let mut bytes = path;
+
+    while !bytes.is_empty() {
+        let advance = if let Some((idx, byte)) = next_invalid(bytes, &is_valid) {
+            try_write(buf, &bytes[..idx])?;
+            percent_encode(buf, byte)?;
+            idx + 1
+        } else {
+            try_write(buf, &bytes)?;
+            bytes.len()
+        };
+
+        bytes = &bytes[advance..];
+    }
+
+    Ok(())
+}
+
+pub(crate) fn write_version<B: BufMut>(buf: &mut B, version: Version) -> Result<()> {
+    match version {
+        Version::Http10 => try_write(buf, HTTP_1_0),
+        Version::Http11 => try_write(buf, HTTP_1_1),
+        Version::Custom(version) => {
+            if validate_version(version) {
+                try_write(buf, version.as_bytes())
+            } else {
+                Err(Error::InvalidVersion)
+            }
+        }
+    }
+}
+
+// Write out a request line as determined by RCP2616.
+//
+// > 5.1 Request-Line
+// >
+// > The Request-Line begins with a method token, followed by the
+// > Request-URI and the protocol version, and ending with CRLF. The
+// > elements are separated by SP characters. No CR or LF is allowed
+// > except in the final CRLF sequence.
+// >
+// >     Request-Line = Method SP Request-URI SP HTTP-Version CRLF
+pub(crate) fn write_request_line<B: BufMut>(
+    buf: &mut B,
+    method: Method,
+    uri: Uri,
+    version: Version,
+) -> Result<()> {
+    write_method(buf, method)?;
+    buf.put_u8(b' ');
+    write_uri(buf, uri)?;
+    buf.put_u8(b' ');
+    write_version(buf, version)?;
+    buf.put_slice(b"\r\n");
+
+    Ok(())
+}
+
+// Write out a u16 in decimal to the buffer.
+pub(crate) fn write_u16<B: BufMut>(buf: &mut B, mut num: u16) -> Result<()> {
+    let mut bytes = [0u8; 5];
+    let mut idx = 0;
+
+    while num != 0 {
+        bytes[idx] = (num % 10) as u8;
+        num /= 10;
+        idx += 1;
+    }
+
+    if idx > buf.remaining_mut() {
+        return Err(Error::OutOfBuffer);
+    }
+
+    for i in (0..idx).rev() {
+        buf.put_u8(b'0' + bytes[i]);
+    }
+
+    Ok(())
+}
+
+// Write out a status code + reason phrase as specified in RFC 7370.
+//
+// > The status-code element is a 3-digit integer code describing the
+// > result of the server's attempt to understand and satisfy the client's
+// > corresponding request.  The rest of the response message is to be
+// > interpreted in light of the semantics defined for that status code.
+// > See Section 6 of [RFC7231] for information about the semantics of
+// > status codes, including the classes of status code (indicated by the
+// > first digit), the status codes defined by this specification,
+// > considerations for the definition of new status codes, and the IANA
+// > registry.
+// >
+// >     status-code    = 3DIGIT
+// >
+// > The reason-phrase element exists for the sole purpose of providing a
+// > textual description associated with the numeric status code, mostly
+// > out of deference to earlier Internet application protocols that were
+// > more frequently used with interactive text clients.  A client SHOULD
+// > ignore the reason-phrase content.
+// >
+// >     reason-phrase  = *( HTAB / SP / VCHAR / obs-text )
+pub(crate) fn write_status<B: BufMut>(buf: &mut B, status: Status) -> Result<()> {
+    write_u16(buf, status.code)
+}
+
+// > 3.1.2.  Status Line
+// >
+// > The first line of a response message is the status-line, consisting
+// > of the protocol version, a space (SP), the status code, another
+// > space, a possibly empty textual phrase describing the status code,
+// > and ending with CRLF.
+// >
+// >     status-line = HTTP-version SP status-code SP reason-phrase CRLF
+// >
+// > The status-code element is a 3-digit integer code describing the
+// > result of the server's attempt to understand and satisfy the client's
+// > corresponding request.  The rest of the response message is to be
+// > interpreted in light of the semantics defined for that status code.
+// > See Section 6 of [RFC7231] for information about the semantics of
+// > status codes, including the classes of status code (indicated by the
+// > first digit), the status codes defined by this specification,
+// > considerations for the definition of new status codes, and the IANA
+// > registry.
+// >
+// >     status-code    = 3DIGIT
+// >
+// > The reason-phrase element exists for the sole purpose of providing a
+// > textual description associated with the numeric status code, mostly
+// > out of deference to earlier Internet application protocols that were
+// > more frequently used with interactive text clients.  A client SHOULD
+// > ignore the reason-phrase content.
+// >
+// >     reason-phrase  = *( HTAB / SP / VCHAR / obs-text )
+pub(crate) fn write_status_line<B: BufMut>(
+    buf: &mut B,
+    version: Version,
+    status: Status,
+    reason: &str,
+) -> Result<()> {
+    write_version(buf, version)?;
+    try_write(buf, b" ")?;
+    write_status(buf, status)?;
+    try_write(buf, b" ")?;
+    try_write(buf, reason.as_bytes())?;
+    try_write(buf, b"\r\n")?;
+
+    Ok(())
+}
+
+// We're already outside of the HTTP standard here so
+// this currently just checks that the method doesn't
+// contain a space or a newline.
+pub(crate) fn validate_method(method: &str) -> bool {
+    !method
+        .as_bytes()
+        .iter()
+        .copied()
+        .any(|c| c == b' ' || c == b'\r' || c == b'\n')
+}
+
+// We're already outside the HTTP standard here so just
+// check to see that the version doesn't contain a space.
+pub(crate) fn validate_version(version: &str) -> bool {
+    !version.as_bytes().iter().copied().any(|c| c == b' ')
+}
+
+// Validate a header name as defined by RFC7230. This implementation
+// does not allow for any obsolete syntax.
+//
+// > Each header field consists of a case-insensitive field name followed
+// > by a colon (":"), optional leading whitespace, the field value, and
+// > optional trailing whitespace.
+// >
+// >     header-field   = field-name ":" OWS field-value OWS
+// >
+// >     field-name     = token
+// >     field-value    = *( field-content / obs-fold )
+// >     field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+// >     field-vchar    = VCHAR / obs-text
+// >
+// >     obs-fold       = CRLF 1*( SP / HTAB )
+// >                    ; obsolete line folding
+// >                    ; see Section 3.2.4
+// >
+// > The field-name token labels the corresponding field-value as having
+// > the semantics defined by that header field.  For example, the Date
+// > header field is defined in Section 7.1.1.2 of [RFC7231] as containing
+// > the origination timestamp for the message in which it appears.
+//
+// `token` is defined in RFC2616 Section 2.2
+// >     token          = 1*<any CHAR except CTLs or separators>
+// >     separators     = "(" | ")" | "<" | ">" | "@"
+// >                    | "," | ";" | ":" | "\" | <">
+// >                    | "/" | "[" | "]" | "?" | "="
+// >                    | "{" | "}" | SP | HT
+pub(crate) fn validate_header_name(header: &[u8]) -> bool {
+    fn is_valid(byte: u8) -> bool {
+        // Bit-packed lookup table of all characters that
+        // are valid within `token`.
+        const LOOKUP: u128 = 0x57FFFFFFC7FFFFFE03FF6CFE00000000;
+
+        (byte < 128) & ((LOOKUP.wrapping_shr(byte as u32) & 1) != 0)
+    }
+
+    header.iter().copied().all(is_valid)
+}
+
+// Validate a header value as defined by RFC7230. This implementation
+// does not allow for any obsolete syntax.
+//
+// > Each header field consists of a case-insensitive field name followed
+// > by a colon (":"), optional leading whitespace, the field value, and
+// > optional trailing whitespace.
+// >
+// >     header-field   = field-name ":" OWS field-value OWS
+// >
+// >     field-name     = token
+// >     field-value    = *( field-content / obs-fold )
+// >     field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+// >     field-vchar    = VCHAR / obs-text
+// >
+// >     obs-fold       = CRLF 1*( SP / HTAB )
+// >                    ; obsolete line folding
+// >                    ; see Section 3.2.4
+// >
+// > The field-name token labels the corresponding field-value as having
+// > the semantics defined by that header field.  For example, the Date
+// > header field is defined in Section 7.1.1.2 of [RFC7231] as containing
+// > the origination timestamp for the message in which it appears.
+pub(crate) fn validate_header_field(field: &[u8]) -> bool {
+    field
+        .iter()
+        .copied()
+        .all(|c| c.is_ascii_graphic() || c == b' ' || c == b'\t')
+}
+
+// Status lines sourced from [here][IANA].
+//
+// [IANA]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+pub(crate) fn lookup_status_line(status: Status) -> Option<&'static str> {
+    Some(match status.code {
+        // 1xx: Informational
+        100 => "Continue",
+        101 => "Switching Protocols",
+        102 => "Processing",
+        103 => "Early Hints",
+
+        // 2xx: Success
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        203 => "Non-Authoratative Information",
+        204 => "No Content",
+        205 => "Reset Content",
+        206 => "Partial Content",
+        207 => "Multi Status",
+        208 => "Already Reported",
+        // 209 - 225 Unassigned
+        226 => "IM Used",
+
+        // 3xx: Redirection
+        300 => "Multiple Choices",
+        301 => "Moved Permanently",
+        302 => "Found",
+        303 => "See Other",
+        304 => "Not Modified",
+        305 => "Use Proxy",
+        306 => "Switch Proxy", // This status code is obsolete
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+
+        // 4xx: Client Error
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        402 => "Payment Required",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        406 => "Not Acceptable",
+        407 => "Proxy Authentication Required",
+        408 => "Request Timeout",
+        409 => "Conflict",
+        410 => "Gone",
+        411 => "Length Required",
+        412 => "Precondition Required",
+        413 => "Request Entity Too Large",
+        414 => "Request-URI Too Large",
+        415 => "Unsupported Media Type",
+        416 => "Requested Range Not Satisfiable",
+        417 => "Expectation Failed",
+        418 => "I'm a Teapot",
+        // 419 - 420 Unassigned
+        421 => "Misdirected Request",
+        422 => "Unprocessable Entity",
+        423 => "Locked",
+        424 => "Failed Dependency",
+        425 => "Too Early",
+        426 => "Upgrade Required",
+        // 427 Unassigned
+        428 => "Precondition Required",
+        429 => "Too Many Requests",
+        // 432 - 450 Unassigned
+        451 => "Unavailable for Legal Reasons",
+
+        // 5xx: Server Error
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Time-out",
+        505 => "HTTP Version Not Supported",
+        506 => "Variant Also Negotiates",
+        507 => "Insufficient Storage",
+        508 => "Loop Detected",
+        // 509 Unassigned
+        510 => "Not Extended",
+        509 => "Network Authentication Required",
+
+        _ => return None,
+    })
+}


### PR DESCRIPTION
This moves the httpencode library (which is used by the twemcache-http PR) into pelikan.