### PR TITLE
seg: allow disabling compaction for merge eviction

### DIFF
--- a/src/rust/storage/seg/src/eviction/mod.rs
+++ b/src/rust/storage/seg/src/eviction/mod.rs
@@ -198,7 +198,11 @@ impl Eviction {
     /// The compact ratio serves as a low watermark for triggering compaction
     /// and combining segments without eviction.
     pub fn compact_ratio(&self) -> f64 {
-        1.0 / self.n_compact() as f64
+        if self.n_compact() == 0 {
+            0.0
+        } else {
+            1.0 / self.n_compact() as f64
+        }
     }
 
     #[inline]

--- a/src/rust/storage/seg/src/eviction/policy.rs
+++ b/src/rust/storage/seg/src/eviction/policy.rs
@@ -50,6 +50,8 @@ pub enum Policy {
         /// will only occur if a segment falls below `1/N`th occupancy. Setting
         /// this higher will cause fewer compaction runs but can result in a
         /// larger percentage of dead bytes.
+        ///
+        /// Note: Compaction will be disabled by setting this parameter to zero.
         compact: usize,
     },
 }


### PR DESCRIPTION
Allows disabling compaction for merge eviction by specifying a
`compact_target` value of 0 in the config.

Compaction is a lossless merge phase which runs on the heel of
item removal if a segment's occupancy is below some watermark. The
`compact_target` setting specifies the minimum number of segments
which should be merged together in this phase. Setting this to 0
should result in disabling compaction.

Changes the handling around calculating the watermark such that
when a `compact_target` of 0 is specified, that compaction is
bypasses as expected.