### PR TITLE
use eventfd for notifications b/w server and worker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(pelikan C)
 #   1. make this a .cmake macro and put it under cmake/
 #   2. avoid calling this twice when included by another project, e.g. Pelikan
 
+include(CheckSymbolExists)
 # detect platform
 macro(set_platform system_name)
     if(${system_name} MATCHES "Darwin")
@@ -19,7 +20,11 @@ macro(set_platform system_name)
         add_definitions(-DOS_DARWIN)
     elseif(${system_name} MATCHES "Linux")
         set(OS_PLATFORM "OS_LINUX")
+        check_symbol_exists(EFD_NONBLOCK "sys/eventfd.h" USE_EVENT_FD)
         add_definitions(-DOS_LINUX)
+        if(USE_EVENT_FD)
+            add_definitions(-DUSE_EVENT_FD)
+        endif()
     else()
         set(OS_PLATFORM "OS_UNSUPPORTED")
     endif()
@@ -279,6 +284,7 @@ message(STATUS "=======================================")
 
 message(STATUS "=======Status of system features=======")
 message(STATUS "HAVE_BACKTRACE: " ${HAVE_BACKTRACE})
+message(STATUS "USE_EVENT_FD: " ${USE_EVENT_FD})
 message(STATUS "=======================================")
 
 message(STATUS "======Status of optional features======")

