### PR TITLE
protocol/memcache: add request cardinality distribution stats

### DIFF
--- a/src/rust/entrystore/src/lib.rs
+++ b/src/rust/entrystore/src/lib.rs
@@ -4,8 +4,8 @@
 
 //! A collection of storage datastructures suitable for use within Pelikan. A
 //! typical storage module will implement one or more storage protocol traits in
-//! addition to the base `Storage` trait. For example [`SegCache`] implements
-//! both [`Storage`] and [`protocol::memcache::MemcacheStorage`].
+//! addition to the base `EntryStore` trait. For example [`Seg`] implements both
+//! [`EntryStore`] and [`protocol::memcache::MemcacheStorage`].
 
 mod noop;
 mod seg;

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -11,7 +11,7 @@ pub use response::*;
 use super::*;
 use crate::*;
 
-use metrics::{static_metrics, Counter, Relaxed, Heatmap};
+use metrics::{static_metrics, Counter, Heatmap, Relaxed};
 use rustcommon_time::{Duration, Instant};
 
 static_metrics! {
@@ -66,7 +66,7 @@ where
                     entries: self.get(keys),
                     cas: false,
                 }
-            },
+            }
             MemcacheRequest::Gets { ref keys } => {
                 GETS_CARDINALITY.increment(Instant::now(), keys.len() as _, 1);
                 MemcacheResult::Values {

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -24,9 +24,6 @@ static_metrics! {
     static GET_KEY_MISS: Counter;
 
     static GETS: Counter;
-    static GETS_CARDINALITY: Relaxed<Heatmap> = Relaxed::new(||
-        Heatmap::new(request::MAX_BATCH_SIZE as _, 3, Duration::from_secs(60), Duration::from_secs(1))
-    );
     static GETS_KEY: Counter;
     static GETS_KEY_HIT: Counter;
     static GETS_KEY_MISS: Counter;
@@ -68,7 +65,6 @@ where
                 }
             }
             MemcacheRequest::Gets { ref keys } => {
-                GETS_CARDINALITY.increment(Instant::now(), keys.len() as _, 1);
                 MemcacheResult::Values {
                     entries: self.get(keys),
                     cas: true,

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -64,12 +64,10 @@ where
                     cas: false,
                 }
             }
-            MemcacheRequest::Gets { ref keys } => {
-                MemcacheResult::Values {
-                    entries: self.get(keys),
-                    cas: true,
-                }
-            }
+            MemcacheRequest::Gets { ref keys } => MemcacheResult::Values {
+                entries: self.get(keys),
+                cas: true,
+            },
             MemcacheRequest::Set { ref entry, noreply } => {
                 let response = match self.set(entry) {
                     Ok(_) => MemcacheResult::Stored,

--- a/src/rust/protocol/src/memcache/wire/request/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/request/mod.rs
@@ -11,7 +11,7 @@ mod test;
 use crate::memcache::MemcacheEntry;
 pub use command::MemcacheCommand;
 
-pub use parse::MemcacheRequestParser;
+pub use parse::{MemcacheRequestParser, MAX_BATCH_SIZE};
 
 pub const NOREPLY: &str = "noreply";
 

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 
 const MAX_COMMAND_LEN: usize = 16;
 const MAX_KEY_LEN: usize = 250;
-const MAX_BATCH_SIZE: usize = 1024;
+pub const MAX_BATCH_SIZE: usize = 1024;
 
 const DEFAULT_MAX_VALUE_SIZE: usize = usize::MAX / 2;
 


### PR DESCRIPTION
Adds stats to track request cardinality for GET and GETS commands.
This allows us to get insight into batch size distribution over
time which can provide better insight into traffic patterns.