### PR TITLE
add stats_log to all C binaries

### DIFF
--- a/src/server/pingserver/admin/process.c
+++ b/src/server/pingserver/admin/process.c
@@ -4,6 +4,7 @@
 #include "util/procinfo.h"
 
 #include <cc_mm.h>
+#include <cc_stats_log.h>
 
 #define PINGSERVER_ADMIN_MODULE_NAME "pingserver::admin"
 
@@ -65,4 +66,12 @@ admin_process_request(struct response *rsp, struct request *req)
         rsp->type = RSP_INVALID;
         break;
     }
+}
+
+void
+stats_dump(void *arg)
+{
+    procinfo_update();
+    stats_log((struct metric *)&stats, nmetric);
+    stats_log_flush();
 }

--- a/src/server/pingserver/admin/process.h
+++ b/src/server/pingserver/admin/process.h
@@ -2,3 +2,5 @@
 
 void admin_process_setup(void);
 void admin_process_teardown(void);
+
+void stats_dump(void *arg); /* compatible type: timeout_cb_fn */

--- a/src/server/pingserver/main.c
+++ b/src/server/pingserver/main.c
@@ -65,6 +65,7 @@ teardown(void)
 
     timing_wheel_teardown();
     tcp_teardown();
+    stats_log_teardown();
     sockio_teardown();
     event_teardown();
     dbuf_teardown();
@@ -107,6 +108,7 @@ setup(void)
     dbuf_setup(&setting.dbuf, &stats.dbuf);
     event_setup(&stats.event);
     sockio_setup(&setting.sockio, &stats.sockio);
+    stats_log_setup(&setting.stats_log);
     tcp_setup(&setting.tcp, &stats.tcp);
     timing_wheel_setup(&stats.timing_wheel);
 
@@ -124,6 +126,12 @@ setup(void)
     intvl = option_uint(&setting.pingserver.dlog_intvl);
     if (core_admin_register(intvl, debug_log_flush, NULL) == NULL) {
         log_stderr("Could not register timed event to flush debug log");
+        goto error;
+    }
+
+    intvl = option_uint(&setting.pingserver.stats_intvl);
+    if (core_admin_register(intvl, stats_dump, NULL) == NULL) {
+        log_error("Could not register timed event to dump stats");
         goto error;
     }
 

--- a/src/server/pingserver/setting.c
+++ b/src/server/pingserver/setting.c
@@ -11,6 +11,7 @@ struct setting setting = {
     { DBUF_OPTION(OPTION_INIT)      },
     { DEBUG_OPTION(OPTION_INIT)     },
     { SOCKIO_OPTION(OPTION_INIT)    },
+    { STATS_LOG_OPTION(OPTION_INIT) },
     { TCP_OPTION(OPTION_INIT)       },
 };
 

--- a/src/server/pingserver/setting.h
+++ b/src/server/pingserver/setting.h
@@ -15,6 +15,7 @@
 #include <cc_option.h>
 #include <cc_ring_array.h>
 #include <cc_signal.h>
+#include <cc_stats_log.h>
 #include <channel/cc_tcp.h>
 #include <stream/cc_sockio.h>
 
@@ -23,7 +24,8 @@
 #define PINGSERVER_OPTION(ACTION)                                                        \
     ACTION( daemonize,      OPTION_TYPE_BOOL,   false,  "daemonize the process"        )\
     ACTION( pid_filename,   OPTION_TYPE_STR,    NULL,   "file storing the pid"         )\
