### PR TITLE
enable cargo audit in CI

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -128,7 +128,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   audit:
-    if: false
     name: audit
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The cargo audit failures have been addressed and we should
re-enable this check in CI.