### PR TITLE
update rustcommon-buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,13 +140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "buffer"
-version = "0.1.0"
-dependencies = [
- "bytes 0.6.0",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1114,7 @@ dependencies = [
  "log",
  "mio 0.7.5",
  "rustcommon-buffer",
+ "rustcommon-logger",
  "rustls",
  "slab",
 ]
@@ -1525,15 +1519,15 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rustcommon-buffer"
-version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#74ed808b81129ab0b694d72bf36737f621751d96"
+version = "0.2.0"
+source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "bytes 0.6.0",
 ]
@@ -1541,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1550,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#74ed808b81129ab0b694d72bf36737f621751d96"
+source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
 dependencies = [
  "log",
  "time",

--- a/src/server/pingserver-rs/Cargo.toml
+++ b/src/server/pingserver-rs/Cargo.toml
@@ -12,5 +12,6 @@ config = { path = "../../rust/config" }
 log = { version = "0.4.8", features = ["std"] }
 mio = { version = "0.7.0", features = ["os-poll", "tcp"] }
 rustcommon-buffer = { git = "http://github.com/twitter/rustcommon" }
+rustcommon-logger = { git = "http://github.com/twitter/rustcommon" }
 rustls = "0.18.1"
 slab = "0.4.2"

--- a/src/server/pingserver-rs/src/main.rs
+++ b/src/server/pingserver-rs/src/main.rs
@@ -3,24 +3,22 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 #[macro_use]
-extern crate log;
+extern crate rustcommon_logger;
 
 use std::net::SocketAddr;
 use std::sync::mpsc::*;
 use std::sync::Arc;
 
 use config::PingserverConfig;
-use log::*;
 use mio::*;
+use rustcommon_logger::{Level, Logger};
 use slab::Slab;
 
 mod event_loop;
-mod logger;
 mod server;
 mod session;
 mod worker;
 
-use crate::logger::*;
 use crate::server::Server;
 use crate::worker::Worker;
 

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -102,7 +102,7 @@ impl Server {
                             let _ = session.register(&self.poll);
                             s.insert(session);
                         } else {
-                            let session = Session::new(addr, stream, State::Reading, None);
+                            let session = Session::new(addr, stream, State::Established, None);
                             trace!("accepted new session: {}", addr);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
@@ -130,7 +130,7 @@ impl Server {
                         if !handshaking {
                             let mut session = self.sessions.remove(token.0);
                             let _ = session.deregister(&self.poll);
-                            session.set_state(State::Reading);
+                            session.set_state(State::Established);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
                             } else {

--- a/src/server/pingserver-rs/src/session.rs
+++ b/src/server/pingserver-rs/src/session.rs
@@ -35,9 +35,13 @@ impl Session {
             addr: addr,
             stream: stream,
             state,
-            buffer: Buffer::new(1024, 1024),
+            buffer: Buffer::with_capacity(1024, 1024),
             tls,
         }
+    }
+
+    pub fn buffer(&mut self) -> &mut Buffer {
+        &mut self.buffer
     }
 
     /// Register the `Session` with the event loop
@@ -140,19 +144,9 @@ impl Session {
         }
     }
 
-    /// Get a reference to the contents of the receive buffer
-    pub fn rx_buffer(&self) -> &[u8] {
-        self.buffer.rx_buffer()
-    }
-
     /// Return true if there are still bytes in the tx buffer
     pub fn tx_pending(&self) -> bool {
-        self.buffer.tx_pending() > 0
-    }
-
-    /// Clear the buffer
-    pub fn clear_buffer(&mut self) {
-        self.buffer.clear()
+        self.buffer.write_pending() > 0
     }
 
     /// Write to the session buffer
@@ -222,7 +216,6 @@ impl Session {
         trace!("closing session");
         let _ = self.stream.shutdown(std::net::Shutdown::Both);
         self.tls = None;
-        self.buffer.clear();
     }
 }
 

--- a/src/server/pingserver-rs/src/worker.rs
+++ b/src/server/pingserver-rs/src/worker.rs
@@ -5,6 +5,8 @@
 use crate::event_loop::EventLoop;
 use crate::session::*;
 use crate::*;
+
+use std::io::BufRead;
 use std::sync::Arc;
 
 /// A `Worker` handles events on `Session`s
@@ -71,8 +73,8 @@ impl Worker {
                         self.do_write(token);
                     }
 
-                    if let Some(session) = self.sessions.get(token.0) {
-                        let pending = session.rx_buffer().len();
+                    if let Some(session) = self.sessions.get_mut(token.0) {
+                        let pending = session.buffer().read_pending();
                         trace!(
                             "{} bytes pending in rx buffer for session: {}",
                             pending,
@@ -85,7 +87,7 @@ impl Worker {
                         .receiver
                         .recv_timeout(std::time::Duration::from_millis(1))
                     {
-                        let pending = s.rx_buffer().len();
+                        let pending = s.buffer().read_pending();
                         trace!("{} bytes pending in rx buffer for new session", pending);
 
                         // reserve vacant slab
@@ -125,39 +127,63 @@ impl EventLoop for Worker {
 
     fn handle_data(&mut self, token: Token) {
         trace!("handling request for session: {}", token.0);
-        if let Some(session) = self.get_mut_session(token) {
-            // parse buffer contents
-            let buf = session.rx_buffer();
-            if buf.len() < 6 || &buf[buf.len() - 2..buf.len()] != b"\r\n" {
-                // Shortest request is "PING\r\n" at 6 bytes
-                // All complete responses end in CRLF
+        loop {
+            if let Some(session) = self.get_mut_session(token) {
+                if let Ok(buf) = session.buffer().fill_buf() {
+                    if buf.len() < 6 {
+                        // Shortest request is "PING\r\n" at 6 bytes
+                        // All complete responses end in CRLF
 
-                // incomplete request, stay in reading
-            } else if buf.len() == 6 && &buf[..] == b"PING\r\n" {
-                session.clear_buffer();
-                if session.write(b"PONG\r\n").is_ok() {
-                    if session.flush().is_ok() {
-                        if session.tx_pending() {
-                            // wait to write again
-                            session.set_state(State::Writing);
-                            self.reregister(token);
+                        // incomplete request, stay in reading
+                        break;
+                    } else if &buf[0..6] == b"PING\r\n" {
+                        session.buffer().consume(6);
+                        if session.write(b"PONG\r\n").is_ok() {
+                            if session.flush().is_ok() {
+                                let rx_pending = session.buffer().read_pending();
+                                if session.tx_pending() {
+                                    // wait to write again
+                                    session.set_state(State::Writing);
+                                    if rx_pending < 6 {
+                                        break;
+                                    }
+                                } else {
+                                    if session.buffer().read_pending() < 6 {
+                                        break;
+                                    }
+                                }
+                            } else {
+                                // error flushing session
+                                self.handle_error(token);
+                                return;
+                            }
+                        } else {
+                            // error writing
+                            self.handle_error(token);
+                            return;
                         }
                     } else {
+                        // invalid command
+                        debug!("error");
                         self.handle_error(token);
+                        return;
                     }
                 } else {
+                    // couldn't get buffer contents
+                    debug!("error");
                     self.handle_error(token);
+                    return;
                 }
             } else {
-                debug!("error");
-                self.handle_error(token);
+                // no session for the token
+                trace!(
+                    "attempted to handle data for non-existent session: {}",
+                    token.0
+                );
+                return;
             }
-        } else {
-            trace!(
-                "attempted to handle data for non-existent session: {}",
-                token.0
-            );
         }
+        self.reregister(token);
     }
 
     /// Reregister the session given its token

--- a/test/server/pingserver-rs/src/lib.rs
+++ b/test/server/pingserver-rs/src/lib.rs
@@ -73,8 +73,6 @@ fn invalid_command() -> IOResult<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
-// TODO(brian): fix this test, it hangs currently
 /// Test that a fragmented ping is properly handled.
 fn fragmented_ping() -> IOResult<()> {
     let expected_res: &[u8] = b"PONG\r\n";
@@ -141,8 +139,6 @@ fn partial_ping() -> IOResult<()> {
     stream.write_all(b"PI")
 }
 
-#[allow(dead_code)]
-// TODO(brian): fix this test, it hangs currently
 fn large_ping() -> IOResult<()> {
     let mut stream = TcpStream::connect("localhost:12321")?;
     stream.set_nodelay(true)?;
@@ -206,9 +202,19 @@ fn run_tests() {
         panic!("\tfailed: {}", e);
     }
 
+    println!("Running test: fragmented ping");
+    if let Err(e) = fragmented_ping() {
+        panic!("\tfailed: {}", e);
+    }
+
     println!("Running test: multiping");
     if let Err(e) = multiping() {
-        eprintln!("\tfailed: {}", e);
+        panic!("\tfailed: {}", e);
+    }
+
+    println!("Running test: large ping");
+    if let Err(e) = large_ping() {
+        panic!("\tfailed: {}", e);
     }
 
     println!("Running test: partial ping");


### PR DESCRIPTION
Updates rustcommon-buffer library to pull-in some api improvements.

Fixes pingserver request parsing to handle multiping and fragmented ping. Re-enables corresponding tests