### PR TITLE
pingserver-rs: fix clippy lints

### DIFF
--- a/src/server/pingserver-rs/src/admin.rs
+++ b/src/server/pingserver-rs/src/admin.rs
@@ -160,6 +160,7 @@ impl Admin {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -182,7 +183,7 @@ impl EventLoop for Admin {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 
@@ -212,11 +213,8 @@ impl EventLoop for Admin {
                             for (metric, value) in snapshot {
                                 let label = metric.statistic().name();
                                 let output = metric.output();
-                                match output {
-                                    Output::Reading => {
-                                        data.push(format!("STAT {} {}", label, value));
-                                    }
-                                    _ => {}
+                                if let Output::Reading = output {
+                                    data.push(format!("STAT {} {}", label, value));
                                 }
                             }
                             data.sort();

--- a/src/server/pingserver-rs/src/event_loop.rs
+++ b/src/server/pingserver-rs/src/event_loop.rs
@@ -26,7 +26,7 @@ pub trait EventLoop {
 
     /// Mutably borrow a `Session` from the event loop if a `Session` with that
     /// `Token` exists.
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session>;
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session>;
 
     /// Takes the `Session` out of the event loop if a `Session` with that
     /// `Token` exists.

--- a/src/server/pingserver-rs/src/metrics.rs
+++ b/src/server/pingserver-rs/src/metrics.rs
@@ -106,8 +106,8 @@ impl Statistic<AtomicU64, AtomicU64> for Stat {
     }
 
     fn source(&self) -> Source {
-        match self {
-            &Stat::Pid => Source::Gauge,
+        match *self {
+            Stat::Pid => Source::Gauge,
             _ => Source::Counter,
         }
     }

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -176,6 +176,7 @@ impl Server {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -196,7 +197,7 @@ impl EventLoop for Server {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 

--- a/src/server/pingserver-rs/src/session.rs
+++ b/src/server/pingserver-rs/src/session.rs
@@ -36,8 +36,8 @@ impl Session {
         let _ = metrics.increment_counter(&Stat::TcpAccept, 1);
         Self {
             token: Token(0),
-            addr: addr,
-            stream: stream,
+            addr,
+            stream,
             state,
             buffer: Buffer::with_capacity(1024, 1024),
             tls,
@@ -251,6 +251,7 @@ impl Session {
 
     /// Get the set of readiness events the session is waiting for
     fn readiness(&self) -> Interest {
+        #[allow(clippy::collapsible_if)]
         if let Some(ref tls) = self.tls {
             if tls.wants_write() || self.buffer.write_pending() != 0 {
                 Interest::READABLE | Interest::WRITABLE

--- a/src/server/pingserver-rs/src/worker.rs
+++ b/src/server/pingserver-rs/src/worker.rs
@@ -138,6 +138,7 @@ impl Worker {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -162,7 +163,7 @@ impl EventLoop for Worker {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 
@@ -217,6 +218,7 @@ impl EventLoop for Worker {
                     }
                 }
             }
+            #[allow(clippy::collapsible_if)]
             if session.buffer().write_pending() > 0 {
                 if session.flush().is_ok() && session.buffer().write_pending() > 0 {
                     self.reregister(token);
@@ -228,7 +230,6 @@ impl EventLoop for Worker {
                 "attempted to handle data for non-existent session: {}",
                 token.0
             );
-            return;
         }
     }
 


### PR DESCRIPTION
Address some clippy lints and add explicit allows where the
exception improves performance or clarity of the code.