-    ACTION( dlog_intvl,     OPTION_TYPE_UINT,   500,    "debug log flush interval(ms)" )
+    ACTION( dlog_intvl,     OPTION_TYPE_UINT,   500,    "debug log flush interval(ms)" )\
+    ACTION( stats_intvl,    OPTION_TYPE_UINT,   100,    "stats dump interval(ms)"      )
 
 typedef struct {
     PINGSERVER_OPTION(OPTION_DECLARE)
@@ -43,6 +45,7 @@ struct setting {
     dbuf_options_st         dbuf;
     debug_options_st        debug;
     sockio_options_st       sockio;
+    stats_log_options_st    stats_log;
     tcp_options_st          tcp;
 };
 

--- a/src/server/rds/main.c
+++ b/src/server/rds/main.c
@@ -64,6 +64,7 @@ teardown(void)
 
     timing_wheel_teardown();
     tcp_teardown();
+    stats_log_teardown();
     sockio_teardown();
     event_teardown();
     dbuf_teardown();
@@ -106,6 +107,7 @@ setup(void)
     dbuf_setup(&setting.dbuf, &stats.dbuf);
     event_setup(&stats.event);
     sockio_setup(&setting.sockio, &stats.sockio);
+    stats_log_setup(&setting.stats_log);
     tcp_setup(&setting.tcp, &stats.tcp);
     timing_wheel_setup(&stats.timing_wheel);
 

--- a/src/server/rds/setting.c
+++ b/src/server/rds/setting.c
@@ -15,6 +15,7 @@ struct setting setting = {
     { DBUF_OPTION(OPTION_INIT)      },
     { DEBUG_OPTION(OPTION_INIT)     },
     { SOCKIO_OPTION(OPTION_INIT)    },
+    { STATS_LOG_OPTION(OPTION_INIT) },
     { TCP_OPTION(OPTION_INIT)       },
 };
 

--- a/src/server/rds/setting.h
+++ b/src/server/rds/setting.h
@@ -13,6 +13,7 @@
 #include <cc_debug.h>
 #include <cc_option.h>
 #include <cc_ring_array.h>
+#include <cc_stats_log.h>
 #include <channel/cc_tcp.h>
 #include <stream/cc_sockio.h>
 
@@ -30,23 +31,24 @@ typedef struct {
 
 struct setting {
     /* top-level */
-    rds_options_st      rds;
+    rds_options_st          rds;
     /* application modules */
-    admin_options_st    admin;
-    server_options_st   server;
-    worker_options_st   worker;
-    process_options_st  process;
-    request_options_st  request;
-    response_options_st response;
-    slab_options_st     slab;
-    time_options_st     time;
+    admin_options_st        admin;
+    server_options_st       server;
+    worker_options_st       worker;
+    process_options_st      process;
+    request_options_st      request;
+    response_options_st     response;
+    slab_options_st         slab;
+    time_options_st         time;
     /* ccommon libraries */
-    array_options_st    array;
-    buf_options_st      buf;
-    dbuf_options_st     dbuf;
-    debug_options_st    debug;
-    sockio_options_st   sockio;
-    tcp_options_st      tcp;
+    array_options_st        array;
+    buf_options_st          buf;
+    dbuf_options_st         dbuf;
+    debug_options_st        debug;
+    sockio_options_st       sockio;
+    stats_log_options_st    stats_log;
+    tcp_options_st          tcp;
 };
 
 extern struct setting setting;

--- a/src/server/slimcache/admin/process.c
+++ b/src/server/slimcache/admin/process.c
@@ -4,6 +4,7 @@
 #include "util/procinfo.h"
 
 #include <cc_mm.h>
+#include <cc_stats_log.h>
 
 #define SLIMCACHE_ADMIN_MODULE_NAME "slimcache::admin"
 
@@ -65,4 +66,12 @@ admin_process_request(struct response *rsp, struct request *req)
         rsp->type = RSP_INVALID;
         break;
     }
+}
+
+void
+stats_dump(void *arg)
+{
+    procinfo_update();
+    stats_log((struct metric *)&stats, nmetric);
+    stats_log_flush();
 }

--- a/src/server/slimcache/admin/process.h
+++ b/src/server/slimcache/admin/process.h
@@ -2,3 +2,5 @@
 
 void admin_process_setup(void);
 void admin_process_teardown(void);
+
+void stats_dump(void *arg); /* compatible type: timeout_cb_fn */

--- a/src/server/slimcache/main.c
+++ b/src/server/slimcache/main.c
@@ -71,6 +71,7 @@ teardown(void)
 
     timing_wheel_teardown();
     tcp_teardown();
+    stats_log_teardown();
     sockio_teardown();
     event_teardown();
     dbuf_teardown();
@@ -113,6 +114,7 @@ setup(void)
     dbuf_setup(&setting.dbuf, &stats.dbuf);
     event_setup(&stats.event);
     sockio_setup(&setting.sockio, &stats.sockio);
+    stats_log_setup(&setting.stats_log);
     tcp_setup(&setting.tcp, &stats.tcp);
     timing_wheel_setup(&stats.timing_wheel);
 
