### PR TITLE
rust/core: flush log before exiting

### DIFF
--- a/src/rust/core/server/src/process/builder.rs
+++ b/src/rust/core/server/src/process/builder.rs
@@ -54,7 +54,7 @@ where
             error!("failed to initialize TLS: {}", e);
             std::process::exit(1);
         });
-        let admin = Admin::new(admin_config, ssl_context, log_drain).unwrap_or_else(|e| {
+        let mut admin = Admin::new(admin_config, ssl_context, log_drain).unwrap_or_else(|e| {
             error!("failed to initialize admin: {}", e);
             std::process::exit(1);
         });
@@ -68,11 +68,13 @@ where
         // initialize server
         let ssl_context = common::ssl::ssl_context(tls_config).unwrap_or_else(|e| {
             error!("failed to initialize TLS: {}", e);
+            let _ = admin.log_flush();
             std::process::exit(1);
         });
         let mut listener = Listener::new(server_config, ssl_context, max_buffer_size)
             .unwrap_or_else(|e| {
                 error!("failed to initialize listener: {}", e);
+                let _ = admin.log_flush();
                 std::process::exit(1);
             });
         let mut session_queues = worker.session_queues(listener.waker());


### PR DESCRIPTION
During startup we use the logging framework to note any fatal
errors during initialization. However, the log might not be flushed
before program termination. This results in useful messages being
lost.

This change adds log flushing before termination so that we can get
useful messages about fatal errors during initialization.

Fixes #372 