### PR TITLE
rust: fix tls certificate chain loading

### DIFF
--- a/config/segcache.toml
+++ b/config/segcache.toml
@@ -82,3 +82,5 @@ sample = 100
 # certificate = "server.crt"
 # server private key
 # private_key = "server.key"
+# ca certificate file used as the root of trust
+# ca_file = "ca.crt"

--- a/src/rust/common/src/ssl.rs
+++ b/src/rust/common/src/ssl.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use boring::x509::X509;
 use boring::ssl::*;
 use config::TlsConfig;
 use std::io::{Error, ErrorKind};
@@ -9,28 +10,63 @@ use std::io::{Error, ErrorKind};
 pub fn ssl_context(config: &TlsConfig) -> Result<Option<SslContext>, std::io::Error> {
     let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())?;
 
-    if let Some(f) = config.certificate_chain() {
-        builder
-            .set_ca_file(f)
-            .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
-    } else {
-        return Ok(None);
-    }
-
-    if let Some(f) = config.certificate() {
-        builder
-            .set_certificate_file(f, SslFiletype::PEM)
-            .map_err(|_| Error::new(ErrorKind::Other, "bad certificate"))?;
-    } else {
-        return Ok(None);
-    }
-
+    // load the private key
     if let Some(f) = config.private_key() {
         builder
             .set_private_key_file(f, SslFiletype::PEM)
             .map_err(|_| Error::new(ErrorKind::Other, "bad private key"))?;
     } else {
         return Ok(None);
+    }
+
+    // load the ca file
+    if let Some(f) = config.ca_file() {
+        builder
+            .set_ca_file(f)
+            .map_err(|_| Error::new(ErrorKind::Other, "bad ca file"))?;
+    } else {
+        return Ok(None);
+    }
+
+    let chain = config.certificate_chain().is_some();
+    let cert = config.certificate().is_some();
+
+    if chain && !cert {
+        // assume we have a complete chain: leaf + intermediates + root in one file
+        if let Some(f) = config.certificate_chain() {
+            builder
+                .set_certificate_chain_file(f)
+                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
+        } else {
+            return Ok(None);
+        }
+    } else if cert && chain {
+        // assume we have the leaf in a standalone file, and the intermediates + root in another file
+
+        // first load the leaf
+        if let Some(f) = config.certificate() {
+            builder
+                .set_certificate_file(f, SslFiletype::PEM)
+                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
+        } else {
+            return Ok(None);
+        }
+
+        // append the rest of the chain
+        if let Some(f) = config.certificate_chain() {
+            let pem = std::fs::read(f).map_err(|_| Error::new(ErrorKind::Other, "failed to read certificate chain"))?;
+            let chain = X509::stack_from_pem(&pem).map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
+            for cert in chain {
+                builder
+                    .add_extra_chain_cert(cert)
+                    .map_err(|_| Error::new(ErrorKind::Other, "bad certificate in chain"))?;
+            }
+        } else {
+            return Ok(None);
+        }
+
+    } else {
+        return Err(Error::new(ErrorKind::Other, "no certificate chain provided"));
     }
 
     Ok(Some(builder.build().into_context()))

--- a/src/rust/common/src/ssl.rs
+++ b/src/rust/common/src/ssl.rs
@@ -2,15 +2,28 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use boring::x509::X509;
 use boring::ssl::*;
+use boring::x509::X509;
 use config::TlsConfig;
 use std::io::{Error, ErrorKind};
 
+/// Create an `SslContext` from the given `TlsConfig`. Returns an error if there
+/// was any issues during initialization. Otherwise, returns a `SslContext`
+/// wrapped in an option, where the `None` variant indicates that TLS should not
+/// be used.
 pub fn ssl_context(config: &TlsConfig) -> Result<Option<SslContext>, std::io::Error> {
     let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())?;
 
+    // we use xor here to check if we have an under-specified tls configuration
+    if config.private_key().is_some()
+        ^ (config.certificate_chain().is_some() || config.certificate().is_some())
+    {
+        return Err(Error::new(ErrorKind::Other, "incomplete tls configuration"));
+    }
+
     // load the private key
