### PR TITLE
segcache_rs stats cleanup

### DIFF
--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -355,12 +355,8 @@ impl Admin {
         };
 
         if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) } == 0 {
-            RU_UTIME.set(
-                rusage.ru_utime.tv_sec as u64 * S + rusage.ru_utime.tv_usec as u64 * US,
-            );
-            RU_STIME.set(
-                rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US,
-            );
+            RU_UTIME.set(rusage.ru_utime.tv_sec as u64 * S + rusage.ru_utime.tv_usec as u64 * US);
+            RU_STIME.set(rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US);
             RU_MAXRSS.set(rusage.ru_maxrss * KB as i64);
             RU_IXRSS.set(rusage.ru_ixrss * KB as i64);
             RU_IDRSS.set(rusage.ru_idrss * KB as i64);

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -53,6 +53,10 @@ static_metrics! {
     static RU_NIVCSW: Counter;
 }
 
+const KB: u64 = 1024; // one kilobyte in bytes
+const S: u64 = 1_000_000_000; // one second in nanoseconds
+const US: u64 = 1_000; // one microsecond in nanoseconds
+
 /// A `Admin` is used to bind to a given socket address and handle out-of-band
 /// admin requests.
 pub struct Admin {
@@ -352,15 +356,15 @@ impl Admin {
 
         if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) } == 0 {
             RU_UTIME.set(
-                rusage.ru_utime.tv_sec as u64 * 1000000000 + rusage.ru_utime.tv_usec as u64 * 1000,
+                rusage.ru_utime.tv_sec as u64 * S + rusage.ru_utime.tv_usec as u64 * US,
             );
             RU_STIME.set(
-                rusage.ru_stime.tv_sec as u64 * 1000000000 + rusage.ru_stime.tv_usec as u64 * 1000,
+                rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US,
             );
-            RU_MAXRSS.set(rusage.ru_maxrss as i64);
-            RU_IXRSS.set(rusage.ru_ixrss as i64);
-            RU_IDRSS.set(rusage.ru_idrss as i64);
-            RU_ISRSS.set(rusage.ru_isrss as i64);
+            RU_MAXRSS.set(rusage.ru_maxrss * KB as i64);
+            RU_IXRSS.set(rusage.ru_ixrss * KB as i64);
+            RU_IDRSS.set(rusage.ru_idrss * KB as i64);
+            RU_ISRSS.set(rusage.ru_isrss * KB as i64);
             RU_MINFLT.set(rusage.ru_minflt as u64);
             RU_MAJFLT.set(rusage.ru_majflt as u64);
             RU_NSWAP.set(rusage.ru_nswap as u64);

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -37,6 +37,7 @@ static_metrics! {
 
     static TCP_ACCEPT: Counter;
     static TCP_CLOSE: Counter;
+    static TCP_CONN_CURR: Gauge;
     static TCP_RECV_BYTE: Counter;
     static TCP_SEND_BYTE: Counter;
     static TCP_SEND_PARTIAL: Counter;
@@ -122,6 +123,7 @@ impl Session {
     /// Create a new `Session`
     fn new(stream: Stream, min_capacity: usize, max_capacity: usize) -> Self {
         TCP_ACCEPT.increment();
+        TCP_CONN_CURR.add(1);
         Self {
             token: Token(0),
             stream,

--- a/src/rust/session/src/stream.rs
+++ b/src/rust/session/src/stream.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use boring::ssl::{HandshakeError, MidHandshakeSslStream, SslStream};
 
 use super::TcpStream;
-use crate::TCP_CLOSE;
+use crate::{TCP_CLOSE, TCP_CONN_CURR};
 
 pub struct Stream {
     inner: Option<StreamType>,
@@ -78,6 +78,7 @@ impl Stream {
 
     pub fn close(&mut self) {
         TCP_CLOSE.increment();
+        TCP_CONN_CURR.sub(1);
         if let Some(stream) = self.inner.take() {
             self.inner = match stream {
                 StreamType::Plain(s) => {

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -11,8 +11,9 @@ use metrics::{static_metrics, Counter};
 const RESERVE_RETRIES: usize = 3;
 
 static_metrics! {
-    static SEGMENT_ACQUIRE: Counter;
-    static SEGMENT_ACQUIRE_EX: Counter;
+    static SEGMENT_REQUEST: Counter;
+    static SEGMENT_REQUEST_FAILURE: Counter;
+    static SEGMENT_REQUEST_SUCCESS: Counter;
 }
 
 /// A pre-allocated key-value store with eager expiration. It uses a
@@ -137,6 +138,11 @@ impl Seg {
                     return Err(SegError::ItemOversized { size, key });
                 }
                 Err(TtlBucketsError::NoFreeSegments) => {
+                    if retries == RESERVE_RETRIES {
+                        // first attempt to acquire a free segment, increment
+                        // the stats
+                        SEGMENT_REQUEST.increment();
+                    }
                     if self
                         .segments
                         .evict(&mut self.ttl_buckets, &mut self.hashtable)
@@ -144,16 +150,17 @@ impl Seg {
                     {
                         retries -= 1;
                     } else {
-                        // segment acquire successful, increment stat and exit
-                        // the loop
-                        SEGMENT_ACQUIRE.increment();
+                        // we successfully got a segment, increment the stat and
+                        // return to start of loop to reserve the item
+                        SEGMENT_REQUEST_SUCCESS.increment();
                         continue;
                     }
                 }
             }
             if retries == 0 {
-                // segment acquire failed, increment the exception stat
-                SEGMENT_ACQUIRE_EX.increment();
+                // segment acquire failed, increment the stat and return with
+                // an error
+                SEGMENT_REQUEST_FAILURE.increment();
                 return Err(SegError::NoFreeSegments);
             }
             retries -= 1;

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -16,8 +16,6 @@ static_metrics! {
     static SEGMENT_EVICT_EX: Counter;
     static SEGMENT_RETURN: Counter;
     static SEGMENT_FREE: Gauge;
-    static SEGMENT_REQUEST: Counter;
-    static SEGMENT_REQUEST_EX: Counter;
     static SEGMENT_MERGE: Counter;
     static SEGMENT_CURRENT: Gauge;
 }
@@ -380,10 +378,7 @@ impl Segments {
     pub(crate) fn pop_free(&mut self) -> Option<NonZeroU32> {
         assert!(self.free <= self.cap);
 
-        SEGMENT_REQUEST.increment();
-
         if self.free == 0 {
-            SEGMENT_REQUEST_EX.increment();
             None
         } else {
             SEGMENT_FREE.decrement();


### PR DESCRIPTION
Adds gauge for current open connections: `tcp_conn_curr`

Changes RSS stats to export as bytes instead of kilobytes.

Fix live/dead item tracking, consolidate updates, add comments.
