### PR TITLE
pingserver-rs: replace rustls with boringssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "boring"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1d6957e9fd6e628e1afa5dad9cfe7bb8aac9cc04237aac77f3f6c20fef864e"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "boring-sys"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c740af8563e42bc34d809e67bd5728d9aa83851d0e7d0611ed21d2f0ed939f"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +652,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,9 +1150,9 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "oorandom"
@@ -1197,6 +1235,8 @@ dependencies = [
 name = "pelikan_pingserver_rs"
 version = "0.0.1"
 dependencies = [
+ "boring",
+ "boring-sys",
  "chrono",
  "config",
  "criterion",
@@ -1205,7 +1245,6 @@ dependencies = [
  "rustcommon-buffer",
  "rustcommon-logger",
  "rustcommon-metrics",
- "rustls",
  "slab",
  "strum",
  "strum_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,6 @@ name = "pelikan_pingserver_rs"
 version = "0.0.1"
 dependencies = [
  "boring",
- "boring-sys",
  "chrono",
  "config",
  "criterion",

--- a/src/server/pingserver-rs/Cargo.toml
+++ b/src/server/pingserver-rs/Cargo.toml
@@ -27,14 +27,14 @@ path = "benches/benchmark.rs"
 harness = false
 
 [dependencies]
+boring = "1.0.3"
 chrono = "0.4.11"
 config = { path = "../../rust/config" }
 log = { version = "0.4.8", features = ["std"] }
 mio = { version = "0.7.0", features = ["os-poll", "tcp"] }
-rustcommon-buffer = { git = "http://github.com/twitter/rustcommon" }
-rustcommon-logger = { git = "http://github.com/twitter/rustcommon" }
-rustcommon-metrics = { git = "http://github.com/twitter/rustcommon" }
-rustls = "0.18.1"
+rustcommon-buffer = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
 slab = "0.4.2"
 strum = "0.20.0"
 strum_macros = "0.20.1"

--- a/src/server/pingserver-rs/src/admin.rs
+++ b/src/server/pingserver-rs/src/admin.rs
@@ -204,6 +204,7 @@ impl Admin {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -226,7 +227,7 @@ impl EventLoop for Admin {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 
@@ -255,12 +256,8 @@ impl EventLoop for Admin {
                             let mut data = Vec::new();
                             for (metric, value) in snapshot {
                                 let label = metric.statistic().name();
-                                let output = metric.output();
-                                match output {
-                                    Output::Reading => {
-                                        data.push(format!("STAT {} {}", label, value));
-                                    }
-                                    _ => {}
+                                if let Output::Reading = metric.output() {
+                                    data.push(format!("STAT {} {}", label, value));
                                 }
                             }
                             data.sort();

--- a/src/server/pingserver-rs/src/admin.rs
+++ b/src/server/pingserver-rs/src/admin.rs
@@ -111,7 +111,8 @@ impl Admin {
                                 // handle case where we have a fully-negotiated
                                 // TLS stream on accept()
                                 Ok(Ok(tls_stream)) => {
-                                    let mut session = Session::tls(addr, tls_stream, self.metrics.clone());
+                                    let mut session =
+                                        Session::tls(addr, tls_stream, self.metrics.clone());
                                     trace!("accepted new session: {}", addr);
                                     let s = self.sessions.vacant_entry();
                                     let token = s.key();
@@ -149,8 +150,7 @@ impl Admin {
                             }
                         } else {
                             // handle plain sessions
-                            let mut session =
-                                Session::plain(addr, stream, self.metrics.clone());
+                            let mut session = Session::plain(addr, stream, self.metrics.clone());
                             trace!("accepted new session: {}", addr);
                             let s = self.sessions.vacant_entry();
                             let token = s.key();

--- a/src/server/pingserver-rs/src/common.rs
+++ b/src/server/pingserver-rs/src/common.rs
@@ -15,19 +15,19 @@ pub fn ssl_context(config: &Arc<PingserverConfig>) -> Result<Option<SslContext>,
     let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())?;
 
     if let Some(f) = config.tls().certificate_chain() {
-        builder.set_ca_file(f);
+        builder.set_ca_file(f)?;
     } else {
         return Ok(None);
     }
 
     if let Some(f) = config.tls().certificate() {
-        builder.set_certificate_file(f, SslFiletype::PEM);
+        builder.set_certificate_file(f, SslFiletype::PEM)?;
     } else {
         return Ok(None);
     }
 
     if let Some(f) = config.tls().private_key() {
-        builder.set_private_key_file(f, SslFiletype::PEM);
+        builder.set_private_key_file(f, SslFiletype::PEM)?;
     } else {
         return Ok(None);
     }

--- a/src/server/pingserver-rs/src/common.rs
+++ b/src/server/pingserver-rs/src/common.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use boring::ssl::{SslAcceptor, SslContext, SslFiletype, SslMethod};
 use config::PingserverConfig;
 
 use std::sync::Arc;
@@ -10,78 +11,26 @@ pub enum Message {
     Shutdown,
 }
 
-pub fn load_tls_config(
-    config: &Arc<PingserverConfig>,
-) -> Result<Option<Arc<rustls::ServerConfig>>, std::io::Error> {
-    let verifier = if let Some(certificate_chain) = config.tls().certificate_chain() {
-        let mut certstore = rustls::RootCertStore::empty();
-        let cafile = std::fs::File::open(certificate_chain).map_err(|e| {
-            error!("{}", e);
-            std::io::Error::new(std::io::ErrorKind::Other, "Could not open CA file")
-        })?;
-        certstore
-            .add_pem_file(&mut std::io::BufReader::new(cafile))
-            .map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::Other, "Could not parse CA file")
-            })?;
-        Some(rustls::AllowAnyAnonymousOrAuthenticatedClient::new(
-            certstore,
-        ))
-    } else {
-        None
-    };
+pub fn ssl_context(config: &Arc<PingserverConfig>) -> Result<Option<SslContext>, std::io::Error> {
+    let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())?;
 
-    let cert = if let Some(certificate) = config.tls().certificate() {
-        let certfile = std::fs::File::open(certificate).map_err(|e| {
-            error!("{}", e);
-            std::io::Error::new(std::io::ErrorKind::Other, "Could not open certificate file")
-        })?;
-        Some(
-            rustls::internal::pemfile::certs(&mut std::io::BufReader::new(certfile)).map_err(
-                |_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Could not parse certificate file",
-                    )
-                },
-            )?,
-        )
+    if let Some(f) = config.tls().certificate_chain() {
+        builder.set_ca_file(f);
     } else {
-        None
-    };
-
-    let key = if let Some(private_key) = config.tls().private_key() {
-        let keyfile = std::fs::File::open(private_key).map_err(|e| {
-            error!("{}", e);
-            std::io::Error::new(std::io::ErrorKind::Other, "Could not open private key file")
-        })?;
-        let keys =
-            rustls::internal::pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(keyfile))
-                .map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Could not parse private key file",
-                    )
-                })?;
-        if keys.len() != 1 {
-            fatal!("Expected 1 private key, got: {}", keys.len());
-        }
-        Some(keys[0].clone())
-    } else {
-        None
-    };
-
-    if verifier.is_none() && cert.is_none() && key.is_none() {
-        Ok(None)
-    } else if verifier.is_some() && cert.is_some() && key.is_some() {
-        let mut tls_config = rustls::ServerConfig::new(verifier.unwrap());
-        let _ = tls_config.set_single_cert(cert.unwrap(), key.unwrap());
-        Ok(Some(Arc::new(tls_config)))
-    } else {
-        error!("Incomplete TLS config");
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Incomplete TLS config",
-        ))
+        return Ok(None);
     }
