### PR TITLE
pingserver-rs: use strum to derive metric names and enum iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1207,8 @@ dependencies = [
  "rustcommon-metrics",
  "rustls",
  "slab",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1844,6 +1855,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strum"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+
+[[package]]
+name = "strum_macros"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2013,12 @@ checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/src/server/pingserver-rs/Cargo.toml
+++ b/src/server/pingserver-rs/Cargo.toml
@@ -36,6 +36,8 @@ rustcommon-logger = { git = "http://github.com/twitter/rustcommon" }
 rustcommon-metrics = { git = "http://github.com/twitter/rustcommon" }
 rustls = "0.18.1"
 slab = "0.4.2"
+strum = "0.20.0"
+strum_macros = "0.20.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/server/pingserver-rs/src/metrics.rs
+++ b/src/server/pingserver-rs/src/metrics.rs
@@ -3,11 +3,15 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use rustcommon_metrics::*;
+use strum::IntoEnumIterator;
+use strum_macros::{AsRefStr, EnumIter};
 
 use std::sync::Arc;
 use std::time::Instant;
 
 /// Defines various statistics
+#[derive(Debug, AsRefStr, EnumIter)]
+#[strum(serialize_all = "snake_case")]
 pub enum Stat {
     AdminEventError,
     AdminEventLoop,
@@ -57,52 +61,7 @@ pub enum Stat {
 
 impl Statistic<AtomicU64, AtomicU64> for Stat {
     fn name(&self) -> &str {
-        match self {
-            Stat::AdminEventError => "admin_event_error",
-            Stat::AdminEventLoop => "admin_event_loop",
-            Stat::AdminEventRead => "admin_event_read",
-            Stat::AdminEventTotal => "admin_event_total",
-            Stat::AdminEventWrite => "admin_event_write",
-            Stat::AdminRequestParse => "admin_request_parse",
-            Stat::AdminRequestParseEx => "admin_request_parse_ex",
-            Stat::AdminResponseCompose => "admin_response_compose",
-            Stat::AdminResponseComposeEx => "admin_response_compose_ex",
-            Stat::Pid => "pid",
-            Stat::RequestParse => "request_parse",
-            Stat::RequestParseEx => "request_parse_ex",
-            Stat::ResponseCompose => "response_compose",
-            Stat::ResponseComposeEx => "response_compose_ex",
-            Stat::ServerEventError => "server_event_error",
-            Stat::ServerEventLoop => "server_event_loop",
-            Stat::ServerEventRead => "server_event_read",
-            Stat::ServerEventTotal => "server_event_total",
-            Stat::ServerEventWrite => "server_event_write",
-            Stat::SessionRecv => "session_recv",
-            Stat::SessionRecvByte => "session_recv_byte",
-            Stat::SessionRecvEx => "session_recv_ex",
-            Stat::SessionSend => "session_send",
-            Stat::SessionSendByte => "session_send_byte",
-            Stat::SessionSendEx => "session_send_ex",
-            Stat::TcpAccept => "tcp_accept",
-            Stat::TcpAcceptEx => "tcp_accept_ex",
-            Stat::TcpClose => "tcp_close",
-            Stat::TcpConnect => "tcp_connect",
-            Stat::TcpConnectEx => "tcp_connect_ex",
-            Stat::TcpRecv => "tcp_recv",
-            Stat::TcpRecvByte => "tcp_recv_byte",
-            Stat::TcpRecvEx => "tcp_recv_ex",
-            Stat::TcpReject => "tcp_reject",
-            Stat::TcpRejectEx => "tcp_reject_ex",
-            Stat::TcpSend => "tcp_send",
-            Stat::TcpSendByte => "tcp_send_byte",
-            Stat::TcpSendEx => "tcp_send_ex",
-            Stat::WorkerEventError => "worker_event_error",
-            Stat::WorkerEventLoop => "worker_event_loop",
-            Stat::WorkerEventRead => "worker_event_read",
-            Stat::WorkerEventTotal => "worker_event_total",
-            Stat::WorkerEventWake => "worker_event_wake",
-            Stat::WorkerEventWrite => "worker_event_write",
-        }
+        self.as_ref()
     }
 
     fn source(&self) -> Source {
@@ -123,53 +82,9 @@ pub fn init() -> Arc<Metrics<AtomicU64, AtomicU64>> {
     metrics.add_output(&Stat::Pid, Output::Reading);
     let _ = metrics.record_gauge(&Stat::Pid, Instant::now(), std::process::id().into());
 
-    for metric in &[
-        Stat::AdminEventError,
-        Stat::AdminEventLoop,
-        Stat::AdminEventRead,
-        Stat::AdminEventTotal,
-        Stat::AdminEventWrite,
-        Stat::AdminRequestParse,
-        Stat::AdminRequestParseEx,
-        Stat::AdminResponseCompose,
-        Stat::AdminResponseComposeEx,
-        Stat::RequestParse,
-        Stat::RequestParseEx,
-        Stat::ResponseCompose,
-        Stat::ResponseComposeEx,
-        Stat::ServerEventError,
-        Stat::ServerEventLoop,
-        Stat::ServerEventRead,
-        Stat::ServerEventTotal,
-        Stat::ServerEventWrite,
-        Stat::SessionRecv,
-        Stat::SessionRecvByte,
-        Stat::SessionRecvEx,
-        Stat::SessionSend,
-        Stat::SessionSendByte,
-        Stat::SessionSendEx,
-        Stat::TcpAccept,
-        Stat::TcpAcceptEx,
-        Stat::TcpClose,
-        Stat::TcpConnect,
-        Stat::TcpConnectEx,
-        Stat::TcpRecv,
-        Stat::TcpRecvByte,
-        Stat::TcpRecvEx,
-        Stat::TcpReject,
-        Stat::TcpRejectEx,
-        Stat::TcpSend,
-        Stat::TcpSendByte,
-        Stat::TcpSendEx,
-        Stat::WorkerEventError,
-        Stat::WorkerEventLoop,
-        Stat::WorkerEventRead,
-        Stat::WorkerEventTotal,
-        Stat::WorkerEventWake,
-        Stat::WorkerEventWrite,
-    ] {
-        metrics.add_output(metric, Output::Reading);
-        let _ = metrics.record_counter(metric, Instant::now(), 0);
+    for metric in Stat::iter() {
+        metrics.add_output(&metric, Output::Reading);
+        let _ = metrics.record_counter(&metric, Instant::now(), 0);
     }
 
     metrics


### PR DESCRIPTION
By using strum derive macros, we are able to simplify the metrics
definitions. As our metric names are well-formed enum variants, we
can simply convert the variant name to snake case and make use of
the enum variant iterator to handle registration.