### PR TITLE
rust/core: improve trace logging

### DIFF
--- a/src/rust/core/server/src/poll/mod.rs
+++ b/src/rust/core/server/src/poll/mod.rs
@@ -14,7 +14,6 @@ use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-// use mio::Poll;
 
 pub const LISTENER_TOKEN: Token = Token(usize::MAX - 1);
 pub const WAKER_TOKEN: Token = Token(usize::MAX);
@@ -110,8 +109,8 @@ impl Poll {
 
     /// Close an existing session
     pub fn close_session(&mut self, token: Token) -> Result<(), std::io::Error> {
-        trace!("closing session: {}", token.0);
         let mut session = self.remove_session(token)?;
+        trace!("closing session: {:?}", session);
         session.close();
         Ok(())
     }
@@ -119,6 +118,7 @@ impl Poll {
     /// Remove a session from the poller and return it to the caller
     pub fn remove_session(&mut self, token: Token) -> Result<Session, std::io::Error> {
         let mut session = self.take_session(token)?;
+        trace!("removing session: {:?}", session);
         session.deregister(&self.poll)?;
         Ok(session)
     }
@@ -142,8 +142,8 @@ impl Poll {
     }
 
     pub fn reregister(&mut self, token: Token) {
-        trace!("reregistering session: {}", token.0);
         if let Some(session) = self.sessions.get_mut(token.0) {
+            trace!("reregistering session: {:?}", session);
             if session.reregister(&self.poll).is_err() {
                 error!("Failed to reregister");
                 let _ = self.close_session(token);

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -90,6 +90,16 @@ pub struct Session {
     pending_bytes: usize,
 }
 
+impl std::fmt::Debug for Session {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        if let Ok(peer_addr) = self.peer_addr() {
+            write!(f, "{}", peer_addr)
+        } else {
+            write!(f, "no peer address")
+        }
+    }
+}
+
 impl Session {
     /// Create a new `Session` with  representing a plain `TcpStream` with
     /// internal buffers which can hold up to capacity bytes without


### PR DESCRIPTION
Improve the trace logging throughout rust core to reference the session peer address and print garbage bytes for bad requests. These changes make it easier to understand the flow for sessions, particularly in multi-worker configuration where session ids are not unique across workers.