### PR TITLE
seg: enable RandomFifo policy in configuration

### DIFF
--- a/src/rust/config/src/seg.rs
+++ b/src/rust/config/src/seg.rs
@@ -31,6 +31,7 @@ const DATAPOOL_PATH: Option<&str> = None;
 pub enum Eviction {
     None,
     Random,
+    RandomFifo,
     Fifo,
     Cte,
     Util,

--- a/src/rust/entrystore/src/seg/mod.rs
+++ b/src/rust/entrystore/src/seg/mod.rs
@@ -30,6 +30,7 @@ impl Seg {
         let eviction = match config.eviction() {
             Eviction::None => Policy::None,
             Eviction::Random => Policy::Random,
+            Eviction::RandomFifo => Policy::RandomFifo,
             Eviction::Fifo => Policy::Fifo,
             Eviction::Cte => Policy::Cte,
             Eviction::Util => Policy::Util,


### PR DESCRIPTION
PR #349 introduced the `RandomFifo` eviction policy to the
`seg` storage crate without allowing for it to be configured as 
an eviction policy for Segcache.

This change fixes that by updating the config and entrystore
crates.