### PR TITLE
segcache-rs: fix segment request stats

### DIFF
--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -5,6 +5,7 @@
 use crate::datapool::*;
 use crate::eviction::*;
 use crate::item::*;
+use crate::seg::{SEGMENT_REQUEST, SEGMENT_REQUEST_SUCCESS};
 use crate::segments::*;
 
 use core::num::NonZeroU32;
@@ -381,6 +382,8 @@ impl Segments {
         if self.free == 0 {
             None
         } else {
+            SEGMENT_REQUEST.increment();
+            SEGMENT_REQUEST_SUCCESS.increment();
             SEGMENT_FREE.decrement();
             self.free -= 1;
             let id = self.free_q;


### PR DESCRIPTION
Bugfix for segment request stats not incrementing unless eviction
was required.

Successful segment acquisition now results in stats being updated.