+    //
+    // NOTE: this is required, so we return `Ok(None)` if it is not specified
     if let Some(f) = config.private_key() {
         builder
             .set_private_key_file(f, SslFiletype::PEM)
@@ -20,53 +33,56 @@ pub fn ssl_context(config: &TlsConfig) -> Result<Option<SslContext>, std::io::Er
     }
 
     // load the ca file
+    //
+    // NOTE: this is optional, so we do not return `Ok(None)` when it has not
+    // been specified
     if let Some(f) = config.ca_file() {
         builder
             .set_ca_file(f)
             .map_err(|_| Error::new(ErrorKind::Other, "bad ca file"))?;
-    } else {
-        return Ok(None);
     }
 
-    let chain = config.certificate_chain().is_some();
-    let cert = config.certificate().is_some();
+    match (config.certificate_chain(), config.certificate()) {
+        (Some(chain), Some(cert)) => {
+            // assume we have the leaf in a standalone file, and the
+            // intermediates + root in another file
 
-    if chain && !cert {
-        // assume we have a complete chain: leaf + intermediates + root in one file
-        if let Some(f) = config.certificate_chain() {
+            // first load the leaf
             builder
-                .set_certificate_chain_file(f)
-                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
-        } else {
-            return Ok(None);
-        }
-    } else if cert && chain {
-        // assume we have the leaf in a standalone file, and the intermediates + root in another file
+                .set_certificate_file(cert, SslFiletype::PEM)
+                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate file"))?;
 
-        // first load the leaf
-        if let Some(f) = config.certificate() {
-            builder
-                .set_certificate_file(f, SslFiletype::PEM)
+            // append the rest of the chain
+            let pem = std::fs::read(chain)
+                .map_err(|_| Error::new(ErrorKind::Other, "failed to read certificate chain"))?;
+            let chain = X509::stack_from_pem(&pem)
                 .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
-        } else {
-            return Ok(None);
-        }
-
-        // append the rest of the chain
-        if let Some(f) = config.certificate_chain() {
-            let pem = std::fs::read(f).map_err(|_| Error::new(ErrorKind::Other, "failed to read certificate chain"))?;
-            let chain = X509::stack_from_pem(&pem).map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
             for cert in chain {
                 builder
                     .add_extra_chain_cert(cert)
                     .map_err(|_| Error::new(ErrorKind::Other, "bad certificate in chain"))?;
             }
-        } else {
+        }
+        (Some(chain), None) => {
+            // assume we have a complete chain: leaf + intermediates + root in
+            // one file
+
+            // load the entire chain
+            builder
+                .set_certificate_chain_file(chain)
+                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate chain"))?;
+        }
+        (None, Some(cert)) => {
+            // this will just load the leaf certificate from the file
+            builder
+                .set_certificate_file(cert, SslFiletype::PEM)
+                .map_err(|_| Error::new(ErrorKind::Other, "bad certificate file"))?;
+        }
+        (None, None) => {
+            // if we have neither a chain nor a leaf cert to load, we return no
+            // ssl context
             return Ok(None);
         }
-
-    } else {
-        return Err(Error::new(ErrorKind::Other, "no certificate chain provided"));
     }
 
     Ok(Some(builder.build().into_context()))

--- a/src/rust/config/src/tls.rs
+++ b/src/rust/config/src/tls.rs
@@ -13,6 +13,8 @@ pub struct TlsConfig {
     private_key: Option<String>,
     #[serde(default)]
     certificate: Option<String>,
+    #[serde(default)]
+    ca_file: Option<String>,
 }
 
 // implementation
@@ -27,5 +29,9 @@ impl TlsConfig {
 
     pub fn certificate(&self) -> Option<String> {
         self.certificate.clone()
+    }
+
+    pub fn ca_file(&self) -> Option<String> {
+        self.ca_file.clone()
     }
 }


### PR DESCRIPTION
Fixes for TLS certificate chain loading when presented with both
a server cert and chain.