### PR TITLE
segcache_rs: add 'flush_all' as no-op admin command

### DIFF
--- a/config/segcache.toml
+++ b/config/segcache.toml
@@ -1,6 +1,9 @@
 daemonize = false
 
 [admin]
+# interfaces listening on
+host = "0.0.0.0"
+# port listening on
 port = "9999"
 
 [server]

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -231,6 +231,7 @@ impl Admin {
 
     fn handle_version_request(session: &mut Session) {
         let _ = session.write(format!("VERSION {}\r\n", env!("CARGO_PKG_VERSION")).as_bytes());
+        session.finalize_response();
         ADMIN_RESPONSE_COMPOSE.increment();
     }
 
@@ -391,6 +392,7 @@ impl EventLoop for Admin {
                         session.consume(consumed);
 
                         match request {
+                            AdminRequest::FlushAll => {}
                             AdminRequest::Stats => {
                                 Self::handle_stats_request(session);
                             }

--- a/src/rust/protocol/src/admin.rs
+++ b/src/rust/protocol/src/admin.rs
@@ -14,6 +14,7 @@ use crate::*;
 // modules.
 #[derive(PartialEq, Eq, Debug)]
 pub enum AdminRequest {
+    FlushAll,
     Stats,
     Version,
     Quit,
@@ -45,6 +46,10 @@ impl Parse<AdminRequest> for AdminRequestParser {
                 }
             } else {
                 match &buffer[0..command_end] {
+                    b"flush_all" => Ok(ParseOk {
+                        message: AdminRequest::FlushAll,
+                        consumed: command_end + CRLF.len(),
+                    }),
                     b"stats" => Ok(ParseOk {
                         message: AdminRequest::Stats,
                         consumed: command_end + CRLF.len(),
@@ -78,6 +83,15 @@ mod tests {
         for buffer in buffers.iter() {
             assert_eq!(parser.parse(buffer), Err(ParseError::Incomplete));
         }
+    }
+
+    #[test]
+    fn parse_flush_all() {
+        let parser = AdminRequestParser::new();
+
+        let parsed = parser.parse(b"flush_all\r\n");
+        assert!(parsed.is_ok());
+        assert_eq!(parsed.unwrap().into_inner(), AdminRequest::FlushAll);
     }
 
     #[test]


### PR DESCRIPTION
Adds a 'flush_all' command to the admin protocol with a no-op
handler. This will enable internal tooling to connect to the admin
port and issue a 'flush_all' and have the connection remain open.

For #365 we will implement the actual functionality for this
command.