### PR TITLE
segcache_rs: add no-op support for flush_all command

### DIFF
--- a/src/rust/protocol/fuzz/fuzz_targets/memcache.rs
+++ b/src/rust/protocol/fuzz/fuzz_targets/memcache.rs
@@ -46,6 +46,7 @@ fuzz_target!(|data: &[u8]| {
             MemcacheRequest::Delete { key, .. } => {
                 validate_key(&key);
             }
+            MemcacheRequest::FlushAll => {}
         }
     }
 });

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -125,6 +125,9 @@ where
                 }
                 response
             }
+            MemcacheRequest::FlushAll => {
+                return None;
+            }
         };
 
         Some(MemcacheResponse { request, result })

--- a/src/rust/protocol/src/memcache/wire/request/command.rs
+++ b/src/rust/protocol/src/memcache/wire/request/command.rs
@@ -16,6 +16,7 @@ pub enum MemcacheCommand {
     Delete,
     Cas,
     Quit,
+    FlushAll,
 }
 
 impl TryFrom<&[u8]> for MemcacheCommand {
@@ -31,6 +32,7 @@ impl TryFrom<&[u8]> for MemcacheCommand {
             b"cas" => MemcacheCommand::Cas,
             b"delete" => MemcacheCommand::Delete,
             b"quit" => MemcacheCommand::Quit,
+            b"flush_all" => MemcacheCommand::FlushAll,
             _ => {
                 return Err(ParseError::UnknownCommand);
             }
@@ -50,6 +52,7 @@ impl std::fmt::Display for MemcacheCommand {
             Self::Cas => "cas",
             Self::Delete => "delete",
             Self::Quit => "quit",
+            Self::FlushAll => "flush_all",
         };
         write!(f, "{}", name)
     }

--- a/src/rust/protocol/src/memcache/wire/request/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/request/mod.rs
@@ -27,6 +27,7 @@ pub enum MemcacheRequest {
     Replace { entry: MemcacheEntry, noreply: bool },
     Delete { key: Key, noreply: bool },
     Cas { entry: MemcacheEntry, noreply: bool },
+    FlushAll,
 }
 
 impl MemcacheRequest {
@@ -71,6 +72,7 @@ impl MemcacheRequest {
             Self::Replace { .. } => MemcacheCommand::Replace,
             Self::Delete { .. } => MemcacheCommand::Delete,
             Self::Cas { .. } => MemcacheCommand::Cas,
+            Self::FlushAll => MemcacheCommand::FlushAll,
         }
     }
 }

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -55,6 +55,7 @@ impl Parse<MemcacheRequest> for MemcacheRequestParser {
                 // command
                 Err(ParseError::Invalid)
             }
+            MemcacheCommand::FlushAll => parse_flush_all(buffer),
         }
     }
 }
@@ -429,6 +430,25 @@ fn parse_delete(buffer: &[u8]) -> Result<ParseOk<MemcacheRequest>, ParseError> {
 
     Ok(ParseOk {
         message: request,
+        consumed,
+    })
+}
+
+#[allow(clippy::unnecessary_unwrap)]
+fn parse_flush_all(buffer: &[u8]) -> Result<ParseOk<MemcacheRequest>, ParseError> {
+    let mut parse_state = ParseState::new(buffer);
+
+    // this was already checked for when determining the command
+    let (whitespace, _cmd_end) = parse_state.next_sequence().unwrap();
+
+    if whitespace != Sequence::Crlf && whitespace != Sequence::SpaceCrlf {
+        return Err(ParseError::Invalid);
+    }
+
+    let consumed = parse_state.position();
+
+    Ok(ParseOk {
+        message: MemcacheRequest::FlushAll,
         consumed,
     })
 }

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -183,11 +183,8 @@ fn delete() {
 fn flush_all() {
     let parser = MemcacheRequestParser::default();
 
-    let request = parser
-        .parse(b"flush_all\r\n")
-        .expect("parse failure");
+    let request = parser.parse(b"flush_all\r\n").expect("parse failure");
     if let MemcacheRequest::FlushAll = request.message {
-
     } else {
         panic!("invalid parse result");
     }

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -180,6 +180,20 @@ fn delete() {
 }
 
 #[test]
+fn flush_all() {
+    let parser = MemcacheRequestParser::default();
+
+    let request = parser
+        .parse(b"flush_all\r\n")
+        .expect("parse failure");
+    if let MemcacheRequest::FlushAll = request.message {
+
+    } else {
+        panic!("invalid parse result");
+    }
+}
+
+#[test]
 fn incomplete() {
     let parser = MemcacheRequestParser::default();
 

--- a/src/rust/protocol/src/memcache/wire/response/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/response/mod.rs
@@ -148,6 +148,7 @@ impl Compose for MemcacheResponse {
                 }
                 CAS.increment();
             }
+            MemcacheRequest::FlushAll => {},
         }
         if let MemcacheResult::Values { ref entries, cas } = self.result {
             let mut hits = 0;

--- a/src/rust/protocol/src/memcache/wire/response/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/response/mod.rs
@@ -148,7 +148,7 @@ impl Compose for MemcacheResponse {
                 }
                 CAS.increment();
             }
-            MemcacheRequest::FlushAll => {},
+            MemcacheRequest::FlushAll => {}
         }
         if let MemcacheResult::Values { ref entries, cas } = self.result {
             let mut hits = 0;


### PR DESCRIPTION
The command `flush_all` is required for some internal tooling and
can be added to pelikan_segcache_rs as a no-op (similar to slimcache).

This causes the command to be handled like a noreply and leaves the
connection open.