### PR TITLE
seg: add RandomFifo eviction strategy

### DIFF
--- a/src/rust/storage/seg/src/eviction/mod.rs
+++ b/src/rust/storage/seg/src/eviction/mod.rs
@@ -72,7 +72,7 @@ impl Eviction {
     pub fn should_rerank(&mut self) -> bool {
         let now = Instant::recent();
         match self.policy {
-            Policy::None | Policy::Random | Policy::Merge { .. } => false,
+            Policy::None | Policy::Random | Policy::RandomFifo | Policy::Merge { .. } => false,
             Policy::Fifo | Policy::Cte | Policy::Util => {
                 if self.ranked_segs[0].is_none()
                     || (now - self.last_update_time).as_secs() > 1
@@ -90,7 +90,7 @@ impl Eviction {
     pub fn rerank(&mut self, headers: &[SegmentHeader]) {
         let mut ids: Vec<NonZeroU32> = headers.iter().map(|h| h.id()).collect();
         match self.policy {
-            Policy::None | Policy::Random | Policy::Merge { .. } => {
+            Policy::None | Policy::Random | Policy::RandomFifo | Policy::Merge { .. } => {
                 return;
             }
             Policy::Fifo { .. } => {

--- a/src/rust/storage/seg/src/eviction/policy.rs
+++ b/src/rust/storage/seg/src/eviction/policy.rs
@@ -12,6 +12,11 @@ pub enum Policy {
     /// Segment random eviction. Selects a random segment and evicts it. Similar
     /// to slab random eviction.
     Random,
+    /// Random FIFO eviction. Selects a random TTL Bucket, weighted by the
+    /// number of segments, and evicts the oldest segment in the bucket. This
+    /// strategy helps preserve the TTL distribution of the working set and
+    /// prioritizes keeping newer items.
+    RandomFifo,
     /// FIFO segment eviction. Selects the oldest segment and evicts it. As
     /// segments are append-only, this is similar to both slab LRU and slab LRC
     /// eviction strategies.


### PR DESCRIPTION
Adds a new eviction strategy that selects a TTL bucket based on the
number of segments per bucket and evicts the head segment for that
bucket.

This strategy preserves the distribution of TTLs in the working set
and prioritizes retaining newer items. Compared to `Random`, this
strategy fits better with the focus of retaining newer items, as it
will always evict the head of a TTL bucket. Compared to `Fifo`, this
strategy should be fairer for workloads with mixed TTLs and varying
write rates per TTL.