### PR TITLE
add server-side latencies to rust servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "serde",
 ]
@@ -1086,15 +1086,26 @@ dependencies = [
 [[package]]
 name = "rustcommon-buffer"
 version = "0.2.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
+name = "rustcommon-heatmap"
+version = "0.1.1"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
+dependencies = [
+ "rustcommon-atomics",
+ "rustcommon-histogram",
+ "rustcommon-time",
+ "thiserror",
+]
+
+[[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1103,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-logger"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "log",
  "time",
@@ -1112,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1123,17 +1134,21 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "linkme",
+ "once_cell",
  "parking_lot",
+ "rustcommon-atomics",
+ "rustcommon-heatmap",
  "rustcommon-metrics-derive",
+ "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-time"
 version = "0.0.6"
-source = "git+https://github.com/twitter/rustcommon#ad0674fbc8b1d861a6200a2b17f13831b7f6fbcb"
+source = "git+https://github.com/twitter/rustcommon#f80fb5a83d057179b14e3871f77a5c61175edd75"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/src/rust/core/server/src/threads/worker/mod.rs
+++ b/src/rust/core/server/src/threads/worker/mod.rs
@@ -12,10 +12,11 @@ mod storage;
 pub use self::storage::StorageWorker;
 use mio::Token;
 pub use multi::MultiWorker;
+use rustcommon_time::Duration;
 pub use single::SingleWorker;
 
 use super::EventLoop;
-use metrics::{static_metrics, Counter};
+use metrics::{static_metrics, Counter, Heatmap, Relaxed};
 
 static_metrics! {
     static WORKER_EVENT_LOOP: Counter;
@@ -27,6 +28,10 @@ static_metrics! {
     static STORAGE_EVENT_LOOP: Counter;
 
     static PROCESS_REQ: Counter;
+
+    static REQUEST_LATENCY: Relaxed<Heatmap> = Relaxed::new(||
+        Heatmap::new(1_000_000_000, 3, Duration::from_secs(60), Duration::from_secs(1))
+    );
 }
 
 pub struct TokenWrapper<T> {

--- a/src/rust/core/server/src/threads/worker/multi.rs
+++ b/src/rust/core/server/src/threads/worker/multi.rs
@@ -7,6 +7,7 @@
 //! the requests to the storage worker. Responses from the storage worker are
 //! then serialized onto the session buffer.
 
+use rustcommon_time::Instant;
 use super::EventLoop;
 use super::*;
 use crate::poll::Poll;
@@ -100,6 +101,8 @@ where
 
             WORKER_EVENT_TOTAL.add(events.iter().count() as _);
 
+            rustcommon_time::refresh_clock();
+
             // process all events
             for event in events.iter() {
                 match event.token() {
@@ -133,6 +136,8 @@ where
     fn handle_event(&mut self, event: &Event) {
         let token = event.token();
 
+
+
         // event for existing session
         trace!("got event for session: {}", token.0);
 
@@ -152,6 +157,9 @@ where
         // read events are handled last
         if event.is_readable() {
             WORKER_EVENT_READ.increment();
+            if let Ok(session) = self.poll.get_mut_session(token) {
+                session.set_timestamp(Instant::recent());
+            }
             let _ = self.do_read(token);
         }
 
@@ -229,6 +237,10 @@ where
                                 debug!("error flushing: {}", e);
                             }
                         }
+                    } else {
+                        let now = rustcommon_time::now_precise();
+                        let latency = (now - session.timestamp()).as_nanos();
+                        REQUEST_LATENCY.increment(now, latency as _, 1);
                     }
                 }
 

--- a/src/rust/core/server/src/threads/worker/single.rs
+++ b/src/rust/core/server/src/threads/worker/single.rs
@@ -7,6 +7,7 @@
 //! the request using the backing storage, and then composes a response onto the
 //! session buffer.
 
+use rustcommon_time::Instant;
 use super::EventLoop;
 use super::*;
 use crate::poll::{Poll, WAKER_TOKEN};
@@ -88,6 +89,8 @@ where
 
             WORKER_EVENT_TOTAL.add(events.iter().count() as _);
 
+            rustcommon_time::refresh_clock();
+
             // process all events
             for event in events.iter() {
                 match event.token() {
@@ -150,6 +153,9 @@ where
         // read events are handled last
         if event.is_readable() {
             WORKER_EVENT_READ.increment();
+            if let Ok(session) = self.poll.get_mut_session(token) {
+                session.set_timestamp(Instant::recent());
+            }
             let _ = self.do_read(token);
         }
 
@@ -214,11 +220,12 @@ where
                     }
                 }
             }
-            #[allow(clippy::collapsible_if)]
-            if session.write_pending() > 0 {
-                if session.flush().is_ok() && session.write_pending() > 0 {
+            if session.write_pending() > 0 && (session.flush().is_ok() && session.write_pending() > 0) {
                     self.poll.reregister(token);
-                }
+            } else {
+                let now = rustcommon_time::now_precise();
+                let latency = (now - session.timestamp()).as_nanos();
+                REQUEST_LATENCY.increment(now, latency as _, 1);
             }
             Ok(())
         } else {

--- a/src/rust/metrics/Cargo.toml
+++ b/src/rust/metrics/Cargo.toml
@@ -11,7 +11,11 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", package="rustcommon-metrics-v2" }
 macros = { path = "../macros" }
 strum = "0.20.0"
 strum_macros = "0.20.1"
+
+[dependencies.rustcommon-metrics]
+git = "https://github.com/twitter/rustcommon"
+package="rustcommon-metrics-v2"
+features = ["heatmap"]

--- a/src/rust/metrics/src/lib.rs
+++ b/src/rust/metrics/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-pub use rustcommon_metrics::{metric, Counter, Gauge};
+pub use rustcommon_metrics::{metric, Counter, Gauge, Heatmap, Relaxed};
 
 #[doc(hidden)]
 pub extern crate rustcommon_metrics;

--- a/src/rust/protocol/src/memcache/wire/response/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/response/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use super::*;
 use crate::memcache::wire::MemcacheCommand;
 use crate::memcache::MemcacheEntry;
 use crate::memcache::MemcacheRequest;
@@ -10,7 +11,6 @@ use crate::CRLF;
 use session::Session;
 use std::borrow::Cow;
 use std::io::Write;
-use super::*;
 
 pub struct MemcacheResponse {
     pub(crate) request: MemcacheRequest,
@@ -76,46 +76,74 @@ impl MemcacheResult {
 impl Compose for MemcacheResponse {
     fn compose(self, dst: &mut Session) {
         match self.request {
-            MemcacheRequest::Get { .. } => { GET.increment(); }
-            MemcacheRequest::Gets { .. } => { GETS.increment(); }
+            MemcacheRequest::Get { .. } => {
+                GET.increment();
+            }
+            MemcacheRequest::Gets { .. } => {
+                GETS.increment();
+            }
             MemcacheRequest::Set { .. } => {
                 match self.result {
-                    MemcacheResult::Stored => { SET_STORED.increment(); }
-                    MemcacheResult::NotStored => { SET_NOT_STORED.increment(); }
+                    MemcacheResult::Stored => {
+                        SET_STORED.increment();
+                    }
+                    MemcacheResult::NotStored => {
+                        SET_NOT_STORED.increment();
+                    }
                     _ => unreachable!(),
                 }
                 SET.increment();
             }
             MemcacheRequest::Add { .. } => {
                 match self.result {
-                    MemcacheResult::Stored => { ADD_STORED.increment(); }
-                    MemcacheResult::NotStored => { ADD_NOT_STORED.increment(); }
+                    MemcacheResult::Stored => {
+                        ADD_STORED.increment();
+                    }
+                    MemcacheResult::NotStored => {
+                        ADD_NOT_STORED.increment();
+                    }
                     _ => unreachable!(),
                 }
                 ADD.increment();
             }
             MemcacheRequest::Replace { .. } => {
                 match self.result {
-                    MemcacheResult::Stored => { REPLACE_STORED.increment(); }
-                    MemcacheResult::NotStored => { REPLACE_NOT_STORED.increment(); }
+                    MemcacheResult::Stored => {
+                        REPLACE_STORED.increment();
+                    }
+                    MemcacheResult::NotStored => {
+                        REPLACE_NOT_STORED.increment();
+                    }
                     _ => unreachable!(),
                 }
                 REPLACE.increment();
             }
             MemcacheRequest::Delete { .. } => {
                 match self.result {
-                    MemcacheResult::NotFound => { DELETE_NOT_FOUND.increment(); }
-                    MemcacheResult::Deleted => { DELETE_DELETED.increment(); }
+                    MemcacheResult::NotFound => {
+                        DELETE_NOT_FOUND.increment();
+                    }
+                    MemcacheResult::Deleted => {
+                        DELETE_DELETED.increment();
+                    }
                     _ => unreachable!(),
                 }
                 DELETE.increment();
             }
             MemcacheRequest::Cas { .. } => {
                 match self.result {
-                    MemcacheResult::Exists => { CAS_EXISTS.increment(); }
-                    MemcacheResult::NotFound => { CAS_NOT_FOUND.increment(); }
-                    MemcacheResult::NotStored => { CAS_EX.increment(); }
-                    MemcacheResult::Stored => { CAS_STORED.increment(); }
+                    MemcacheResult::Exists => {
+                        CAS_EXISTS.increment();
+                    }
+                    MemcacheResult::NotFound => {
+                        CAS_NOT_FOUND.increment();
+                    }
+                    MemcacheResult::NotStored => {
+                        CAS_EX.increment();
+                    }
+                    MemcacheResult::Stored => {
+                        CAS_STORED.increment();
+                    }
                     _ => unreachable!(),
                 }
                 CAS.increment();

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -10,16 +10,15 @@ mod buffer;
 mod stream;
 mod tcp_stream;
 
-use std::borrow::Borrow;
-use std::borrow::BorrowMut;
-use std::io::BufRead;
-use std::io::{ErrorKind, Read, Write};
+use std::borrow::{Borrow, BorrowMut};
+use std::io::{BufRead, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 
 use boring::ssl::{MidHandshakeSslStream, SslStream};
 use metrics::{static_metrics, Counter};
 use mio::event::Source;
 use mio::{Interest, Poll, Token};
+use rustcommon_time::Instant;
 
 use buffer::Buffer;
 use stream::Stream;
@@ -51,6 +50,7 @@ pub struct Session {
     write_buffer: Buffer,
     min_capacity: usize,
     max_capacity: usize,
+    timestamp: Instant,
 }
 
 impl Session {
@@ -93,6 +93,7 @@ impl Session {
             write_buffer: Buffer::with_capacity(min_capacity),
             min_capacity,
             max_capacity,
+            timestamp: Instant::now(),
         }
     }
 
@@ -181,6 +182,14 @@ impl Session {
 
     pub fn peer_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.stream.peer_addr()
+    }
+
+    pub fn timestamp(&self) -> Instant {
+        self.timestamp
+    }
+
+    pub fn set_timestamp(&mut self, timestamp: Instant) {
+        self.timestamp = timestamp;
     }
 }
 


### PR DESCRIPTION
Adds server-side request latency distributions to both Rust servers (segcache and pingserver) by adding a timestamp to the session and modifying core.

Need to think through some of the handling challenges for pipelined requests and validate that I've selected the right spots to
timestamp and record latencies.