### PR TITLE
WIP: storage/seg: add support for increment and decrement

### DIFF
--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -13,9 +13,12 @@ impl MemcacheStorage for Seg {
             if let Some(item) = self.data.get(key) {
                 let o = item.optional().unwrap_or(&[0, 0, 0, 0]);
                 let flags = u32::from_be_bytes([o[0], o[1], o[2], o[3]]);
+                let value = item.value();
+                let mut owned_value = vec![0; value.len()];
+                let _ = value.write_all_to(&mut owned_value);
                 items.push(MemcacheEntry {
                     key: item.key().to_vec().into_boxed_slice(),
-                    value: Some(item.value().to_vec().into_boxed_slice()),
+                    value: Some(owned_value.into_boxed_slice()),
                     flags,
                     cas: Some(item.cas().into()),
                     ttl: None,

--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -14,7 +14,7 @@ impl MemcacheStorage for Seg {
                 let o = item.optional().unwrap_or(&[0, 0, 0, 0]);
                 let flags = u32::from_be_bytes([o[0], o[1], o[2], o[3]]);
                 let value = item.value();
-                let mut owned_value = vec![0; value.len()];
+                let mut owned_value = Vec::with_capacity(value.len());
                 let _ = value.write_all_to(&mut owned_value);
                 items.push(MemcacheEntry {
                     key: item.key().to_vec().into_boxed_slice(),

--- a/src/rust/storage/seg/src/error.rs
+++ b/src/rust/storage/seg/src/error.rs
@@ -23,4 +23,6 @@ pub enum SegError<'a> {
     NotFound,
     #[error("data corruption detected")]
     DataCorrupted,
+    #[error("item is not numeric")]
+    NotNumeric,
 }

--- a/src/rust/storage/seg/src/item/mod.rs
+++ b/src/rust/storage/seg/src/item/mod.rs
@@ -7,13 +7,18 @@
 mod header;
 mod raw;
 mod reserved;
+mod value;
+
+pub use value::Value;
 
 #[cfg(any(feature = "magic", feature = "debug"))]
 pub(crate) use header::ITEM_MAGIC_SIZE;
-
 pub(crate) use header::{ItemHeader, ITEM_HDR_SIZE};
 pub(crate) use raw::RawItem;
 pub(crate) use reserved::ReservedItem;
+pub(crate) use value::TypedValue;
+
+use crate::SegError;
 
 /// Items are the base unit of data stored within the cache.
 pub struct Item {
@@ -44,7 +49,7 @@ impl Item {
     }
 
     /// Borrow the item value
-    pub fn value(&self) -> &[u8] {
+    pub fn value(&self) -> Value {
         self.raw.value()
     }
 
@@ -56,6 +61,14 @@ impl Item {
     /// Borrow the optional data
     pub fn optional(&self) -> Option<&[u8]> {
         self.raw.optional()
+    }
+
+    pub(crate) fn increment(&mut self, rhs: u64) -> Result<u64, SegError> {
+        self.raw.increment(rhs)
+    }
+
+    pub(crate) fn decrement(&mut self, rhs: u64) -> Result<u64, SegError> {
+        self.raw.decrement(rhs)
     }
 }
 

--- a/src/rust/storage/seg/src/item/raw.rs
+++ b/src/rust/storage/seg/src/item/raw.rs
@@ -7,8 +7,8 @@
 //! Unlike an [`Item`], the [`RawItem`] does not contain any fields which are
 //! shared within a hash bucket such as the CAS value.
 
-use crate::SegError;
 use crate::item::*;
+use crate::SegError;
 use std::convert::TryInto;
 
 /// The raw byte-level representation of an item

--- a/src/rust/storage/seg/src/item/reserved.rs
+++ b/src/rust/storage/seg/src/item/reserved.rs
@@ -5,8 +5,8 @@
 //! A reserved item is an item which has been allocated, but has not been
 //! defined or linked in the hashtable.
 
-use crate::Value;
 use crate::RawItem;
+use crate::Value;
 use core::num::NonZeroU32;
 
 /// Represents an item which has been allocated but is not defined or linked in

--- a/src/rust/storage/seg/src/item/reserved.rs
+++ b/src/rust/storage/seg/src/item/reserved.rs
@@ -5,6 +5,7 @@
 //! A reserved item is an item which has been allocated, but has not been
 //! defined or linked in the hashtable.
 
+use crate::Value;
 use crate::RawItem;
 use core::num::NonZeroU32;
 
@@ -24,7 +25,7 @@ impl ReservedItem {
     }
 
     /// Store the key, value, and optional data into the item
-    pub fn define(&mut self, key: &[u8], value: &[u8], optional: &[u8]) {
+    pub fn define(&mut self, key: &[u8], value: &Value, optional: &[u8]) {
         self.item.define(key, value, optional)
     }
 

--- a/src/rust/storage/seg/src/item/value.rs
+++ b/src/rust/storage/seg/src/item/value.rs
@@ -55,15 +55,9 @@ impl Value<'_> {
     /// length.
     pub fn write_all_to<W: Write>(&self, mut dst: W) -> Result<(), std::io::Error> {
         match self.inner {
-            TypedValue::Bytes(v) => {
-                dst.write_all(v)
-            },
-            TypedValue::OwnedBytes(ref v) => {
-                dst.write_all(v)
-            }
-            TypedValue::U64(v) => {
-                dst.write_all(format!("{}", v).as_bytes())
-            },
+            TypedValue::Bytes(v) => dst.write_all(v),
+            TypedValue::OwnedBytes(ref v) => dst.write_all(v),
+            TypedValue::U64(v) => dst.write_all(format!("{}", v).as_bytes()),
         }
     }
 }
@@ -81,7 +75,7 @@ impl<'a> core::fmt::Debug for Value<'a> {
 impl<'a, const N: usize> From<[u8; N]> for Value<'a> {
     fn from(other: [u8; N]) -> Self {
         Value {
-            inner: TypedValue::OwnedBytes(Box::new(other))
+            inner: TypedValue::OwnedBytes(Box::new(other)),
         }
     }
 }
@@ -89,7 +83,7 @@ impl<'a, const N: usize> From<[u8; N]> for Value<'a> {
 impl<'a, const N: usize> From<&'a [u8; N]> for Value<'a> {
     fn from(other: &'a [u8; N]) -> Self {
         Value {
-            inner: TypedValue::Bytes(&other[0..N])
+            inner: TypedValue::Bytes(&other[0..N]),
         }
     }
 }
@@ -97,7 +91,7 @@ impl<'a, const N: usize> From<&'a [u8; N]> for Value<'a> {
 impl<'a> From<Box<[u8]>> for Value<'a> {
     fn from(other: Box<[u8]>) -> Self {
         Value {
-            inner: TypedValue::OwnedBytes(other)
+            inner: TypedValue::OwnedBytes(other),
         }
     }
 }
@@ -105,7 +99,7 @@ impl<'a> From<Box<[u8]>> for Value<'a> {
 impl<'a> From<&'a [u8]> for Value<'a> {
     fn from(other: &'a [u8]) -> Self {
         Value {
-            inner: TypedValue::Bytes(other)
+            inner: TypedValue::Bytes(other),
         }
     }
 }
@@ -113,7 +107,7 @@ impl<'a> From<&'a [u8]> for Value<'a> {
 impl<'a> From<Vec<u8>> for Value<'a> {
     fn from(other: Vec<u8>) -> Self {
         Value {
-            inner: TypedValue::OwnedBytes(other.into_boxed_slice())
+            inner: TypedValue::OwnedBytes(other.into_boxed_slice()),
         }
     }
 }
@@ -121,7 +115,7 @@ impl<'a> From<Vec<u8>> for Value<'a> {
 impl<'a> From<&'a Vec<u8>> for Value<'a> {
     fn from(other: &'a Vec<u8>) -> Self {
         Value {
-            inner: TypedValue::Bytes(other)
+            inner: TypedValue::Bytes(other),
         }
     }
 }
@@ -129,7 +123,7 @@ impl<'a> From<&'a Vec<u8>> for Value<'a> {
 impl<'a> From<u64> for Value<'a> {
     fn from(other: u64) -> Self {
         Value {
-            inner: TypedValue::U64(other)
+            inner: TypedValue::U64(other),
         }
     }
 }
@@ -137,15 +131,9 @@ impl<'a> From<u64> for Value<'a> {
 impl<'a> PartialEq<[u8]> for Value<'a> {
     fn eq(&self, rhs: &[u8]) -> bool {
         match self.inner {
-            TypedValue::Bytes(v) => {
-                v == rhs
-            }
-            TypedValue::OwnedBytes(ref v) => {
-                v.as_ref() == rhs
-            }
-            TypedValue::U64(_) => {
-                false
-            }
+            TypedValue::Bytes(v) => v == rhs,
+            TypedValue::OwnedBytes(ref v) => v.as_ref() == rhs,
+            TypedValue::U64(_) => false,
         }
     }
 }
@@ -153,15 +141,9 @@ impl<'a> PartialEq<[u8]> for Value<'a> {
 impl<'a, const N: usize> PartialEq<[u8; N]> for Value<'a> {
     fn eq(&self, rhs: &[u8; N]) -> bool {
         match self.inner {
-            TypedValue::Bytes(v) => {
-                v == rhs
-            }
-            TypedValue::OwnedBytes(ref v) => {
-                v.as_ref() == rhs
-            }
-            TypedValue::U64(_) => {
-                false
-            }
+            TypedValue::Bytes(v) => v == rhs,
+            TypedValue::OwnedBytes(ref v) => v.as_ref() == rhs,
+            TypedValue::U64(_) => false,
         }
     }
 }
@@ -169,15 +151,9 @@ impl<'a, const N: usize> PartialEq<[u8; N]> for Value<'a> {
 impl<'a, const N: usize> PartialEq<&[u8; N]> for Value<'a> {
     fn eq(&self, rhs: &&[u8; N]) -> bool {
         match self.inner {
-            TypedValue::Bytes(v) => {
-                v == *rhs
-            }
-            TypedValue::OwnedBytes(ref v) => {
-                v.as_ref() == *rhs
-            }
-            TypedValue::U64(_) => {
-                false
-            }
+            TypedValue::Bytes(v) => v == *rhs,
+            TypedValue::OwnedBytes(ref v) => v.as_ref() == *rhs,
+            TypedValue::U64(_) => false,
         }
     }
 }
@@ -185,16 +161,9 @@ impl<'a, const N: usize> PartialEq<&[u8; N]> for Value<'a> {
 impl<'a> PartialEq<u64> for Value<'a> {
     fn eq(&self, rhs: &u64) -> bool {
         match self.inner {
-            TypedValue::Bytes(_) => {
-                false
-            }
-            TypedValue::OwnedBytes(_) => {
-                false
-            }
-            TypedValue::U64(v) => {
-                v == *rhs
-            }
+            TypedValue::Bytes(_) => false,
+            TypedValue::OwnedBytes(_) => false,
+            TypedValue::U64(v) => v == *rhs,
         }
     }
 }
-

--- a/src/rust/storage/seg/src/item/value.rs
+++ b/src/rust/storage/seg/src/item/value.rs
@@ -1,0 +1,200 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+//! A mostly opaque representation of an item's value to allow a it to carry
+//! type information.
+
+use std::io::Write;
+
+pub struct Value<'a> {
+    pub(crate) inner: TypedValue<'a>,
+}
+
+#[derive(PartialEq)]
+pub enum TypedValue<'a> {
+    Bytes(&'a [u8]),
+    U64(u64),
+    OwnedBytes(Box<[u8]>),
+}
+
+impl Value<'_> {
+    /// The length of the value in bytes for the internal representation
+    pub(crate) fn packed_len(&self) -> usize {
+        match self.inner {
+            TypedValue::Bytes(v) => v.len(),
+            TypedValue::OwnedBytes(ref v) => v.len(),
+            TypedValue::U64(_) => core::mem::size_of::<u64>(),
+        }
+    }
+
+    /// The length of the value in bytes as it would be in a serialized format.
+    ///
+    /// *NOTE*: numeric types are serialized in a string format and not as the
+    /// raw byte representation. This means that these types will be variable
+    /// length.
+    pub fn len(&self) -> usize {
+        match self.inner {
+            TypedValue::Bytes(v) => v.len(),
+            TypedValue::OwnedBytes(ref v) => v.len(),
+            TypedValue::U64(v) => format!("{}", v).as_bytes().len(),
+        }
+    }
+
+    /// Returns true if the value has no size. For example, if the value is a
+    /// byte slice with zero length.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Writes the value to the provided writer. This can be used to serialize
+    /// the value onto the wire.
+    ///
+    /// *NOTE*: numeric types are serialized in a string format and not as the
+    /// raw byte representation. This means that these types will be variable
+    /// length.
+    pub fn write_all_to<W: Write>(&self, mut dst: W) -> Result<(), std::io::Error> {
+        match self.inner {
+            TypedValue::Bytes(v) => {
+                dst.write_all(v)
+            },
+            TypedValue::OwnedBytes(ref v) => {
+                dst.write_all(v)
+            }
+            TypedValue::U64(v) => {
+                dst.write_all(format!("{}", v).as_bytes())
+            },
+        }
+    }
+}
+
+impl<'a> core::fmt::Debug for Value<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match &self.inner {
+            TypedValue::Bytes(v) => write!(f, "{:?}", v),
+            TypedValue::OwnedBytes(v) => write!(f, "{:?}", v),
+            TypedValue::U64(v) => write!(f, "{:?}", v),
+        }
+    }
+}
+
+impl<'a, const N: usize> From<[u8; N]> for Value<'a> {
+    fn from(other: [u8; N]) -> Self {
+        Value {
+            inner: TypedValue::OwnedBytes(Box::new(other))
+        }
+    }
+}
+
+impl<'a, const N: usize> From<&'a [u8; N]> for Value<'a> {
+    fn from(other: &'a [u8; N]) -> Self {
+        Value {
+            inner: TypedValue::Bytes(&other[0..N])
+        }
+    }
+}
+
+impl<'a> From<Box<[u8]>> for Value<'a> {
+    fn from(other: Box<[u8]>) -> Self {
+        Value {
+            inner: TypedValue::OwnedBytes(other)
+        }
+    }
+}
+
+impl<'a> From<&'a [u8]> for Value<'a> {
+    fn from(other: &'a [u8]) -> Self {
+        Value {
+            inner: TypedValue::Bytes(other)
+        }
+    }
+}
+
+impl<'a> From<Vec<u8>> for Value<'a> {
+    fn from(other: Vec<u8>) -> Self {
+        Value {
+            inner: TypedValue::OwnedBytes(other.into_boxed_slice())
+        }
+    }
+}
+
+impl<'a> From<&'a Vec<u8>> for Value<'a> {
+    fn from(other: &'a Vec<u8>) -> Self {
+        Value {
+            inner: TypedValue::Bytes(other)
+        }
+    }
+}
+
+impl<'a> From<u64> for Value<'a> {
+    fn from(other: u64) -> Self {
+        Value {
+            inner: TypedValue::U64(other)
+        }
+    }
+}
+
+impl<'a> PartialEq<[u8]> for Value<'a> {
+    fn eq(&self, rhs: &[u8]) -> bool {
+        match self.inner {
+            TypedValue::Bytes(v) => {
+                v == rhs
+            }
+            TypedValue::OwnedBytes(ref v) => {
+                v.as_ref() == rhs
+            }
+            TypedValue::U64(_) => {
+                false
+            }
+        }
+    }
+}
+
+impl<'a, const N: usize> PartialEq<[u8; N]> for Value<'a> {
+    fn eq(&self, rhs: &[u8; N]) -> bool {
+        match self.inner {
+            TypedValue::Bytes(v) => {
+                v == rhs
+            }
+            TypedValue::OwnedBytes(ref v) => {
+                v.as_ref() == rhs
+            }
+            TypedValue::U64(_) => {
+                false
+            }
+        }
+    }
+}
+
+impl<'a, const N: usize> PartialEq<&[u8; N]> for Value<'a> {
+    fn eq(&self, rhs: &&[u8; N]) -> bool {
+        match self.inner {
+            TypedValue::Bytes(v) => {
+                v == *rhs
+            }
+            TypedValue::OwnedBytes(ref v) => {
+                v.as_ref() == *rhs
+            }
+            TypedValue::U64(_) => {
+                false
+            }
+        }
+    }
+}
+
+impl<'a> PartialEq<u64> for Value<'a> {
+    fn eq(&self, rhs: &u64) -> bool {
+        match self.inner {
+            TypedValue::Bytes(_) => {
+                false
+            }
+            TypedValue::OwnedBytes(_) => {
+                false
+            }
+            TypedValue::U64(v) => {
+                v == *rhs
+            }
+        }
+    }
+}
+

--- a/src/rust/storage/seg/src/lib.rs
+++ b/src/rust/storage/seg/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::seg::Seg;
 pub use builder::Builder;
 pub use error::SegError;
 pub use eviction::Policy;
-pub use item::Item;
+pub use item::{Item, Value};
 
 // publicly exported items from external crates
 pub use rustcommon_time::CoarseDuration;

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -26,7 +26,6 @@ pub struct Seg {
     pub(crate) ttl_buckets: TtlBuckets,
 }
 
-
 impl Seg {
     /// Returns a new `Builder` which is used to configure and construct a
     /// `Seg` instance.
@@ -121,7 +120,8 @@ impl Seg {
         let optional = optional.unwrap_or(&[]);
 
         // calculate size for item
-        let size = (((ITEM_HDR_SIZE + key.len() + value.packed_len() + optional.len()) >> 3) + 1) << 3;
+        let size =
+            (((ITEM_HDR_SIZE + key.len() + value.packed_len() + optional.len()) >> 3) + 1) << 3;
 
         // try to get a `ReservedItem`
         let mut retries = RESERVE_RETRIES;

--- a/src/rust/storage/seg/src/tests.rs
+++ b/src/rust/storage/seg/src/tests.rs
@@ -198,7 +198,9 @@ fn incr_decr() {
     assert_eq!(item.value(), 0, "item is: {:?}", item);
     cache.increment(b"coffee", 1).expect("failed to increment");
     assert_eq!(item.value(), 1, "item is: {:?}", item);
-    cache.increment(b"coffee", u64::MAX - 1).expect("failed to increment");
+    cache
+        .increment(b"coffee", u64::MAX - 1)
+        .expect("failed to increment");
     assert_eq!(item.value(), u64::MAX, "item is: {:?}", item);
     cache.increment(b"coffee", 1).expect("failed to increment");
     assert_eq!(item.value(), 0, "item is: {:?}", item);


### PR DESCRIPTION
Adds support for incrementing and decrementing values stored in
the seg storage. This is necessary for implementing the incr/decr
commands in the segcache backend.