### PR TITLE
rust core: improve TLS negotiation behavior

### DIFF
--- a/src/rust/core/server/src/poll/mod.rs
+++ b/src/rust/core/server/src/poll/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use mio::event::Source;
 use mio::net::TcpListener;
 use mio::Events;
 use mio::Interest;
@@ -14,7 +15,6 @@ use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-// use mio::Poll;
 
 pub const LISTENER_TOKEN: Token = Token(usize::MAX - 1);
 pub const WAKER_TOKEN: Token = Token(usize::MAX);
@@ -80,7 +80,7 @@ impl Poll {
     }
 
     pub fn accept(&mut self) -> Result<(TcpStream, SocketAddr), std::io::Error> {
-        if let Some(ref listener) = self.listener {
+        if let Some(ref mut listener) = self.listener {
             let (stream, addr) = listener.accept()?;
 
             // disable Nagle's algorithm
@@ -142,14 +142,38 @@ impl Poll {
     }
 
     pub fn reregister(&mut self, token: Token) {
-        trace!("reregistering session: {}", token.0);
-        if let Some(session) = self.sessions.get_mut(token.0) {
-            if session.reregister(&self.poll).is_err() {
-                error!("Failed to reregister");
-                let _ = self.close_session(token);
+        match token {
+            LISTENER_TOKEN => {
+                if let Some(ref mut listener) = self.listener {
+                    if listener
+                        .reregister(self.poll.registry(), LISTENER_TOKEN, Interest::READABLE)
+                        .is_err()
+                    {
+                        warn!("reregister of listener failed, attempting to recover");
+                        let _ = listener.deregister(self.poll.registry());
+                        if listener
+                            .register(self.poll.registry(), LISTENER_TOKEN, Interest::READABLE)
+                            .is_err()
+                        {
+                            fatal!("reregister of listener failed and was unrecoverable");
+                        }
+                    }
+                }
             }
-        } else {
-            trace!("attempted to reregister non-existent session: {}", token.0);
+            WAKER_TOKEN => {
+                trace!("reregister of waker token is not supported");
+            }
+            _ => {
+                trace!("reregistering session: {}", token.0);
+                if let Some(session) = self.sessions.get_mut(token.0) {
+                    if session.reregister(&self.poll).is_err() {
+                        error!("failed to reregister session");
+                        let _ = self.close_session(token);
+                    }
+                } else {
+                    trace!("attempted to reregister non-existent session: {}", token.0);
+                }
+            }
         }
     }
 }

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -81,6 +81,9 @@ impl Listener {
     }
 
     /// Call accept one time
+    // TODO(bmartin): splitting accept and negotiation into separate threads
+    // would allow us to handle TLS handshake with multiple threads and avoid
+    // the overhead of re-registering the listener after each accept.
     fn do_accept(&mut self) {
         if let Ok((stream, _)) = self.poll.accept() {
             // handle TLS if it is configured

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -17,7 +17,6 @@ use mio::Events;
 use mio::Token;
 use queues::*;
 use session::{Session, TcpStream};
-use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -81,40 +80,37 @@ impl Listener {
         })
     }
 
-    /// Repeatedly call accept on the listener
+    /// Call accept one time
     fn do_accept(&mut self) {
-        loop {
-            match self.poll.accept() {
-                Ok((stream, _)) => {
-                    // handle TLS if it is configured
-                    if let Some(ssl_context) = &self.ssl_context {
-                        match Ssl::new(ssl_context).map(|v| v.accept(stream)) {
-                            // handle case where we have a fully-negotiated
-                            // TLS stream on accept()
-                            Ok(Ok(tls_stream)) => {
-                                self.add_established_tls_session(tls_stream);
-                            }
-                            // handle case where further negotiation is
-                            // needed
-                            Ok(Err(HandshakeError::WouldBlock(tls_stream))) => {
-                                self.add_handshaking_tls_session(tls_stream);
-                            }
-                            // some other error has occurred and we drop the
-                            // stream
-                            Ok(Err(_)) | Err(_) => {
-                                TCP_ACCEPT_EX.increment();
-                            }
-                        }
-                    } else {
-                        self.add_plain_session(stream);
-                    };
-                }
-                Err(e) => {
-                    if e.kind() == ErrorKind::WouldBlock {
-                        break;
+        if let Ok((stream, _)) = self.poll.accept() {
+            // handle TLS if it is configured
+            if let Some(ssl_context) = &self.ssl_context {
+                match Ssl::new(ssl_context).map(|v| v.accept(stream)) {
+                    // handle case where we have a fully-negotiated
+                    // TLS stream on accept()
+                    Ok(Ok(tls_stream)) => {
+                        self.add_established_tls_session(tls_stream);
+                    }
+                    // handle case where further negotiation is
+                    // needed
+                    Ok(Err(HandshakeError::WouldBlock(tls_stream))) => {
+                        self.add_handshaking_tls_session(tls_stream);
+                    }
+                    // some other error has occurred and we drop the
+                    // stream
+                    Ok(Err(e)) => {
+                        error!("accept failed: {}", e);
+                        TCP_ACCEPT_EX.increment();
+                    }
+                    Err(e) => {
+                        error!("accept failed: {}", e);
+                        TCP_ACCEPT_EX.increment();
                     }
                 }
-            }
+            } else {
+                self.add_plain_session(stream);
+            };
+            self.poll.reregister(LISTENER_TOKEN);
         }
     }
 
@@ -137,6 +133,7 @@ impl Listener {
             self.max_buffer_size,
         );
         if self.poll.add_session(session).is_err() {
+            error!("failed to register handshaking TLS session with epoll");
             TCP_ACCEPT_EX.increment();
         }
     }


### PR DESCRIPTION
Currently the listener thread is responsible for calling accept on
the `TcpListener` and driving TLS negotiation. Under heavy connect
pressure, we observe timeouts which may be due to contention
between accepting new TCP connections and driving the TLS
handshakes.

To conserve work put into partially negotiated TLS sessions, we
change the behavior of calling accept on the `TcpListener` to be
called only once per loop. This allows us to prioritize handling
partially negotiated TLS sessions to avoid timeouts during the
handshake phase.