### PR TITLE
[pre-segcache] preparations for segcache 

### DIFF
--- a/src/data_structure/sarray/sarray.c
+++ b/src/data_structure/sarray/sarray.c
@@ -32,7 +32,7 @@ _validate_range(uint32_t esize, uint64_t val)
     }
 }
 
-static inline uint64_t
+static uint64_t
 _get_value(char *p, uint32_t esize)
 {
     switch (esize) {

--- a/src/protocol/data/memcache/response.c
+++ b/src/protocol/data/memcache/response.c
@@ -36,6 +36,7 @@ response_reset(struct response *rsp)
     rsp->vcas = 0;
     rsp->met = NULL;
     rsp->flag = 0;
+    rsp->item = NULL;
 
     rsp->cas = 0;
     rsp->num = 0;

--- a/src/protocol/data/memcache/response.h
+++ b/src/protocol/data/memcache/response.h
@@ -86,6 +86,8 @@ struct response {
     uint64_t                vcas;       /* value for cas */
     struct metric           *met;       /* metric, for reporting stats */
 
+    void                    *item;      /* pointer to item, used by segcache */
+
     uint32_t                flag;
     uint32_t                vlen;
 

--- a/src/server/twemcache/main.c
+++ b/src/server/twemcache/main.c
@@ -203,6 +203,9 @@ main(int argc, char **argv)
         exit(EX_CONFIG);
     }
 
+    /* set the default time type to memcached before loading config */
+    setting.time.time_type.val.vuint = TIME_MEMCACHE;
+
     if (fp != NULL) {
         log_stderr("load config from %s", argv[1]);
         status = option_load_file(fp, (struct option *)&setting, nopt);

--- a/src/server/twemcache/main.c
+++ b/src/server/twemcache/main.c
@@ -203,9 +203,6 @@ main(int argc, char **argv)
         exit(EX_CONFIG);
     }
 
-    /* set the default time type to memcached before loading config */
-    setting.time.time_type.val.vuint = TIME_MEMCACHE;
-
     if (fp != NULL) {
         log_stderr("load config from %s", argv[1]);
         status = option_load_file(fp, (struct option *)&setting, nopt);

--- a/src/storage/slab/item.c
+++ b/src/storage/slab/item.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 
 extern delta_time_i max_ttl;
-static proc_time_i flush_at = -1;
+proc_time_i flush_at = -1;
 
 static inline bool
 _item_expired(struct item *it)

--- a/src/storage/slab/slab.c
+++ b/src/storage/slab/slab.c
@@ -61,6 +61,8 @@ delta_time_i max_ttl = ITEM_MAX_TTL;
 static bool slab_init = false;
 slab_metrics_st *slab_metrics = NULL;
 
+extern proc_time_i flush_at;
+
 cc_declare_itt_function(,slab_malloc);
 cc_declare_itt_function(,slab_free);
 
@@ -619,6 +621,8 @@ slab_setup(slab_options_st *options, slab_metrics_st *metrics)
 
      cc_create_itt_malloc(slab_malloc);
      cc_create_itt_free(slab_free);
+
+    flush_at = -1;
 
     slab_init = true;
 

--- a/src/time/time.h
+++ b/src/time/time.h
@@ -67,9 +67,9 @@ enum {
     TIME_SENTINEL = 3
 };
 
-/*          name          type                default       description */
+/*          name          type                default           description */
 #define TIME_OPTION(ACTION) \
-    ACTION( time_type,    OPTION_TYPE_UINT,   TIME_UNIX,    "Expiry timestamp mode" )
+    ACTION( time_type,    OPTION_TYPE_UINT,   TIME_MEMCACHE,    "Expiry timestamp mode" )
 
 typedef struct {
     TIME_OPTION(OPTION_DECLARE)


### PR DESCRIPTION
1. add a new field in memcache response that Segcache will use to decrease ref count after serving; 
2. change the timer in pelikan_twemcache so that the default timer is memcached_time; 
3. fix a bug in pelikan_twemcache where flush_at is not reset during tear and setup. 
4. add segcache in calculator 