+
+    if let Some(f) = config.tls().certificate() {
+        builder.set_certificate_file(f, SslFiletype::PEM);
+    } else {
+        return Ok(None);
+    }
+
+    if let Some(f) = config.tls().private_key() {
+        builder.set_private_key_file(f, SslFiletype::PEM);
+    } else {
+        return Ok(None);
+    }
+
+    Ok(Some(builder.build().into_context()))
 }

--- a/src/server/pingserver-rs/src/event_loop.rs
+++ b/src/server/pingserver-rs/src/event_loop.rs
@@ -26,7 +26,7 @@ pub trait EventLoop {
 
     /// Mutably borrow a `Session` from the event loop if a `Session` with that
     /// `Token` exists.
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session>;
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session>;
 
     /// Takes the `Session` out of the event loop if a `Session` with that
     /// `Token` exists.

--- a/src/server/pingserver-rs/src/metrics.rs
+++ b/src/server/pingserver-rs/src/metrics.rs
@@ -65,8 +65,8 @@ impl Statistic<AtomicU64, AtomicU64> for Stat {
     }
 
     fn source(&self) -> Source {
-        match self {
-            &Stat::Pid => Source::Gauge,
+        match *self {
+            Stat::Pid => Source::Gauge,
             _ => Source::Counter,
         }
     }

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -6,7 +6,8 @@ use crate::event_loop::EventLoop;
 use crate::session::*;
 use crate::*;
 
-use mio::net::TcpListener;
+use boring::ssl::{HandshakeError, Ssl, SslContext};
+use mio::net::{TcpListener};
 
 use std::convert::TryInto;
 
@@ -19,7 +20,7 @@ pub struct Server {
     listener: TcpListener,
     poll: Poll,
     sender: SyncSender<Session>,
-    tls_config: Option<Arc<rustls::ServerConfig>>,
+    ssl_context: Option<SslContext>,
     sessions: Slab<Session>,
     metrics: Arc<Metrics<AtomicU64, AtomicU64>>,
     message_receiver: Receiver<Message>,
@@ -49,7 +50,7 @@ impl Server {
             std::io::Error::new(std::io::ErrorKind::Other, "Failed to create epoll instance")
         })?;
 
-        let tls_config = crate::common::load_tls_config(&config)?;
+        let ssl_context = crate::common::ssl_context(&config)?;
 
         let (message_sender, message_receiver) = sync_channel(128);
 
@@ -72,7 +73,7 @@ impl Server {
             listener,
             poll,
             sender,
-            tls_config,
+            ssl_context,
             sessions,
             metrics,
             message_sender,
@@ -105,30 +106,51 @@ impl Server {
             for event in events.iter() {
                 if event.token() == Token(LISTENER_TOKEN) {
                     while let Ok((stream, addr)) = self.listener.accept() {
-                        if let Some(tls_config) = &self.tls_config {
-                            let mut session = Session::new(
-                                addr,
-                                stream,
-                                State::Handshaking,
-                                Some(rustls::ServerSession::new(&tls_config)),
-                                self.metrics.clone(),
-                            );
-                            let s = self.sessions.vacant_entry();
-                            let token = s.key();
-                            session.set_token(Token(token));
-                            if session.register(&self.poll).is_ok() {
-                                s.insert(session);
-                            } else {
-                                let _ = self.metrics().increment_counter(&Stat::TcpAcceptEx, 1);
+                        // handle TLS if it is configured
+                        if let Some(ssl_context) = &self.ssl_context {
+                            match Ssl::new(&ssl_context).map(|v| v.accept(stream)) {
+                                // handle case where we have a fully-negotiated
+                                // TLS stream on accept()
+                                Ok(Ok(tls_stream)) => {
+                                    let session = Session::tls(
+                                        addr,
+                                        tls_stream,
+                                        self.metrics.clone(),
+                                    );
+                                    trace!("accepted new session: {}", addr);
+                                    if self.sender.send(session).is_err() {
+                                        error!("error sending session to worker");
+                                        let _ =
+                                            self.metrics().increment_counter(&Stat::TcpAcceptEx, 1);
+                                    }
+                                }
+                                // handle case where further negotiation is
+                                // needed
+                                Ok(Err(HandshakeError::WouldBlock(tls_stream))) => {
+                                    let mut session = Session::handshaking(
+                                        addr,
+                                        tls_stream,
+                                        self.metrics.clone(),
+                                    );
+                                    let s = self.sessions.vacant_entry();
+                                    let token = s.key();
+                                    session.set_token(Token(token));
+                                    if session.register(&self.poll).is_ok() {
+                                        s.insert(session);
+                                    } else {
+                                        let _ =
+                                            self.metrics().increment_counter(&Stat::TcpAcceptEx, 1);
+                                    }
+                                }
+                                // some other error has occurred and we drop the
+                                // stream
+                                Ok(Err(_)) | Err(_) => {
+                                    let _ = self.metrics().increment_counter(&Stat::TcpAcceptEx, 1);
+                                }
                             }
                         } else {
-                            let session = Session::new(
-                                addr,
-                                stream,
-                                State::Established,
-                                None,
-                                self.metrics.clone(),
-                            );
+                            let session =
+                                Session::plain(addr, stream, self.metrics.clone());
                             trace!("accepted new session: {}", addr);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
@@ -137,6 +159,7 @@ impl Server {
                         };
                     }
                 } else {
+                    // handle plain sessions
                     let token = event.token();
                     trace!("got event for session: {}", token.0);
 
@@ -146,26 +169,10 @@ impl Server {
                         self.handle_error(token);
                     }
 
-                    // handle write events before read events to reduce write
-                    // buffer growth if there is also a readable event
-                    if event.is_writable() {
-                        let _ = self.metrics.increment_counter(&Stat::ServerEventWrite, 1);
-                        self.do_write(token);
-                    }
-
-                    // read events are handled last
-                    if event.is_readable() {
-                        let _ = self.metrics.increment_counter(&Stat::ServerEventRead, 1);
-                        let _ = self.do_read(token);
-                    }
-
-                    if let Some(handshaking) =
-                        self.sessions.get(token.0).map(|v| v.is_handshaking())
-                    {
-                        if !handshaking {
+                    if let Some(session) = self.sessions.get_mut(token.0) {
+                        if session.do_handshake().is_ok() {
                             let mut session = self.sessions.remove(token.0);
                             let _ = session.deregister(&self.poll);
-                            session.set_state(State::Established);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
                                 let _ = self.metrics().increment_counter(&Stat::TcpAcceptEx, 1);

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -7,7 +7,7 @@ use crate::session::*;
 use crate::*;
 
 use boring::ssl::{HandshakeError, Ssl, SslContext};
-use mio::net::{TcpListener};
+use mio::net::TcpListener;
 
 use std::convert::TryInto;
 
@@ -112,11 +112,8 @@ impl Server {
                                 // handle case where we have a fully-negotiated
                                 // TLS stream on accept()
                                 Ok(Ok(tls_stream)) => {
-                                    let session = Session::tls(
-                                        addr,
-                                        tls_stream,
-                                        self.metrics.clone(),
-                                    );
+                                    let session =
+                                        Session::tls(addr, tls_stream, self.metrics.clone());
                                     trace!("accepted new session: {}", addr);
                                     if self.sender.send(session).is_err() {
                                         error!("error sending session to worker");
@@ -149,8 +146,7 @@ impl Server {
                                 }
                             }
                         } else {
-                            let session =
-                                Session::plain(addr, stream, self.metrics.clone());
+                            let session = Session::plain(addr, stream, self.metrics.clone());
                             trace!("accepted new session: {}", addr);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -179,6 +179,7 @@ impl Server {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -199,7 +200,7 @@ impl EventLoop for Server {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 

--- a/src/server/pingserver-rs/src/session.rs
+++ b/src/server/pingserver-rs/src/session.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use mio::net::TcpStream;
 use crate::*;
+use mio::net::TcpStream;
 
 use boring::ssl::{HandshakeError, MidHandshakeSslStream, SslStream};
 use rustcommon_buffer::*;
@@ -29,26 +29,34 @@ pub struct Session {
 
 impl Session {
     /// Create a new `Session` representing a plain `TcpStream`
-    pub fn plain(addr: SocketAddr, stream: TcpStream, metrics: Arc<Metrics<AtomicU64, AtomicU64>>) -> Self {
+    pub fn plain(
+        addr: SocketAddr,
+        stream: TcpStream,
+        metrics: Arc<Metrics<AtomicU64, AtomicU64>>,
+    ) -> Self {
         Self::new(addr, Stream::Plain(stream), metrics)
     }
 
     /// Create a new `Session` representing a negotiated `SslStream`
-    pub fn tls(addr: SocketAddr, stream: SslStream<TcpStream>, metrics: Arc<Metrics<AtomicU64, AtomicU64>>) -> Self {
+    pub fn tls(
+        addr: SocketAddr,
+        stream: SslStream<TcpStream>,
+        metrics: Arc<Metrics<AtomicU64, AtomicU64>>,
+    ) -> Self {
         Self::new(addr, Stream::Tls(stream), metrics)
     }
 
     /// Create a new `Session` representing a `MidHandshakeSslStream`
-    pub fn handshaking(addr: SocketAddr, stream: MidHandshakeSslStream<TcpStream>, metrics: Arc<Metrics<AtomicU64, AtomicU64>>) -> Self {
+    pub fn handshaking(
+        addr: SocketAddr,
+        stream: MidHandshakeSslStream<TcpStream>,
+        metrics: Arc<Metrics<AtomicU64, AtomicU64>>,
+    ) -> Self {
         Self::new(addr, Stream::Handshaking(stream), metrics)
     }
 
     /// Create a new `Session` from an address, stream, and state
-    fn new(
-        addr: SocketAddr,
-        stream: Stream,
-        metrics: Arc<Metrics<AtomicU64, AtomicU64>>,
-    ) -> Self {
+    fn new(addr: SocketAddr, stream: Stream, metrics: Arc<Metrics<AtomicU64, AtomicU64>>) -> Self {
         let _ = metrics.increment_counter(&Stat::TcpAccept, 1);
         Self {
             token: Token(0),
@@ -227,7 +235,7 @@ impl Session {
             };
             return ret;
         } else {
-            panic!("corrupted session");
+            Err(Error::new(ErrorKind::Other, "session contains no stream"))
         }
     }
 

--- a/src/server/pingserver-rs/src/session.rs
+++ b/src/server/pingserver-rs/src/session.rs
@@ -60,7 +60,7 @@ impl Session {
         let _ = metrics.increment_counter(&Stat::TcpAccept, 1);
         Self {
             token: Token(0),
-            addr: addr,
+            addr,
             stream: Some(stream),
             buffer: Buffer::with_capacity(1024, 1024),
             metrics,
@@ -208,11 +208,7 @@ impl Session {
     }
 
     pub fn is_handshaking(&self) -> bool {
-        if let Some(Stream::Handshaking(_)) = self.stream {
-            true
-        } else {
-            false
-        }
+        matches!(self.stream, Some(Stream::Handshaking(_)))
     }
 
     pub fn do_handshake(&mut self) -> Result<(), std::io::Error> {
@@ -233,7 +229,7 @@ impl Session {
                     None
                 }
             };
-            return ret;
+            ret
         } else {
             Err(Error::new(ErrorKind::Other, "session contains no stream"))
         }

--- a/src/server/pingserver-rs/src/worker.rs
+++ b/src/server/pingserver-rs/src/worker.rs
@@ -138,6 +138,7 @@ impl Worker {
             }
 
             // poll queue to receive new messages
+            #[allow(clippy::never_loop)]
             while let Ok(message) = self.message_receiver.try_recv() {
                 match message {
                     Message::Shutdown => {
@@ -162,7 +163,7 @@ impl EventLoop for Worker {
         &self.metrics
     }
 
-    fn get_mut_session<'a>(&'a mut self, token: Token) -> Option<&'a mut Session> {
+    fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }
 
@@ -215,6 +216,7 @@ impl EventLoop for Worker {
                     }
                 }
             }
+            #[allow(clippy::collapsible_if)]
             if session.buffer().write_pending() > 0 {
                 if session.flush().is_ok() && session.buffer().write_pending() > 0 {
                     self.reregister(token);
@@ -226,7 +228,6 @@ impl EventLoop for Worker {
                 "attempted to handle data for non-existent session: {}",
                 token.0
             );
-            return;
         }
     }
 

--- a/src/server/pingserver-rs/src/worker.rs
+++ b/src/server/pingserver-rs/src/worker.rs
@@ -167,10 +167,8 @@ impl EventLoop for Worker {
     }
 
     fn handle_data(&mut self, token: Token) {
-        // TODO(bmartin): find a better solution to multiple borrow issue
-        let metrics = self.metrics.clone();
         trace!("handling request for session: {}", token.0);
-        if let Some(session) = self.get_mut_session(token) {
+        if let Some(session) = self.sessions.get_mut(token.0) {
             loop {
                 // TODO(bmartin): buffer should allow us to check remaining
                 // write capacity.
@@ -187,15 +185,15 @@ impl EventLoop for Worker {
                             // incomplete request, stay in reading
                             break;
                         } else if &buf[0..6] == b"PING\r\n" {
-                            let _ = metrics.increment_counter(&Stat::RequestParse, 1);
+                            let _ = self.metrics.increment_counter(&Stat::RequestParse, 1);
                             session.buffer().consume(6);
                             if session.write(b"PONG\r\n").is_err() {
                                 // error writing
-                                let _ = metrics.increment_counter(&Stat::ResponseComposeEx, 1);
+                                let _ = self.metrics.increment_counter(&Stat::ResponseComposeEx, 1);
                                 self.handle_error(token);
                                 return;
                             } else {
-                                let _ = metrics.increment_counter(&Stat::ResponseCompose, 1);
+                                let _ = self.metrics.increment_counter(&Stat::ResponseCompose, 1);
                             }
                         } else {
                             // invalid command

--- a/src/server/pingserver-rs/tests/integration.rs
+++ b/src/server/pingserver-rs/tests/integration.rs
@@ -29,28 +29,38 @@ fn main() {
     std::thread::sleep(Duration::from_secs(10));
 
     debug!("beginning tests");
-    println!("");
+    println!();
 
-    test("ping", &[("PING\r\n", Some("PONG\r\n"))]);
-    test(
+    data("ping", &[("PING\r\n", Some("PONG\r\n"))]);
+    data(
         "multiping",
         &[("PING\r\nPING\r\n", Some("PONG\r\nPONG\r\n"))],
     );
-    test("partial", &[("PI", None)]);
-    test("fragmented", &[("PI", None), ("NG\r\n", Some("PONG\r\n"))]);
-    test("quit", &[("QUIT\r\n", Some(""))]);
+    data("partial", &[("PI", None)]);
+    data("fragmented", &[("PI", None), ("NG\r\n", Some("PONG\r\n"))]);
+    data("quit", &[("QUIT\r\n", Some(""))]);
+
+    admin("admin invalid", &[("INVALID REQUEST\r\n", Some(""))]);
 
     // shutdown server and join
     debug!("shutdown");
     let _ = pingserver.shutdown();
 }
 
+fn data(name: &str, data: &[(&str, Option<&str>)]) {
+    test("127.0.0.1:12321", name, data)
+}
+
+fn admin(name: &str, data: &[(&str, Option<&str>)]) {
+    test("127.0.0.1:9999", name, data)
+}
+
 // opens a new connection, operating on request + response pairs from the
 // provided data.
-fn test(name: &str, data: &[(&str, Option<&str>)]) {
+fn test(endpoint: &str, name: &str, data: &[(&str, Option<&str>)]) {
     info!("testing: {}", name);
     debug!("connecting to server");
-    let mut stream = TcpStream::connect("127.0.0.1:12321").expect("failed to connect");
+    let mut stream = TcpStream::connect(endpoint).expect("failed to connect");
     stream
         .set_read_timeout(Some(Duration::from_millis(250)))
         .expect("failed to set read timeout");


### PR DESCRIPTION
Replaces rustls with boringssl. This will be a better dependency
for long-term at the cost of an initial performance regression.