### PR TITLE
seg: cleanup item removal

### DIFF
--- a/src/rust/storage/seg/src/segments/segment.rs
+++ b/src/rust/storage/seg/src/segments/segment.rs
@@ -322,13 +322,6 @@ impl<'a> Segment<'a> {
         self.check_magic();
     }
 
-    /// Returns the item looking it up from the item_info
-    // TODO(bmartin): consider changing the return type here and removing asserts?
-    pub(crate) fn get_item(&mut self, item_info: u64) -> Option<RawItem> {
-        assert_eq!(get_seg_id(item_info), Some(self.id()));
-        self.get_item_at(get_offset(item_info) as usize)
-    }
-
     /// Returns the item at the given offset
     // TODO(bmartin): consider changing the return type here and removing asserts?
     #[allow(clippy::unnecessary_wraps)]
@@ -613,9 +606,10 @@ impl<'a> Segment<'a> {
 
             debug_assert!(item.klen() > 0, "invalid klen: ({})", item.klen());
 
+            items += 1;
+            bytes += item.size();
+
             if !item.deleted() {
-                items += 1;
-                bytes += item.size();
                 trace!("evicting from hashtable");
                 let removed = if expire {
                     hashtable.expire(item.key(), offset.try_into().unwrap(), self)

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -172,7 +172,9 @@ impl Segments {
         if segment.next_seg().is_none() && !expire {
             Err(())
         } else {
-            assert_eq!(segment.evictable(), true);
+            // TODO(bmartin): this should probably result in an error and not be
+            // an assert
+            assert!(segment.evictable(), "segment was not evictable");
             segment.set_evictable(false);
             segment.set_accessible(false);
             segment.clear(hashtable, expire);

--- a/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -125,7 +125,7 @@ impl TtlBucket {
             }
             self.tail = Some(id);
             self.nseg += 1;
-            debug_assert_eq!(segment.evictable(), false);
+            debug_assert!(segment.evictable(), "segment should not be evictable");
             segment.set_evictable(true);
             segment.set_accessible(true);
             Ok(())


### PR DESCRIPTION
Looking at the `HashTable::remove_from()` function, it should be
patterned more like `relink_item()`. This allows us to avoid a full
key comparison.

Also addresses some clippy lints.