### PR TITLE
ci: fix uncaught failure in #339

### DIFF
--- a/ci/cargo.sh
+++ b/ci/cargo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -euo pipefail
+
 cargo build
 cargo test
 cargo build --release

--- a/src/rust/storage/seg/src/tests.rs
+++ b/src/rust/storage/seg/src/tests.rs
@@ -22,7 +22,7 @@ fn sizes() {
     assert_eq!(std::mem::size_of::<HashTable>(), 64);
 
     assert_eq!(std::mem::size_of::<crate::ttl_buckets::TtlBucket>(), 64);
-    assert_eq!(std::mem::size_of::<TtlBuckets>(), 16);
+    assert_eq!(std::mem::size_of::<TtlBuckets>(), 24);
 }
 
 #[test]


### PR DESCRIPTION
CI failed to catch a failure in PR #339 related to a struct size test that was not updated with the corresponding change to the struct.

This change causes the CI job to properly fail and then fixes the test so that CI passes.