--- a/src/core/data/server.c
+++ b/src/core/data/server.c
@@ -248,11 +248,11 @@ _server_event(void *arg, uint32_t events)
         if (events & EVENT_WRITE) { /* retrying worker notification */
             log_verb("processing server write event on pipe");
             INCR(server_metrics, server_event_write);
-            #ifdef USE_EVENT_FD
+#ifdef USE_EVENT_FD
             _server_notify_worker();
-            #else
+#else
             _server_pipe_write();
-            #endif
+#endif
         }
         if (events & EVENT_ERR) {
             log_debug("processing server error event on pipe");

--- a/src/core/data/server.c
+++ b/src/core/data/server.c
@@ -278,6 +278,11 @@ core_server_setup(server_options_st *options, server_metrics_st *metrics)
     /* setup shared data structures between server and worker */
     #ifdef USE_EVENT_FD
     event_fd_s2w = eventfd(0 /* intval */, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (event_fd_s2w < 0) {
+        int err = errno;
+        log_error("Could not create event fd %s, abort", strerror(err));
+        goto error;
+    }
     #else
     pipe_new = pipe_conn_create();
     if (pipe_new == NULL) {

--- a/src/core/data/server.c
+++ b/src/core/data/server.c
@@ -24,11 +24,12 @@
 #define SERVER_MODULE_NAME "core::server"
 
 #ifdef USE_EVENT_FD
-int event_fd_s2w = -1;               /* server(w) -> worker(r) */
+int efd_server_to_worker = -1;       /* server(w) -> worker(r) */
+int efd_worker_to_server = -1;       /* worker(w) -> server(r) */
 #else
 struct pipe_conn *pipe_new = NULL;   /* server(w) -> worker(r) */
-#endif
 struct pipe_conn *pipe_term = NULL;  /* worker(w) -> server(r) */
+#endif
 struct ring_array *conn_new = NULL;  /* server(w) -> worker(r) */
 struct ring_array *conn_term = NULL; /* worker(w) -> server(r) */
 
@@ -63,17 +64,17 @@ _server_close(struct buf_sock *s)
 
 #ifdef USE_EVENT_FD
 static inline void
-_server_notify_worker(void)
+_server_event_fd_write(void)
 {
-    ASSERT(event_fd_s2w != -1);
+    ASSERT(efd_server_to_worker != -1);
 
     uint64_t u = 1;
-    ssize_t status = write(event_fd_s2w, &u, sizeof(uint64_t));
+    ssize_t status = write(efd_server_to_worker, &u, sizeof(uint64_t));
 
     if (status == CC_EAGAIN) {
         /* retry write */
         log_verb("server core: retry write to eventfd");
-        event_add_write(ctx->evb, event_fd_s2w, NULL);
+        event_add_write(ctx->evb, efd_server_to_worker, NULL);
     } else if (status == CC_ERROR) {
         log_error("could not write to eventfd - %d", status);
     }
@@ -96,22 +97,47 @@ _server_pipe_write(void)
 }
 #endif
 
+static inline void
+_server_notify_worker(void)
+{
+#ifdef USE_EVENT_FD
+    _server_event_fd_write();
+#else
+    _server_pipe_write();
+#endif
+}
+
 /* pipe_read recycles returned streams from worker thread */
 static inline void
-_server_pipe_read(void)
+_server_read_notification(void)
 {
-    struct buf_sock *s;
-    char buf[RING_ARRAY_DEFAULT_CAP]; /* buffer for discarding pipe data */
-    int i;
-    rstatus_i status;
+#ifdef USE_EVENT_FD
+    ASSERT(efd_worker_to_server != -1);
 
+    uint64_t i;
+#else
     ASSERT(pipe_term != NULL);
 
+    char buf[RING_ARRAY_DEFAULT_CAP]; /* buffer for discarding pipe data */
+    int i;
+#endif
+
+    struct buf_sock *s;
+    rstatus_i status;
+
+#ifdef USE_EVENT_FD
+    int rc = read(efd_worker_to_server, &i, sizeof(uint64_t));
+    if (rc < 0) {
+        log_warn("not adding new connections due to eventfd error");
+        return;
+    }
+#else
     i = pipe_recv(pipe_term, buf, RING_ARRAY_DEFAULT_CAP);
     if (i < 0) { /* errors, do not read from ring array */
         log_warn("not reclaiming connections due to pipe error");
         return;
     }
+#endif
 
     /* each byte in the pipe corresponds to a connection in the array */
     for (; i > 0; --i) {
@@ -192,11 +218,7 @@ _tcp_accept(struct buf_sock *ss)
     }
 
     /* notify worker, note this may fail and will be retried via write event */
-    #ifdef USE_EVENT_FD
     _server_notify_worker();
-    #else
-    _server_pipe_write();
-    #endif
 
     return true;
 }
@@ -221,7 +243,7 @@ _server_event(void *arg, uint32_t events)
         if (events & EVENT_READ) { /* terminating connection from worker */
             log_verb("processing server read event on pipe");
             INCR(server_metrics, server_event_read);
-            _server_pipe_read();
+            _server_read_notification();
         }
         if (events & EVENT_WRITE) { /* retrying worker notification */
             log_verb("processing server write event on pipe");
@@ -276,44 +298,46 @@ core_server_setup(server_options_st *options, server_metrics_st *metrics)
     }
 
     /* setup shared data structures between server and worker */
-    #ifdef USE_EVENT_FD
-    event_fd_s2w = eventfd(0 /* intval */, EFD_CLOEXEC | EFD_NONBLOCK);
-    if (event_fd_s2w < 0) {
+#ifdef USE_EVENT_FD
+    efd_server_to_worker = eventfd(0 /* intval */, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (efd_server_to_worker < 0) {
         int err = errno;
         log_error("Could not create event fd %s, abort", strerror(err));
         goto error;
     }
-    #else
+    efd_worker_to_server = eventfd(0 /* intval */, EFD_CLOEXEC | EFD_NONBLOCK);
+    if (efd_worker_to_server < 0) {
+        int err = errno;
+        log_error("Could not create event fd %s, abort", strerror(err));
+        goto error;
+    }
+#else
     pipe_new = pipe_conn_create();
     if (pipe_new == NULL) {
         log_error("Could not create connection for pipe, abort");
         goto error;
     }
-    #endif
     pipe_term = pipe_conn_create();
     if (pipe_term == NULL) {
         log_error("Could not create connection for pipe, abort");
         goto error;
     }
 
-    #ifndef USE_EVENT_FD
     if (!pipe_open(NULL, pipe_new)) {
         log_error("Could not open pipe for new connection: %s",
                 strerror(pipe_new->err));
         goto error;
     }
-    #endif
     if (!pipe_open(NULL, pipe_term)) {
         log_error("Could not open pipe for terminated connection: %s",
                 strerror(pipe_term->err));
         goto error;
     }
 
-    #ifndef USE_EVENT_FD
     /* event_fd is set to nonblocking during creation */
     pipe_set_nonblocking(pipe_new);
-    #endif
     pipe_set_nonblocking(pipe_term);
+#endif
 
     conn_new = ring_array_create(sizeof(struct buf_sock *),
             RING_ARRAY_DEFAULT_CAP);
@@ -368,7 +392,11 @@ core_server_setup(server_options_st *options, server_metrics_st *metrics)
     c->level = CHANNEL_META;
 
     event_add_read(ctx->evb, hdl->rid(c), server_sock);
+#ifdef USE_EVENT_FD
+    event_add_read(ctx->evb, efd_worker_to_server, NULL);
+#else
     event_add_read(ctx->evb, pipe_read_id(pipe_term), NULL);
+#endif
 
     server_init = true;
 
@@ -392,12 +420,13 @@ core_server_teardown(void)
     }
     ring_array_destroy(&conn_term);
     ring_array_destroy(&conn_new);
-    pipe_conn_destroy(&pipe_term);
-    #ifdef USE_EVENT_FD
-    close(event_fd_s2w);
-    #else
+#ifdef USE_EVENT_FD
+    close(efd_server_to_worker);
+    close(efd_worker_to_server);
+#else
     pipe_conn_destroy(&pipe_new);
-    #endif
+    pipe_conn_destroy(&pipe_term);
+#endif
     server_metrics = NULL;
     server_init = false;
 }

--- a/src/core/data/shared.h
+++ b/src/core/data/shared.h
@@ -5,11 +5,12 @@ struct ring_array;
 
 /* pipe for server/worker thread communication */
 #ifdef USE_EVENT_FD
-extern int event_fd_s2w;
+extern int efd_server_to_worker;
+extern int efd_worker_to_server;
 #else
 extern struct pipe_conn *pipe_new;
-#endif
 extern struct pipe_conn *pipe_term;
+#endif
 
 /* array holding accepted connections */
 extern struct ring_array *conn_new;

--- a/src/core/data/shared.h
+++ b/src/core/data/shared.h
@@ -4,7 +4,11 @@ struct pipe_conn;
 struct ring_array;
 
 /* pipe for server/worker thread communication */
+#ifdef USE_EVENT_FD
+extern int event_fd_s2w;
+#else
 extern struct pipe_conn *pipe_new;
+#endif
 extern struct pipe_conn *pipe_term;
 
 /* array holding accepted connections */

--- a/src/core/data/worker.c
+++ b/src/core/data/worker.c
@@ -93,6 +93,7 @@ static void
 worker_add_stream(void)
 {
     struct buf_sock *s;
+
 #ifdef USE_EVENT_FD
     uint64_t i;
 #else


### PR DESCRIPTION
**event_fd** is much faster and easier to use to cross thread/process [notification](https://man7.org/linux/man-pages/man2/eventfd.2.html).
**event_fd** is a basically an atomic uint64 counter, that acts like _pollable_ file descriptor and was designed specifically for notification purposes.
