### PR TITLE
bugfix: seg storage CAS may give incorrect result

### DIFF
--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -12,6 +12,10 @@ pub fn tests() {
     debug!("beginning tests");
     println!();
 
+    test(
+        "cas not found (key: 0)",
+        &[("cas 0 0 0 1 1\r\n0\r\n", Some("NOT_FOUND\r\n"))],
+    );
     test("get empty (key: 0)", &[("get 0\r\n", Some("END\r\n"))]);
     test("gets empty (key: 0)", &[("gets 0\r\n", Some("END\r\n"))]);
     test(

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -511,10 +511,6 @@ impl HashTable {
 
         trace!("hash: {} mask: {} bucket: {}", hash, self.mask, bucket_id);
 
-        if cas != get_cas(bucket.data[0]) {
-            return Err(SegError::Exists);
-        }
-
         loop {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
@@ -550,6 +546,8 @@ impl HashTable {
                             // TODO(bmartin): what is expected on overflow of the cas bits?
                             self.data[(hash & self.mask) as usize].data[0] += 1;
                             return Ok(());
+                        } else {
+                            return Err(SegError::Exists);
                         }
                     }
                 }


### PR DESCRIPTION
The Rust implementation of seg storage appears to have a simple bug
which can result in an incorrect result for a CAS operation.

If the CAS value in the hashtable does not match the provided
value, the code immediately returns that the item exists which is
used to indicate a stale CAS value. However, it does not check if
the item is actually in the table or if this is just a collision.

Changes the code to scan through the items in the bucket even if
the CAS value does not match.