### PR TITLE
rust/core: track depth of storage queue

### DIFF
--- a/src/rust/core/server/src/threads/worker/mod.rs
+++ b/src/rust/core/server/src/threads/worker/mod.rs
@@ -10,12 +10,14 @@ mod single;
 mod storage;
 
 pub use self::storage::StorageWorker;
-use mio::Token;
 pub use multi::MultiWorker;
 pub use single::SingleWorker;
 
 use super::EventLoop;
-use metrics::{static_metrics, Counter};
+
+use metrics::{static_metrics, Counter, Heatmap, Relaxed};
+use mio::Token;
+use rustcommon_time::Duration;
 
 static_metrics! {
     static WORKER_EVENT_LOOP: Counter;
@@ -25,6 +27,9 @@ static_metrics! {
     static WORKER_EVENT_READ: Counter;
 
     static STORAGE_EVENT_LOOP: Counter;
+    static STORAGE_QUEUE_DEPTH: Relaxed<Heatmap> = Relaxed::new(||
+        Heatmap::new(1_000_000, 3, Duration::from_secs(60), Duration::from_secs(1))
+    );
 
     static PROCESS_REQ: Counter;
 }

--- a/src/rust/core/server/src/threads/worker/storage.rs
+++ b/src/rust/core/server/src/threads/worker/storage.rs
@@ -14,6 +14,7 @@ use mio::Token;
 use mio::Waker;
 use protocol::{Compose, Execute};
 use queues::{QueueError, QueuePair, QueuePairs};
+use rustcommon_time::Instant;
 use std::sync::Arc;
 
 // TODO(bmartin): this *should* be plenty safe, the queue should rarely ever be
@@ -97,6 +98,8 @@ where
 
             if !events.is_empty() {
                 let mut worker_pending = self.worker_queues.pending();
+                let total_pending: usize = worker_pending.iter().sum();
+                STORAGE_QUEUE_DEPTH.increment(Instant::now(), total_pending as _, 1);
 
                 trace!("handling events");
                 let mut empty = false;


### PR DESCRIPTION
Adds a new metric which tracks the distribution of the storage
queue depth at the start of each iteration.