### PR TITLE
Added first fuzzer with oss-fuzz build script

### DIFF
--- a/test/fuzz/build.sh
+++ b/test/fuzz/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+
+mkdir _build && cd _build
+cmake -DHAVE_TEST=OFF \
+	-DTARGET_SLIMRDS=OFF \
+	-DHAVE_ASSERT_PANIC=OFF \
+	-DTARGET_SLIMCACHE=OFF \
+	-DTARGET_RDS=OFF \
+	-DTARGET_TWEMCACHE=OFF \
+	-DTARGET_PINGSERVER=OFF \
+	 ..
+make -j4
+
+cd $SRC/pelikan/test/fuzz
+
+$CC $CFLAGS -DOS_LINUX -DUSE_EVENT_FD \
+        -D_FiILE_OFFSET_BITS=64 -D_GNU_SOURCE \
+        -I../../deps/ccommon/include \
+        -I../../deps/ccommon/include/buffer \
+        -I../../src/protocol/data/resp \
+        -I../../_build \
+        -O2  -std=c11 -ggdb3  \
+        -fno-strict-aliasing -O2  \
+        -std=c11 -ggdb3 \
+        -fstrict-aliasing  -O3 -fPIC \
+        -o compiled.o -c fuzzer.c
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE compiled.o -o $OUT/fuzzer \
+        ../../_build/protocol/data/resp/libprotocol_resp.a \
+        ../../_build/core/libcore.a \
+        ../../_build/ccommon/lib/libccommon-2.1.0.a

--- a/test/fuzz/fuzzer.c
+++ b/test/fuzz/fuzzer.c
@@ -1,0 +1,39 @@
+#include "request.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+
+    // Null-terminate our string
+    char *new_str = (char *)malloc(size+1);
+    if (new_str == NULL){
+            return 0;
+    }
+    memcpy(new_str, data, size);
+    new_str[size] = '\0';
+
+    // Create a constant
+    char str[(int)size+1];
+    snprintf(str, (int)size+1, "%s",  new_str);
+    int len = sizeof(str);
+
+    // Create necessary structs
+    struct request *req;
+    struct buf *buf;
+
+    buf = buf_create();
+    buf_write(buf, str, len);
+    req = request_create();
+
+    if(req==NULL){
+        printf("req is null\n");
+        buf_destroy(&buf);
+        free(new_str);
+        return 0;
+    }
+
+    parse_req(req, buf);
+
+    request_destroy(&req);
+    buf_destroy(&buf);
+    free(new_str);
+    return 0;
+}


### PR DESCRIPTION
This PR adds a fuzzer and a build script to integrate Pelikan with oss-fuzz for continuous fuzzing.

The fuzzer is implemented by way of LibFuzzer. Fuzzing is a way of testing programs whereby pseudo-random data is passed to a target function with the goal of finding bugs and vulnerabilities. Continuous fuzzing contributes to this in several ways, some of which are:

1. Some harder-to-find bugs take longer to find, and there have been examples of bugs having been found after several CPU years of continuous fuzzing.
2. It ensures that the fuzzers are actually run occassionally. Often effort is put into writing the fuzzers, and afterwards they are rarely run if at all.

By setting up continuous fuzzing through oss-fuzz, maintainers are notified if and when bugs are found. Notifications include detailed reports with stacktraces and test cases. oss-fuzz is a free service for open source projects that is offered with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Pelikan are put to good use.

I have the build scripts for the oss-fuzz side as well and will be happy to complete the integration.

The location of the fuzzer and the oss-fuzz build script in the `test/fuzz` dir is a suggestion.