### PR TITLE
pingserver-rs: add rusage metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,15 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,9 +192,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cast"
@@ -431,28 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486d435a7351580347279f374cb8a3c16937485441db80181357b7c4d70f17ed"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a84d8ff70e3ec52311109b019c27672b4c1929e4cf7c18bcf0cd9fb5e230be"
-dependencies = [
- "getrandom 0.2.0",
- "lazy_static",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
 name = "const_fn"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,20 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,16 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,12 +509,6 @@ dependencies = [
  "const_fn",
  "lazy_static",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
@@ -591,17 +530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "dashmap"
-version = "3.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
-dependencies = [
- "ahash",
- "cfg-if 0.1.10",
- "num_cpus",
 ]
 
 [[package]]
@@ -805,17 +733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,9 +868,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 
 [[package]]
 name = "libloading"
@@ -1239,11 +1156,12 @@ dependencies = [
  "chrono",
  "config",
  "criterion",
+ "libc",
  "log",
  "mio 0.7.5",
  "rustcommon-buffer",
+ "rustcommon-fastmetrics",
  "rustcommon-logger",
- "rustcommon-metrics",
  "slab",
  "strum",
  "strum_macros",
@@ -1412,7 +1330,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1460,7 +1378,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -1649,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
+source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
 dependencies = [
  "serde",
 ]
@@ -1657,26 +1575,20 @@ dependencies = [
 [[package]]
 name = "rustcommon-buffer"
 version = "0.2.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
+source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
 dependencies = [
- "bytes 0.6.0",
+ "bytes 1.0.1",
 ]
 
 [[package]]
-name = "rustcommon-heatmap"
-version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
-dependencies = [
- "crossbeam",
- "rustcommon-atomics",
- "rustcommon-histogram",
- "thiserror",
-]
+name = "rustcommon-fastmetrics"
+version = "0.0.1"
+source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
 
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
+source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1685,32 +1597,10 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
+source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
 dependencies = [
  "log",
  "time",
-]
-
-[[package]]
-name = "rustcommon-metrics"
-version = "2.0.0-alpha.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
-dependencies = [
- "crossbeam",
- "dashmap",
- "rustcommon-atomics",
- "rustcommon-heatmap",
- "rustcommon-streamstats",
- "thiserror",
-]
-
-[[package]]
-name = "rustcommon-streamstats"
-version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#6a963460a9b363e02d6782ff5a5cbefb1db035ef"
-dependencies = [
- "rustcommon-atomics",
- "thiserror",
 ]
 
 [[package]]
@@ -2003,15 +1893,6 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
+source = "git+https://github.com/twitter/rustcommon#2d70e44ff8a066d34576a7d021e9df0a72543588"
 dependencies = [
  "serde",
 ]
@@ -1575,20 +1575,23 @@ dependencies = [
 [[package]]
 name = "rustcommon-buffer"
 version = "0.2.0"
-source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
+source = "git+https://github.com/twitter/rustcommon#2d70e44ff8a066d34576a7d021e9df0a72543588"
 dependencies = [
  "bytes 1.0.1",
 ]
 
 [[package]]
 name = "rustcommon-fastmetrics"
-version = "0.0.1"
-source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
+version = "0.0.2"
+source = "git+https://github.com/twitter/rustcommon#2d70e44ff8a066d34576a7d021e9df0a72543588"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
+source = "git+https://github.com/twitter/rustcommon#2d70e44ff8a066d34576a7d021e9df0a72543588"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1597,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#b9c86dd0e674a14fff5c98f574d753b54c41b424"
+source = "git+https://github.com/twitter/rustcommon#2d70e44ff8a066d34576a7d021e9df0a72543588"
 dependencies = [
  "log",
  "time",
@@ -1857,18 +1860,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/server/pingserver-rs/Cargo.toml
+++ b/src/server/pingserver-rs/Cargo.toml
@@ -30,11 +30,12 @@ harness = false
 boring = "1.0.3"
 chrono = "0.4.11"
 config = { path = "../../rust/config" }
+libc = "0.2.83"
 log = { version = "0.4.8", features = ["std"] }
 mio = { version = "0.7.0", features = ["os-poll", "tcp"] }
 rustcommon-buffer = { git = "https://github.com/twitter/rustcommon" }
 rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-fastmetrics = { git = "https://github.com/twitter/rustcommon" }
 slab = "0.4.2"
 strum = "0.20.0"
 strum_macros = "0.20.1"

--- a/src/server/pingserver-rs/src/admin.rs
+++ b/src/server/pingserver-rs/src/admin.rs
@@ -269,19 +269,15 @@ impl EventLoop for Admin {
                             session.buffer().consume(7);
                             let mut data = Vec::new();
                             for metric in Stat::iter() {
-                                match metric {
-                                    Stat::Pid
-                                    | Stat::RuMaxrss
-                                    | Stat::RuIxrss
-                                    | Stat::RuIdrss
-                                    | Stat::RuIsrss => {
+                                match metric.source() {
+                                    Source::Gauge => {
                                         data.push(format!(
                                             "STAT {} {}\r\n",
                                             metric,
                                             get_gauge!(&metric).unwrap_or(0)
                                         ));
                                     }
-                                    _ => {
+                                    Source::Counter => {
                                         data.push(format!(
                                             "STAT {} {}\r\n",
                                             metric,

--- a/src/server/pingserver-rs/src/common.rs
+++ b/src/server/pingserver-rs/src/common.rs
@@ -7,6 +7,15 @@ use config::PingserverConfig;
 
 use std::sync::Arc;
 
+const SECOND: u64 = 1_000 * MILLISECOND;
+const MILLISECOND: u64 = 1_000 * MICROSECOND;
+const MICROSECOND: u64 = 1_000 * NANOSECOND;
+const NANOSECOND: u64 = 1;
+
+pub fn timeval_to_ns(timeval: libc::timeval) -> u64 {
+    timeval.tv_sec as u64 * SECOND + timeval.tv_usec as u64 * MICROSECOND
+}
+
 pub enum Message {
     Shutdown,
 }

--- a/src/server/pingserver-rs/src/event_loop.rs
+++ b/src/server/pingserver-rs/src/event_loop.rs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use crate::metrics::Metrics;
 use crate::session::Session;
 use crate::{Stat, Token};
 
 use mio::Poll;
-use rustcommon_metrics::{AtomicU64, Metrics};
 
 use std::sync::Arc;
 
@@ -18,7 +18,7 @@ pub trait EventLoop {
     /// Provides access to an atomic-reference counted `Metrics` structure. This
     /// is used to allow consistent access to the `Metrics` structure and allow
     /// the default implementation of the related helper functions.
-    fn metrics(&self) -> &Arc<Metrics<AtomicU64, AtomicU64>>;
+    fn metrics(&self) -> &Arc<Metrics<Stat>>;
 
     /// Provides access to the `Poll` structure which allows polling for new
     /// readiness events and managing registration for event sources.
@@ -42,12 +42,12 @@ pub trait EventLoop {
     // stats helper functions
 
     /// Increment the statistic counter.
-    fn increment_count(&self, stat: &Stat) {
+    fn increment_count(&self, stat: Stat) {
         self.increment_count_n(stat, 1)
     }
 
     /// Increment the statistic counter by a provided count.
-    fn increment_count_n(&self, stat: &Stat, count: u64) {
+    fn increment_count_n(&self, stat: Stat, count: u64) {
         let _ = self.metrics().increment_counter(stat, count);
     }
 

--- a/src/server/pingserver-rs/src/event_loop.rs
+++ b/src/server/pingserver-rs/src/event_loop.rs
@@ -2,23 +2,15 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::metrics::Metrics;
 use crate::session::Session;
-use crate::{Stat, Token};
+use crate::Token;
 
 use mio::Poll;
-
-use std::sync::Arc;
 
 /// An `EventLoop` describes the functions which must be implemented for a basic
 /// event loop and provides some default implementations and helper functions.
 pub trait EventLoop {
     // the following functions must be implemented
-
-    /// Provides access to an atomic-reference counted `Metrics` structure. This
-    /// is used to allow consistent access to the `Metrics` structure and allow
-    /// the default implementation of the related helper functions.
-    fn metrics(&self) -> &Arc<Metrics<Stat>>;
 
     /// Provides access to the `Poll` structure which allows polling for new
     /// readiness events and managing registration for event sources.
@@ -38,18 +30,6 @@ pub trait EventLoop {
     /// Handle new data received for the `Session` with the provided `Token`.
     /// This will include parsing the incoming data and composing a response.
     fn handle_data(&mut self, token: Token);
-
-    // stats helper functions
-
-    /// Increment the statistic counter.
-    fn increment_count(&self, stat: Stat) {
-        self.increment_count_n(stat, 1)
-    }
-
-    /// Increment the statistic counter by a provided count.
-    fn increment_count_n(&self, stat: Stat, count: u64) {
-        let _ = self.metrics().increment_counter(stat, count);
-    }
 
     /// Handle a read event for the `Session` with the `Token`.
     fn do_read(&mut self, token: Token) -> Result<(), ()> {

--- a/src/server/pingserver-rs/src/lib.rs
+++ b/src/server/pingserver-rs/src/lib.rs
@@ -12,7 +12,6 @@ use std::thread::JoinHandle;
 
 use config::PingserverConfig;
 use mio::*;
-use rustcommon_metrics::*;
 use slab::Slab;
 
 mod admin;

--- a/src/server/pingserver-rs/src/lib.rs
+++ b/src/server/pingserver-rs/src/lib.rs
@@ -5,6 +5,9 @@
 #[macro_use]
 extern crate rustcommon_logger;
 
+#[macro_use]
+extern crate rustcommon_fastmetrics;
+
 use std::net::SocketAddr;
 use std::sync::mpsc::*;
 use std::sync::Arc;
@@ -56,7 +59,7 @@ impl PingserverBuilder {
     /// issues encountered while initializing the components.
     pub fn new(config_file: Option<String>) -> Self {
         // initialize metrics
-        let metrics = crate::metrics::init();
+        crate::metrics::init();
 
         // load config from file
         let config = if let Some(file) = config_file {
@@ -73,19 +76,19 @@ impl PingserverBuilder {
         };
 
         // initialize admin
-        let admin = Admin::new(config.clone(), metrics.clone()).unwrap_or_else(|e| {
+        let admin = Admin::new(config.clone()).unwrap_or_else(|e| {
             error!("{}", e);
             std::process::exit(1);
         });
 
         // initialize worker
-        let worker = Worker::new(config.clone(), metrics.clone()).unwrap_or_else(|e| {
+        let worker = Worker::new(config.clone()).unwrap_or_else(|e| {
             error!("{}", e);
             std::process::exit(1);
         });
 
         // initialize server
-        let server = Server::new(config, metrics, worker.session_sender()).unwrap_or_else(|e| {
+        let server = Server::new(config, worker.session_sender()).unwrap_or_else(|e| {
             error!("{}", e);
             std::process::exit(1);
         });

--- a/src/server/pingserver-rs/src/metrics.rs
+++ b/src/server/pingserver-rs/src/metrics.rs
@@ -93,7 +93,7 @@ pub fn init() -> Arc<Metrics<Stat>> {
     let mut builder = MetricsBuilder::new();
     for stat in Stat::iter() {
         match stat {
-            Stat::Pid => {
+            Stat::Pid | Stat::RuMaxrss | Stat::RuIxrss | Stat::RuIdrss | Stat::RuIsrss => {
                 builder = builder.gauge(stat);
             }
             _ => {

--- a/src/server/pingserver-rs/src/server.rs
+++ b/src/server/pingserver-rs/src/server.rs
@@ -3,14 +3,13 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::event_loop::EventLoop;
-use crate::metrics::Metrics;
+use rustcommon_fastmetrics::metrics;
+
 use crate::session::*;
 use crate::*;
 
 use boring::ssl::{HandshakeError, Ssl, SslContext};
 use mio::net::TcpListener;
-
-use std::convert::TryInto;
 
 /// A `Server` is used to bind to a given socket address and accept new
 /// sessions. These sessions are moved onto a MPSC queue, where they can be
@@ -23,7 +22,6 @@ pub struct Server {
     sender: SyncSender<Session>,
     ssl_context: Option<SslContext>,
     sessions: Slab<Session>,
-    metrics: Arc<Metrics<Stat>>,
     message_receiver: Receiver<Message>,
     message_sender: SyncSender<Message>,
 }
@@ -35,7 +33,6 @@ impl Server {
     /// `Session`s over the `sender`
     pub fn new(
         config: Arc<PingserverConfig>,
-        metrics: Arc<Metrics<Stat>>,
         sender: SyncSender<Session>,
     ) -> Result<Self, std::io::Error> {
         let addr = config.server().socket_addr().map_err(|e| {
@@ -76,7 +73,6 @@ impl Server {
             sender,
             ssl_context,
             sessions,
-            metrics,
             message_sender,
             message_receiver,
         })
@@ -94,14 +90,11 @@ impl Server {
 
         // repeatedly run accepting new connections and moving them to the worker
         loop {
-            let _ = self.metrics.increment_counter(Stat::ServerEventLoop, 1);
+            increment_counter!(&Stat::ServerEventLoop);
             if self.poll.poll(&mut events, timeout).is_err() {
                 error!("Error polling server");
             }
-            let _ = self.metrics.increment_counter(
-                Stat::ServerEventTotal,
-                events.iter().count().try_into().unwrap(),
-            );
+            increment_counter_by!(&Stat::ServerEventTotal, events.iter().count() as u64,);
 
             // handle all events
             for event in events.iter() {
@@ -113,45 +106,38 @@ impl Server {
                                 // handle case where we have a fully-negotiated
                                 // TLS stream on accept()
                                 Ok(Ok(tls_stream)) => {
-                                    let session =
-                                        Session::tls(addr, tls_stream, self.metrics.clone());
+                                    let session = Session::tls(addr, tls_stream);
                                     trace!("accepted new session: {}", addr);
                                     if self.sender.send(session).is_err() {
                                         error!("error sending session to worker");
-                                        let _ =
-                                            self.metrics().increment_counter(Stat::TcpAcceptEx, 1);
+                                        let _ = increment_counter!(&Stat::TcpAcceptEx);
                                     }
                                 }
                                 // handle case where further negotiation is
                                 // needed
                                 Ok(Err(HandshakeError::WouldBlock(tls_stream))) => {
-                                    let mut session = Session::handshaking(
-                                        addr,
-                                        tls_stream,
-                                        self.metrics.clone(),
-                                    );
+                                    let mut session = Session::handshaking(addr, tls_stream);
                                     let s = self.sessions.vacant_entry();
                                     let token = s.key();
                                     session.set_token(Token(token));
                                     if session.register(&self.poll).is_ok() {
                                         s.insert(session);
                                     } else {
-                                        let _ =
-                                            self.metrics().increment_counter(Stat::TcpAcceptEx, 1);
+                                        let _ = increment_counter!(&Stat::TcpAcceptEx);
                                     }
                                 }
                                 // some other error has occurred and we drop the
                                 // stream
                                 Ok(Err(_)) | Err(_) => {
-                                    let _ = self.metrics().increment_counter(Stat::TcpAcceptEx, 1);
+                                    increment_counter!(&Stat::TcpAcceptEx);
                                 }
                             }
                         } else {
-                            let session = Session::plain(addr, stream, self.metrics.clone());
+                            let session = Session::plain(addr, stream);
                             trace!("accepted new session: {}", addr);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
-                                let _ = self.metrics().increment_counter(Stat::TcpAcceptEx, 1);
+                                increment_counter!(&Stat::TcpAcceptEx);
                             }
                         };
                     }
@@ -162,7 +148,7 @@ impl Server {
 
                     // handle error events first
                     if event.is_error() {
-                        let _ = self.metrics().increment_counter(Stat::ServerEventError, 1);
+                        increment_counter!(&Stat::ServerEventError);
                         self.handle_error(token);
                     }
 
@@ -172,7 +158,7 @@ impl Server {
                             let _ = session.deregister(&self.poll);
                             if self.sender.send(session).is_err() {
                                 error!("error sending session to worker");
-                                let _ = self.metrics().increment_counter(Stat::TcpAcceptEx, 1);
+                                increment_counter!(&Stat::TcpAcceptEx);
                             }
                         }
                     }
@@ -197,10 +183,6 @@ impl Server {
 }
 
 impl EventLoop for Server {
-    fn metrics(&self) -> &Arc<Metrics<Stat>> {
-        &self.metrics
-    }
-
     fn get_mut_session(&mut self, token: Token) -> Option<&mut Session> {
         self.sessions.get_mut(token.0)
     }

--- a/src/server/pingserver-rs/src/session.rs
+++ b/src/server/pingserver-rs/src/session.rs
@@ -2,14 +2,11 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use crate::metrics::Metrics;
 use crate::*;
-use mio::net::TcpStream;
-
 use boring::ssl::{HandshakeError, MidHandshakeSslStream, SslStream};
+use mio::net::TcpStream;
 use rustcommon_buffer::*;
-
-use std::convert::TryInto;
+use rustcommon_fastmetrics::metrics;
 use std::io::{Error, ErrorKind, Write};
 
 pub enum Stream {
@@ -25,42 +22,32 @@ pub struct Session {
     addr: SocketAddr,
     stream: Option<Stream>,
     buffer: Buffer,
-    metrics: Arc<Metrics<Stat>>,
 }
 
 impl Session {
     /// Create a new `Session` representing a plain `TcpStream`
-    pub fn plain(addr: SocketAddr, stream: TcpStream, metrics: Arc<Metrics<Stat>>) -> Self {
-        Self::new(addr, Stream::Plain(stream), metrics)
+    pub fn plain(addr: SocketAddr, stream: TcpStream) -> Self {
+        Self::new(addr, Stream::Plain(stream))
     }
 
     /// Create a new `Session` representing a negotiated `SslStream`
-    pub fn tls(
-        addr: SocketAddr,
-        stream: SslStream<TcpStream>,
-        metrics: Arc<Metrics<Stat>>,
-    ) -> Self {
-        Self::new(addr, Stream::Tls(stream), metrics)
+    pub fn tls(addr: SocketAddr, stream: SslStream<TcpStream>) -> Self {
+        Self::new(addr, Stream::Tls(stream))
     }
 
     /// Create a new `Session` representing a `MidHandshakeSslStream`
-    pub fn handshaking(
-        addr: SocketAddr,
-        stream: MidHandshakeSslStream<TcpStream>,
-        metrics: Arc<Metrics<Stat>>,
-    ) -> Self {
-        Self::new(addr, Stream::Handshaking(stream), metrics)
+    pub fn handshaking(addr: SocketAddr, stream: MidHandshakeSslStream<TcpStream>) -> Self {
+        Self::new(addr, Stream::Handshaking(stream))
     }
 
     /// Create a new `Session` from an address, stream, and state
-    fn new(addr: SocketAddr, stream: Stream, metrics: Arc<Metrics<Stat>>) -> Self {
-        let _ = metrics.increment_counter(Stat::TcpAccept, 1);
+    fn new(addr: SocketAddr, stream: Stream) -> Self {
+        increment_counter!(&Stat::TcpAccept);
         Self {
             token: Token(0),
             addr,
             stream: Some(stream),
             buffer: Buffer::with_capacity(1024, 1024),
-            metrics,
         }
     }
 
@@ -111,7 +98,7 @@ impl Session {
 
     /// Reads from the stream into the session buffer
     pub fn read(&mut self) -> Result<Option<usize>, std::io::Error> {
-        let _ = self.metrics.increment_counter(Stat::TcpRecv, 1);
+        increment_counter!(&Stat::TcpRecv);
 
         let read_result = match &mut self.stream {
             Some(Stream::Plain(s)) => self.buffer.read_from(s),
@@ -123,14 +110,12 @@ impl Session {
         match read_result {
             Ok(Some(0)) => Ok(Some(0)),
             Ok(Some(bytes)) => {
-                let _ = self
-                    .metrics
-                    .increment_counter(Stat::TcpRecvByte, bytes.try_into().unwrap());
+                increment_counter_by!(&Stat::TcpRecvByte, bytes as u64);
                 Ok(Some(bytes))
             }
             Ok(None) => Ok(None),
             Err(e) => {
-                let _ = self.metrics.increment_counter(Stat::TcpRecvEx, 1);
+                increment_counter!(&Stat::TcpRecvEx);
                 Err(e)
             }
         }
@@ -152,14 +137,12 @@ impl Session {
 
         match write_result {
             Ok(Some(bytes)) => {
-                let _ = self
-                    .metrics
-                    .increment_counter(Stat::TcpSendByte, bytes.try_into().unwrap());
+                increment_counter_by!(&Stat::TcpSendByte, bytes as u64);
                 Ok(Some(bytes))
             }
             Ok(None) => Ok(None),
             Err(e) => {
-                let _ = self.metrics.increment_counter(Stat::TcpSendEx, 1);
+                increment_counter!(&Stat::TcpSendEx);
                 Err(e)
             }
         }
@@ -209,7 +192,7 @@ impl Session {
 
     pub fn close(&mut self) {
         trace!("closing session");
-        let _ = self.metrics.increment_counter(Stat::TcpClose, 1);
+        increment_counter!(&Stat::TcpClose);
         if let Some(stream) = self.stream.take() {
             self.stream = match stream {
                 Stream::Plain(s) => {

--- a/src/server/pingserver-rs/tests/integration.rs
+++ b/src/server/pingserver-rs/tests/integration.rs
@@ -113,9 +113,7 @@ fn get_response(stream: &mut TcpStream, buf: &mut [u8]) -> usize {
 
 fn did_hangup(stream: &mut TcpStream, buf: &mut [u8]) -> bool {
     match stream.read(buf) {
-        Ok(0) => {
-            true
-        }
+        Ok(0) => true,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::WouldBlock {
                 debug!("got no response");


### PR DESCRIPTION
Adds rusage metrics to pingserver to address #314

Replaces the current metrics library with one being developed for
twemcache-rs. It removes overhead of a hash lookup for each metric
increment by using a fixed indexing from the metric enum into a
vec of channels.

On a test host this is giving ~4-5% gain in peak throughput.