### PR TITLE
segcache: fix incorrect item stats following merge

### DIFF
--- a/src/storage/seg/segmerge.c
+++ b/src/storage/seg/segmerge.c
@@ -443,6 +443,8 @@ seg_copy(int32_t seg_id_dest, int32_t seg_id_src,
         it_freq = it_freq / ((double) it_sz / mean_size);
 
         if (it_freq <= cutoff && (!copy_all_items)) {
+            DECR_N(seg_metrics, item_curr_bytes, it_sz);
+            DECR(seg_metrics, item_curr);
             hashtable_evict(item_key(it), it->klen, seg_id_src_ht, it_offset);
             curr_src += it_sz;
             continue;


### PR DESCRIPTION
Segcache currently doesn't properly decrement the item_curr_bytes
or item_curr gauges when items are removed during segment merge.

Adds decrement for both counters during merge phase.