@@ -142,6 +144,13 @@ setup(void)
     intvl = option_uint(&setting.slimcache.klog_intvl);
     if (core_admin_register(intvl, klog_flush, NULL) == NULL) {
         log_error("Could not register timed event to flush command log");
+        goto error;
+    }
+
+
+    intvl = option_uint(&setting.slimcache.stats_intvl);
+    if (core_admin_register(intvl, stats_dump, NULL) == NULL) {
+        log_error("Could not register timed event to dump stats");
         goto error;
     }
 

--- a/src/server/slimcache/setting.c
+++ b/src/server/slimcache/setting.c
@@ -17,6 +17,7 @@ struct setting setting = {
     { DBUF_OPTION(OPTION_INIT)      },
     { DEBUG_OPTION(OPTION_INIT)     },
     { SOCKIO_OPTION(OPTION_INIT)    },
+    { STATS_LOG_OPTION(OPTION_INIT) },
     { TCP_OPTION(OPTION_INIT)       },
 };
 

--- a/src/server/slimcache/setting.h
+++ b/src/server/slimcache/setting.h
@@ -16,6 +16,7 @@
 #include <cc_option.h>
 #include <cc_ring_array.h>
 #include <cc_signal.h>
+#include <cc_stats_log.h>
 #include <channel/cc_tcp.h>
 #include <stream/cc_sockio.h>
 
@@ -25,7 +26,8 @@
     ACTION( daemonize,      OPTION_TYPE_BOOL,   false,  "daemonize the process"        )\
     ACTION( pid_filename,   OPTION_TYPE_STR,    NULL,   "file storing the pid"         )\
     ACTION( dlog_intvl,     OPTION_TYPE_UINT,   500,    "debug log flush interval(ms)" )\
-    ACTION( klog_intvl,     OPTION_TYPE_UINT,   100,    "cmd log flush interval(ms)"   )
+    ACTION( klog_intvl,     OPTION_TYPE_UINT,   100,    "cmd log flush interval(ms)"   )\
+    ACTION( stats_intvl,    OPTION_TYPE_UINT,   100,    "stats dump interval(ms)"      )
 
 typedef struct {
     SLIMCACHE_OPTION(OPTION_DECLARE)
@@ -51,6 +53,7 @@ struct setting {
     dbuf_options_st         dbuf;
     debug_options_st        debug;
     sockio_options_st       sockio;
+    stats_log_options_st    stats_log;
     tcp_options_st          tcp;
 };
 

--- a/src/server/twemcache/main.c
+++ b/src/server/twemcache/main.c
@@ -67,11 +67,11 @@ teardown(void)
 
     timing_wheel_teardown();
     tcp_teardown();
+    stats_log_teardown();
     sockio_teardown();
     event_teardown();
     dbuf_teardown();
     buf_teardown();
-    stats_log_teardown();
 
     debug_teardown();
     log_teardown();
@@ -106,11 +106,11 @@ setup(void)
     }
 
     /* setup library modules */
-    stats_log_setup(&setting.stats_log);
     buf_setup(&setting.buf, &stats.buf);
     dbuf_setup(&setting.dbuf, &stats.dbuf);
     event_setup(&stats.event);
     sockio_setup(&setting.sockio, &stats.sockio);
+    stats_log_setup(&setting.stats_log);
     tcp_setup(&setting.tcp, &stats.tcp);
     timing_wheel_setup(&stats.timing_wheel);
 

--- a/src/server/twemcache/setting.c
+++ b/src/server/twemcache/setting.c
@@ -16,8 +16,8 @@ struct setting setting = {
     { BUF_OPTION(OPTION_INIT)       },
     { DBUF_OPTION(OPTION_INIT)      },
     { DEBUG_OPTION(OPTION_INIT)     },
-    { STATS_LOG_OPTION(OPTION_INIT) },
     { SOCKIO_OPTION(OPTION_INIT)    },
+    { STATS_LOG_OPTION(OPTION_INIT) },
     { TCP_OPTION(OPTION_INIT)       },
 };
 

--- a/src/server/twemcache/setting.h
+++ b/src/server/twemcache/setting.h
@@ -50,8 +50,8 @@ struct setting {
     buf_options_st          buf;
     dbuf_options_st         dbuf;
     debug_options_st        debug;
-    stats_log_options_st    stats_log;
     sockio_options_st       sockio;
+    stats_log_options_st    stats_log;
     tcp_options_st          tcp;
 };
 


### PR DESCRIPTION
enabling dumping stats to a configurable file at configurable interval for all C binaries.