### PR TITLE
rust: memcache protocol fixes

### DIFF
--- a/src/rust/core/server/src/threads/traits/event_loop.rs
+++ b/src/rust/core/server/src/threads/traits/event_loop.rs
@@ -92,6 +92,7 @@ pub trait EventLoop {
     fn handle_error(&mut self, token: Token) {
         if let Ok(session) = self.poll().get_mut_session(token) {
             trace!("handling error for session: {:?}", session);
+            let _ = session.flush();
             let _ = self.poll().close_session(token);
         } else {
             trace!(

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -180,7 +180,6 @@ fn parse_get(buffer: &[u8]) -> Result<ParseOk<MemcacheRequest>, ParseError> {
             Sequence::Crlf | Sequence::SpaceCrlf => {
                 if key_end > previous && key_end <= previous + MAX_KEY_LEN {
                     keys.push(buffer[previous..key_end].to_vec().into_boxed_slice());
-                    println!("whitespace sequence: {:?} with len: {}", whitespace, whitespace.len());
 
                     let consumed = key_end + whitespace.len();
 

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -166,7 +166,9 @@ fn parse_get(buffer: &[u8]) -> Result<ParseOk<MemcacheRequest>, ParseError> {
     while let Some((sequence, key_end)) = parse_state.next_sequence() {
         match sequence {
             Sequence::Space => {
-                if key_end <= previous || key_end > previous + MAX_KEY_LEN {
+                if key_end == previous {
+                    previous = key_end + whitespace.len();
+                } else if key_end < previous || key_end > previous + MAX_KEY_LEN {
                     return Err(ParseError::Invalid);
                 } else {
                     keys.push(buffer[previous..key_end].to_vec().into_boxed_slice());

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -120,9 +120,6 @@ impl<'a> ParseState<'a> {
                         self.position += 1;
                     }
                 }
-                b'\0' => {
-                    return None;
-                }
                 _ => {
                     self.position += 1;
                 }

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -180,6 +180,17 @@ fn delete() {
         }
         assert_eq!(request.consumed, buffer.len());
     }
+
+    // tricky edge-case where the key is 'noreply'
+    let buffer = b"delete  noreply\r\n";
+    let request = parser.parse(buffer).expect("parse failure");
+    if let MemcacheRequest::Delete { key, noreply } = request.message {
+        assert_eq!(key.as_ref(), b"noreply");
+        assert!(!noreply);
+    } else {
+        panic!("invalid parse result");
+    }
+    assert_eq!(request.consumed, buffer.len());
 }
 
 #[test]

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -223,6 +223,25 @@ fn incomplete() {
 }
 
 #[test]
+fn middle_whitespace() {
+    let parser = MemcacheRequestParser::default();
+
+    // get
+    let request = parser.parse(b"get  a  b    c    d           e\r\n").expect("parse failure");
+    if let MemcacheRequest::Get { keys } = request.message {
+        println!("keys: {:?}", keys);
+        assert_eq!(keys.len(), 5);
+        assert_eq!(keys[0].as_ref(), b"a");
+        assert_eq!(keys[1].as_ref(), b"b");
+        assert_eq!(keys[2].as_ref(), b"c");
+        assert_eq!(keys[3].as_ref(), b"d");
+        assert_eq!(keys[4].as_ref(), b"e");
+    } else {
+        panic!("invalid parse result");
+    }
+}
+
+#[test]
 fn trailing_whitespace() {
     let parser = MemcacheRequestParser::default();
 
@@ -294,7 +313,6 @@ fn invalid() {
     // invalid
     for request in &[
         "get \r\n",
-        "get this     is    malformed\r\n",
         "get\r\n",
         "get lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_\
         eiusmod_tempor_incididunt_ut_labore_et_dolore_magna_aliqua_Ut_enim_ad_\

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -17,6 +17,7 @@ fn get() {
         vec!["0", "1", "2"],
         vec!["espresso"],
         vec!["ice", "cofffee"],
+        vec!["ca0\0\0"],
     ];
 
     // covers get on single and multiple keys

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -312,6 +312,7 @@ fn invalid() {
 
     // invalid
     for request in &[
+        "get   \r\n",
         "get \r\n",
         "get\r\n",
         "get lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_\
@@ -352,6 +353,14 @@ fn pipelined() {
     if let MemcacheRequest::Get { keys } = request.message {
         assert!(keys.len() == 1);
         assert_eq!(keys[0].as_ref(), b"0");
+    } else {
+        panic!("invalid parse result");
+    }
+
+    let request = parser.parse(b"get t\x0d\x0a ").expect("parse failure");
+    if let MemcacheRequest::Get { keys } = request.message {
+        assert!(keys.len() == 1);
+        assert_eq!(keys[0].as_ref(), b"t");
     } else {
         panic!("invalid parse result");
     }

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -24,9 +24,7 @@ fn get() {
     for keyset in keysets {
         println!("keyset: {:?}", keyset);
         let buffer = format!("get {}\r\n", keyset.join(" "));
-        let request = parser
-            .parse(buffer.as_bytes())
-            .expect("parse failure");
+        let request = parser.parse(buffer.as_bytes()).expect("parse failure");
         if let MemcacheRequest::Get { keys } = request.message {
             println!("keys: {:?}", keys);
             assert_eq!(keys.len(), keyset.len());
@@ -67,9 +65,7 @@ fn gets() {
     for keyset in keysets {
         println!("keyset: {:?}", keyset);
         let buffer = format!("gets {}\r\n", keyset.join(" "));
-        let request = parser
-            .parse(buffer.as_bytes())
-            .expect("parse failure");
+        let request = parser.parse(buffer.as_bytes()).expect("parse failure");
         if let MemcacheRequest::Gets { keys } = request.message {
             println!("keys: {:?}", keys);
             assert_eq!(keys.len(), keyset.len());
@@ -110,9 +106,7 @@ fn set() {
     }
 
     let buffer = b"set 0 0 0 1 noreply\r\n0\r\n";
-    let request = parser
-        .parse(buffer)
-        .expect("parse failure");
+    let request = parser.parse(buffer).expect("parse failure");
     if let MemcacheRequest::Set { entry, noreply } = request.message {
         assert_eq!(entry.key(), b"0");
         assert_eq!(entry.value(), Some("0".as_bytes()));
@@ -128,9 +122,7 @@ fn cas() {
     let parser = MemcacheRequestParser::default();
 
     let buffer = b"cas 0 0 0 1 0\r\n0\r\n";
-    let request = parser
-        .parse(buffer)
-        .expect("parse failure");
+    let request = parser.parse(buffer).expect("parse failure");
     if let MemcacheRequest::Cas { entry, noreply } = request.message {
         assert_eq!(entry.key(), b"0");
         assert_eq!(entry.value(), Some("0".as_bytes()));
@@ -142,9 +134,7 @@ fn cas() {
     assert_eq!(request.consumed, buffer.len());
 
     let buffer = b"cas 0 0 0 1 0 noreply\r\n0\r\n";
-    let request = parser
-        .parse(buffer)
-        .expect("parse failure");
+    let request = parser.parse(buffer).expect("parse failure");
     if let MemcacheRequest::Cas { entry, noreply } = request.message {
         assert_eq!(entry.key(), b"0");
         assert_eq!(entry.value(), Some("0".as_bytes()));
@@ -167,9 +157,7 @@ fn delete() {
     for k in &keys {
         println!("key: {:?}", k);
         let buffer = format!("delete {}\r\n", k);
-        let request = parser
-            .parse(buffer.as_bytes())
-            .expect("parse failure");
+        let request = parser.parse(buffer.as_bytes()).expect("parse failure");
         if let MemcacheRequest::Delete { key, noreply } = request.message {
             assert_eq!(key.as_ref(), k.as_bytes());
             assert!(!noreply);
@@ -183,9 +171,7 @@ fn delete() {
     for k in keys {
         println!("key: {:?}", k);
         let buffer = format!("delete {} noreply\r\n", k);
-        let request = parser
-            .parse(buffer.as_bytes())
-            .expect("parse failure");
+        let request = parser.parse(buffer.as_bytes()).expect("parse failure");
         if let MemcacheRequest::Delete { key, noreply } = request.message {
             assert_eq!(key.as_ref(), k.as_bytes());
             assert!(noreply);
@@ -246,7 +232,9 @@ fn middle_whitespace() {
     let parser = MemcacheRequestParser::default();
 
     // get
-    let request = parser.parse(b"get  a  b    c    d           e\r\n").expect("parse failure");
+    let request = parser
+        .parse(b"get  a  b    c    d           e\r\n")
+        .expect("parse failure");
     if let MemcacheRequest::Get { keys } = request.message {
         println!("keys: {:?}", keys);
         assert_eq!(keys.len(), 5);

--- a/src/rust/protocol/src/memcache/wire/request/test.rs
+++ b/src/rust/protocol/src/memcache/wire/request/test.rs
@@ -358,13 +358,16 @@ fn invalid() {
 fn pipelined() {
     let parser = MemcacheRequestParser::default();
 
-    let request = parser.parse(b"get 0\r\nget 1\r\n").expect("parse failure");
+    // 2 get requests in the buffer, parsing once returns only the first
+    let buffer = b"get 0\r\nget 1\r\n";
+    let request = parser.parse(buffer).expect("parse failure");
     if let MemcacheRequest::Get { keys } = request.message {
         assert!(keys.len() == 1);
         assert_eq!(keys[0].as_ref(), b"0");
     } else {
         panic!("invalid parse result");
     }
+    assert_eq!(request.consumed, 7);
 
     let request = parser.parse(b"get t\x0d\x0a ").expect("parse failure");
     if let MemcacheRequest::Get { keys } = request.message {
@@ -373,4 +376,5 @@ fn pipelined() {
     } else {
         panic!("invalid parse result");
     }
+    assert_eq!(request.consumed, 7);
 }

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -95,6 +95,16 @@ pub fn tests() {
         "pipelined get and add (key 4, depth 2)",
         &[("get 4 \r\nadd 4 0 0 1\r\n1\r\n", Some("END\r\nSTORED\r\n"))],
     );
+    test(
+        "pipelined get and set (key 5, depth 2)",
+        &[("get 5 \r\nset 5 0 0 1 \r\n1\r\n", Some("END\r\nSTORED\r\n"))],
+    );
+    test(
+        "pipelined set and get (key 6, depth 3)",
+        &[("set 6 0 0 2 \r\nhi\r\nset 6 0 0 6\r\nhello!\r\nget 6 \r\n", Some("STORED\r\nSTORED\r\nVALUE 6 0 6\r\nhello!\r\nEND\r\n"))],
+    );
+
+    std::thread::sleep(Duration::from_millis(500));
 }
 
 // opens a new connection, operating on request + response pairs from the
@@ -132,10 +142,12 @@ fn test(name: &str, data: &[(&str, Option<&str>)]) {
 
         if let Some(response) = response {
             if stream.read(&mut buf).is_err() {
+                std::thread::sleep(Duration::from_millis(500));
                 panic!("error reading response");
             } else if response.as_bytes() != &buf[0..response.len()] {
                 error!("expected: {:?}", response.as_bytes());
                 error!("received: {:?}", &buf[0..response.len()]);
+                std::thread::sleep(Duration::from_millis(500));
                 panic!("status: failed\n");
             } else {
                 debug!("correct response");
@@ -146,10 +158,12 @@ fn test(name: &str, data: &[(&str, Option<&str>)]) {
                 debug!("got no response");
             } else {
                 error!("error reading response");
+                std::thread::sleep(Duration::from_millis(500));
                 panic!("status: failed\n");
             }
         } else {
             error!("expected no response");
+            std::thread::sleep(Duration::from_millis(500));
             panic!("status: failed\n");
         }
 

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -91,6 +91,10 @@ pub fn tests() {
         "pipelined get and invalid (key 4, depth 2)",
         &[("get 4\r\n ", Some("END\r\n"))],
     );
+    test(
+        "pipelined get and add (key 4, depth 2)",
+        &[("get 4 \r\nadd 4 0 0 1\r\n1\r\n", Some("END\r\nSTORED\r\n"))],
+    );
 }
 
 // opens a new connection, operating on request + response pairs from the

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -101,7 +101,10 @@ pub fn tests() {
     );
     test(
         "pipelined set and get (key 6, depth 3)",
-        &[("set 6 0 0 2 \r\nhi\r\nset 6 0 0 6\r\nhello!\r\nget 6 \r\n", Some("STORED\r\nSTORED\r\nVALUE 6 0 6\r\nhello!\r\nEND\r\n"))],
+        &[(
+            "set 6 0 0 2 \r\nhi\r\nset 6 0 0 6\r\nhello!\r\nget 6 \r\n",
+            Some("STORED\r\nSTORED\r\nVALUE 6 0 6\r\nhello!\r\nEND\r\n"),
+        )],
     );
 
     std::thread::sleep(Duration::from_millis(500));

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -87,6 +87,10 @@ pub fn tests() {
         "pipelined get (key: 4 depth: 2)",
         &[("get 4\r\nget 4\r\n", Some("END\r\nEND\r\n"))],
     );
+    test(
+        "pipelined get and invalid (key 4, depth 2)",
+        &[("get 4\r\n ", Some("END\r\n"))],
+    );
 }
 
 // opens a new connection, operating on request + response pairs from the


### PR DESCRIPTION
Bugfixes for memcache protocol handling.

Fix calculation of how many bytes to consume off the buffer.
Allow middle-whitespace in get request: eg `get  0\r\n` (note: two spaces)
Allow null bytes in key.
Adds some additional tests.

Fixes: #371 