### PR TITLE
update rustcommon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,18 +567,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f7a548defb4c688d16c333586fe92907d774c2df78037ab098b8f7202bf7fb"
+checksum = "edd4ad156b9934dc21cad96fd17278a7cb6f30a5657a9d976cd7b71d6d49c02c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcc41894750103e29b7d4b0763bbf807eb723ce78626c461cf6dadb84124ac"
+checksum = "73fd9dc7072de7168cbdaba9125e8f742cd3a965aa12bde994b4611a174488d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "serde",
 ]
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "rustcommon-atomics",
  "rustcommon-histogram",
@@ -1051,7 +1051,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "linkme",
  "once_cell",
@@ -1084,8 +1084,8 @@ dependencies = [
 
 [[package]]
 name = "rustcommon-time"
-version = "0.0.10"
-source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+version = "0.0.11"
+source = "git+https://github.com/twitter/rustcommon?rev=c8aeeb605b3bdc42c2c309ac8c096f17fed5380d#c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"
 dependencies = [
  "lazy_static",
  "libc",

--- a/src/rust/common/Cargo.toml
+++ b/src/rust/common/Cargo.toml
@@ -12,11 +12,11 @@ license = "Apache-2.0"
 
 [dependencies]
 boring = "2.0.0"
-rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "cd7411b687150d707a8cda5ec116eee79ef3a50b" }
+rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "c8aeeb605b3bdc42c2c309ac8c096f17fed5380d" }
 serde = { version = "1.0.117", features = ["derive"] }
 
 [dependencies.rustcommon-metrics]
 git = "https://github.com/twitter/rustcommon"
 package="rustcommon-metrics-v2"
 features = ["heatmap"]
-rev = "cd7411b687150d707a8cda5ec116eee79ef3a50b"
+rev = "c8aeeb605b3bdc42c2c309ac8c096f17fed5380d"

--- a/src/rust/common/src/expiry.rs
+++ b/src/rust/common/src/expiry.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_time::{CoarseDuration, Duration};
+use crate::time::*;
 use serde::{Deserialize, Serialize};
 
 use std::time::SystemTime;
@@ -70,11 +70,11 @@ impl Expiry {
         }
     }
 
-    pub fn as_duration(&self) -> Duration {
-        Duration::from_secs(self.as_secs().into())
+    pub fn as_duration(&self) -> Duration<Nanoseconds<u64>> {
+        Duration::<Nanoseconds<u64>>::from_secs(self.as_secs().into())
     }
 
-    pub fn as_coarse_duration(&self) -> CoarseDuration {
-        CoarseDuration::from_secs(self.as_secs())
+    pub fn as_coarse_duration(&self) -> Duration<Seconds<u32>> {
+        Duration::<Seconds<u32>>::from_secs(self.as_secs())
     }
 }

--- a/src/rust/core/server/src/threads/worker/mod.rs
+++ b/src/rust/core/server/src/threads/worker/mod.rs
@@ -15,7 +15,7 @@ pub use single::SingleWorker;
 
 use super::EventLoop;
 
-use common::time::Duration;
+use common::time::{Duration, Nanoseconds};
 use metrics::{static_metrics, Counter, Heatmap, Relaxed};
 use mio::Token;
 
@@ -28,7 +28,7 @@ static_metrics! {
 
     static STORAGE_EVENT_LOOP: Counter;
     static STORAGE_QUEUE_DEPTH: Relaxed<Heatmap> = Relaxed::new(||
-        Heatmap::new(1_000_000, 3, Duration::from_secs(60), Duration::from_secs(1))
+        Heatmap::new(1_000_000, 3, Duration::<Nanoseconds<u64>>::from_secs(60), Duration::<Nanoseconds<u64>>::from_secs(1))
     );
 
     static PROCESS_REQ: Counter;

--- a/src/rust/core/server/src/threads/worker/multi.rs
+++ b/src/rust/core/server/src/threads/worker/multi.rs
@@ -153,7 +153,7 @@ where
         if event.is_readable() {
             WORKER_EVENT_READ.increment();
             if let Ok(session) = self.poll.get_mut_session(token) {
-                session.set_timestamp(Instant::recent());
+                session.set_timestamp(Instant::<Nanoseconds<u64>>::recent());
             }
             let _ = self.do_read(token);
         }

--- a/src/rust/core/server/src/threads/worker/single.rs
+++ b/src/rust/core/server/src/threads/worker/single.rs
@@ -155,7 +155,7 @@ where
         if event.is_readable() {
             WORKER_EVENT_READ.increment();
             if let Ok(session) = self.poll.get_mut_session(token) {
-                session.set_timestamp(Instant::recent());
+                session.set_timestamp(Instant::<Nanoseconds<u64>>::recent());
             }
             let _ = self.do_read(token);
         }

--- a/src/rust/core/server/src/threads/worker/storage.rs
+++ b/src/rust/core/server/src/threads/worker/storage.rs
@@ -99,7 +99,11 @@ where
             if !events.is_empty() {
                 let mut worker_pending = self.worker_queues.pending();
                 let total_pending: usize = worker_pending.iter().sum();
-                STORAGE_QUEUE_DEPTH.increment(Instant::<Nanoseconds<u64>>::now(), total_pending as _, 1);
+                STORAGE_QUEUE_DEPTH.increment(
+                    Instant::<Nanoseconds<u64>>::now(),
+                    total_pending as _,
+                    1,
+                );
 
                 trace!("handling events");
                 let mut empty = false;

--- a/src/rust/core/server/src/threads/worker/storage.rs
+++ b/src/rust/core/server/src/threads/worker/storage.rs
@@ -99,7 +99,7 @@ where
             if !events.is_empty() {
                 let mut worker_pending = self.worker_queues.pending();
                 let total_pending: usize = worker_pending.iter().sum();
-                STORAGE_QUEUE_DEPTH.increment(Instant::now(), total_pending as _, 1);
+                STORAGE_QUEUE_DEPTH.increment(Instant::<Nanoseconds<u64>>::now(), total_pending as _, 1);
 
                 trace!("handling events");
                 let mut empty = false;

--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -40,7 +40,10 @@ impl MemcacheStorage for Seg {
         let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
+            entry
+                .ttl()
+                .map(|v| Duration::from_secs(v.as_secs()))
+                .unwrap_or_else(|| Duration::from_secs(0))
         };
 
         match self.data.insert(
@@ -58,7 +61,10 @@ impl MemcacheStorage for Seg {
         let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
+            entry
+                .ttl()
+                .map(|v| Duration::from_secs(v.as_secs()))
+                .unwrap_or_else(|| Duration::from_secs(0))
         };
 
         if self.data.get_no_freq_incr(entry.key()).is_none()
@@ -82,7 +88,10 @@ impl MemcacheStorage for Seg {
         let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
+            entry
+                .ttl()
+                .map(|v| Duration::from_secs(v.as_secs()))
+                .unwrap_or_else(|| Duration::from_secs(0))
         };
 
         if self.data.get_no_freq_incr(entry.key()).is_some()
@@ -130,7 +139,10 @@ impl MemcacheStorage for Seg {
         let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
+            entry
+                .ttl()
+                .map(|v| Duration::from_secs(v.as_secs()))
+                .unwrap_or_else(|| Duration::from_secs(0))
         };
 
         match self.data.cas(

--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -6,6 +6,8 @@ use super::*;
 
 use protocol::memcache::{MemcacheEntry, MemcacheStorage, MemcacheStorageError};
 
+use std::time::Duration;
+
 impl MemcacheStorage for Seg {
     fn get(&mut self, keys: &[Box<[u8]>]) -> Box<[MemcacheEntry]> {
         let mut items = Vec::with_capacity(keys.len());
@@ -35,10 +37,10 @@ impl MemcacheStorage for Seg {
     }
 
     fn set(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {
-        let ttl = if entry.ttl() == Some(0) {
+        let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            CoarseDuration::from_secs(entry.ttl().unwrap_or(0))
+            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
         };
 
         match self.data.insert(
@@ -53,10 +55,10 @@ impl MemcacheStorage for Seg {
     }
 
     fn add(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {
-        let ttl = if entry.ttl() == Some(0) {
+        let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            CoarseDuration::from_secs(entry.ttl().unwrap_or(0))
+            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
         };
 
         if self.data.get_no_freq_incr(entry.key()).is_none()
@@ -77,10 +79,10 @@ impl MemcacheStorage for Seg {
     }
 
     fn replace(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {
-        let ttl = if entry.ttl() == Some(0) {
+        let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            CoarseDuration::from_secs(entry.ttl().unwrap_or(0))
+            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
         };
 
         if self.data.get_no_freq_incr(entry.key()).is_some()
@@ -125,10 +127,10 @@ impl MemcacheStorage for Seg {
     }
 
     fn cas(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {
-        let ttl = if entry.ttl() == Some(0) {
+        let ttl = if entry.ttl().map(|v| v.as_secs()) == Some(0) {
             return Err(MemcacheStorageError::NotStored);
         } else {
-            CoarseDuration::from_secs(entry.ttl().unwrap_or(0))
+            entry.ttl().map(|v| Duration::from_secs(v.as_secs())).unwrap_or_else(|| Duration::from_secs(0))
         };
 
         match self.data.cas(

--- a/src/rust/entrystore/src/seg/mod.rs
+++ b/src/rust/entrystore/src/seg/mod.rs
@@ -9,7 +9,6 @@
 
 use crate::EntryStore;
 
-use common::time::CoarseDuration;
 use config::seg::Eviction;
 use config::SegConfig;
 use seg::{Policy, SegError};

--- a/src/rust/logger/src/lib.rs
+++ b/src/rust/logger/src/lib.rs
@@ -52,7 +52,7 @@ pub use sampling::*;
 pub use single::*;
 pub use traits::*;
 
-use common::time::recent_utc;
+use common::time::DateTime;
 use config::{DebugConfig, KlogConfig};
 use metrics::{static_metrics, Counter, Gauge};
 use mpmc::Queue;

--- a/src/rust/logger/src/single.rs
+++ b/src/rust/logger/src/single.rs
@@ -40,7 +40,7 @@ impl Log for Logger {
             .unwrap_or_else(|| Vec::with_capacity(self.buffer_size));
 
         // Write the log message into the buffer and send to the receiver
-        if (self.format)(&mut buffer, recent_utc(), record).is_ok() {
+        if (self.format)(&mut buffer, DateTime::recent(), record).is_ok() {
             let bytes = buffer.len();
 
             // Note this may drop a log message, but avoids blocking. The

--- a/src/rust/protocol/src/memcache/entry/mod.rs
+++ b/src/rust/protocol/src/memcache/entry/mod.rs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use std::time::Duration;
+
 #[derive(Debug)]
 pub struct MemcacheEntry {
     pub key: Box<[u8]>,
     pub value: Option<Box<[u8]>>,
-    pub ttl: Option<u32>,
+    pub ttl: Option<Duration>,
     pub flags: u32,
     pub cas: Option<u64>,
 }
@@ -24,9 +26,8 @@ impl MemcacheEntry {
         }
     }
 
-    /// The TTL in seconds. `Some(0)` indicates immediate expiration. `None`
-    /// indicates that the item will not expire.
-    pub fn ttl(&self) -> Option<u32> {
+    /// The TTL in seconds. `None` indicates that the item will not expire.
+    pub fn ttl(&self) -> Option<Duration> {
         self.ttl
     }
 

--- a/src/rust/protocol/src/memcache/mod.rs
+++ b/src/rust/protocol/src/memcache/mod.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+//! Defines the `Memcache` storage interface and implements the wire protocol.
+
 mod entry;
 mod storage;
 mod wire;
@@ -9,3 +11,11 @@ mod wire;
 pub use entry::MemcacheEntry;
 pub use storage::{MemcacheStorage, MemcacheStorageError};
 pub use wire::{MemcacheRequest, MemcacheRequestParser, MemcacheResponse};
+
+use common::time::Nanoseconds;
+use common::time::Seconds;
+
+pub(crate) type UnixInstant = common::time::UnixInstant<Seconds<u32>>;
+// pub(crate) type Duration = common::time::Duration<Seconds<u32>>;
+pub(crate) type PreciseDuration = common::time::Duration<Nanoseconds<u64>>;
+pub(crate) type PreciseInstant = common::time::Instant<Nanoseconds<u64>>;

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -11,14 +11,13 @@ pub use response::*;
 use super::*;
 use crate::*;
 
-use common::time::{Duration, Instant};
 use metrics::{static_metrics, Counter, Heatmap, Relaxed};
 
 static_metrics! {
     static GET: Counter;
     static GET_EX: Counter;
     static GET_CARDINALITY: Relaxed<Heatmap> = Relaxed::new(||
-        Heatmap::new(request::MAX_BATCH_SIZE as _, 3, Duration::from_secs(60), Duration::from_secs(1))
+        Heatmap::new(request::MAX_BATCH_SIZE as _, 3, PreciseDuration::from_secs(60), PreciseDuration::from_secs(1))
     );
     static GET_KEY: Counter;
     static GET_KEY_HIT: Counter;
@@ -82,7 +81,7 @@ where
     fn execute(&mut self, request: MemcacheRequest) -> Option<MemcacheResponse> {
         let result = match request {
             MemcacheRequest::Get { ref keys } => {
-                GET_CARDINALITY.increment(Instant::now(), keys.len() as _, 1);
+                GET_CARDINALITY.increment(PreciseInstant::now(), keys.len() as _, 1);
                 MemcacheResult::Values {
                     entries: self.get(keys),
                     cas: false,

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use super::super::*;
+use crate::memcache::wire::*;
 use crate::*;
+use crate::memcache::*;
 
 use config::TimeType;
 
 use std::convert::TryFrom;
+use std::time::Duration;
 
 const MAX_COMMAND_LEN: usize = 16;
 const MAX_KEY_LEN: usize = 250;
@@ -264,11 +266,15 @@ fn parse_set(
     let ttl = if time_type == TimeType::Unix
         || (time_type == TimeType::Memcache && expiry >= 60 * 60 * 24 * 30)
     {
-        Some(expiry.saturating_sub(common::time::recent_unix()))
+        if let Some(d) = UnixInstant::from_secs(expiry).checked_duration_since(UnixInstant::recent()) {
+            Some(Duration::from_secs(d.as_secs().into()))
+        } else {
+            Some(Duration::from_secs(0))
+        }
     } else if expiry == 0 {
         None
     } else {
-        Some(expiry)
+        Some(Duration::from_secs(expiry.into()))
     };
 
     let mut noreply = false;

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -3,8 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use crate::memcache::wire::*;
-use crate::*;
 use crate::memcache::*;
+use crate::*;
 
 use config::TimeType;
 
@@ -266,7 +266,9 @@ fn parse_set(
     let ttl = if time_type == TimeType::Unix
         || (time_type == TimeType::Memcache && expiry >= 60 * 60 * 24 * 30)
     {
-        if let Some(d) = UnixInstant::from_secs(expiry).checked_duration_since(UnixInstant::recent()) {
+        if let Some(d) =
+            UnixInstant::from_secs(expiry).checked_duration_since(UnixInstant::recent())
+        {
             Some(Duration::from_secs(d.as_secs().into()))
         } else {
             Some(Duration::from_secs(0))

--- a/src/rust/protocol/src/memcache/wire/response/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/response/mod.rs
@@ -333,7 +333,7 @@ fn klog_cas(response: &MemcacheResponse, response_len: usize) {
             response.request.command(),
             string_key(response.request.key()),
             entry.flags(),
-            entry.ttl.unwrap_or(0),
+            entry.ttl.map(|v| v.as_secs()).unwrap_or(0),
             entry.value().map(|v| v.len()).unwrap_or(0),
             entry.cas().unwrap_or(0) as u32,
             response.result.code(),
@@ -383,7 +383,7 @@ fn klog_store(response: &MemcacheResponse, response_len: usize) {
             response.request.command(),
             string_key(response.request.key()),
             entry.flags(),
-            entry.ttl.unwrap_or(0),
+            entry.ttl.map(|v| v.as_secs()).unwrap_or(0),
             entry.value().map(|v| v.len()).unwrap_or(0),
             response.result.code(),
             response_len

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -19,7 +19,7 @@ use std::io::{BufRead, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 
 use common::ssl::{MidHandshakeSslStream, SslStream};
-use common::time::{Nanoseconds};
+use common::time::Nanoseconds;
 use metrics::{static_metrics, Counter, Gauge, Heatmap, Relaxed};
 use mio::event::Source;
 use mio::{Interest, Poll, Token};

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -19,13 +19,16 @@ use std::io::{BufRead, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 
 use common::ssl::{MidHandshakeSslStream, SslStream};
-use common::time::{Duration, Instant};
+use common::time::{Nanoseconds};
 use metrics::{static_metrics, Counter, Gauge, Heatmap, Relaxed};
 use mio::event::Source;
 use mio::{Interest, Poll, Token};
 
 use buffer::Buffer;
 use stream::Stream;
+
+type Instant = common::time::Instant<Nanoseconds<u64>>;
+type Duration = common::time::Duration<Nanoseconds<u64>>;
 
 pub use tcp_stream::TcpStream;
 

--- a/src/rust/storage/seg/benches/benchmark.rs
+++ b/src/rust/storage/seg/benches/benchmark.rs
@@ -7,6 +7,8 @@ use rand::RngCore;
 use rand::SeedableRng;
 use seg::*;
 
+use std::time::Duration;
+
 pub const MB: usize = 1024 * 1024;
 
 // A very fast PRNG which is appropriate for testing
@@ -16,7 +18,7 @@ pub fn rng() -> impl RngCore {
 
 fn get_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("get");
-    group.measurement_time(core::time::Duration::from_secs(30));
+    group.measurement_time(Duration::from_secs(30));
     group.throughput(Throughput::Elements(1));
 
     for key_size in [1, 255].iter() {
@@ -69,9 +71,9 @@ fn key_values(
 }
 
 fn set_benchmark(c: &mut Criterion) {
-    let ttl = common::time::CoarseDuration::MAX;
+    let ttl = Duration::ZERO;
     let mut group = c.benchmark_group("set");
-    group.measurement_time(core::time::Duration::from_secs(30));
+    group.measurement_time(Duration::from_secs(30));
     group.throughput(Throughput::Elements(1));
 
     for key_size in [1, 255].iter() {

--- a/src/rust/storage/seg/src/eviction/mod.rs
+++ b/src/rust/storage/seg/src/eviction/mod.rs
@@ -8,12 +8,12 @@
 use core::cmp::{max, Ordering};
 use core::num::NonZeroU32;
 
-use common::time::CoarseInstant as Instant;
-use rand::Rng;
+use ::rand::Rng;
 
 use crate::rng;
 use crate::segments::*;
 use crate::Random;
+use crate::*;
 
 mod policy;
 

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -78,8 +78,6 @@ use ahash::RandomState;
 use core::num::NonZeroU32;
 use metrics::{static_metrics, Counter};
 
-use common::time::CoarseInstant as Instant;
-
 mod hash_bucket;
 
 pub(crate) use hash_bucket::*;
@@ -107,7 +105,7 @@ pub(crate) struct HashTable {
     mask: u64,
     data: Box<[HashBucket]>,
     rng: Box<Random>,
-    started: CoarseInstant,
+    started: Instant,
     next_to_chain: u64,
 }
 

--- a/src/rust/storage/seg/src/lib.rs
+++ b/src/rust/storage/seg/src/lib.rs
@@ -27,7 +27,7 @@
 extern crate logger;
 
 // external crate includes
-use common::time::*;
+use common::time::Seconds;
 
 // includes from core/std
 use core::hash::{BuildHasher, Hasher};
@@ -56,8 +56,9 @@ pub use error::SegError;
 pub use eviction::Policy;
 pub use item::Item;
 
-// publicly exported items from external crates
-pub use common::time::CoarseDuration;
+// type aliases
+pub(crate) type Duration = common::time::Duration<Seconds<u32>>;
+pub(crate) type Instant = common::time::Instant<Seconds<u32>>;
 
 // items from submodules which are imported for convenience to the crate level
 pub(crate) use crate::rand::*;

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -4,8 +4,8 @@
 
 //! Core datastructure
 
-use std::cmp::min;
 use crate::*;
+use std::cmp::min;
 
 use metrics::{static_metrics, Counter};
 

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -4,6 +4,7 @@
 
 //! Core datastructure
 
+use std::cmp::min;
 use crate::*;
 
 use metrics::{static_metrics, Counter};
@@ -65,12 +66,13 @@ impl Seg {
     /// Get the item in the `Seg` with the provided key
     ///
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg};
+    /// use seg::{Policy, Seg};
+    /// use std::time::Duration;
     ///
     /// let mut cache = Seg::builder().build();
     /// assert!(cache.get(b"coffee").is_none());
     ///
-    /// cache.insert(b"coffee", b"strong", None, CoarseDuration::ZERO);
+    /// cache.insert(b"coffee", b"strong", None, Duration::ZERO);
     /// let item = cache.get(b"coffee").expect("didn't get item back");
     /// assert_eq!(item.value(), b"strong");
     /// ```
@@ -82,7 +84,7 @@ impl Seg {
     /// increasing the item frequency - useful for combined operations that
     /// check for presence - eg replace is a get + set
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg};
+    /// use seg::{Policy, Seg};
     ///
     /// let mut cache = Seg::builder().build();
     /// assert!(cache.get_no_freq_incr(b"coffee").is_none());
@@ -94,16 +96,17 @@ impl Seg {
     /// Insert a new item into the cache. May return an error indicating that
     /// the insert was not successful.
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg};
+    /// use seg::{Policy, Seg};
+    /// use std::time::Duration;
     ///
     /// let mut cache = Seg::builder().build();
     /// assert!(cache.get(b"drink").is_none());
     ///
-    /// cache.insert(b"drink", b"coffee", None, CoarseDuration::ZERO);
+    /// cache.insert(b"drink", b"coffee", None, Duration::ZERO);
     /// let item = cache.get(b"drink").expect("didn't get item back");
     /// assert_eq!(item.value(), b"coffee");
     ///
-    /// cache.insert(b"drink", b"whisky", None, CoarseDuration::ZERO);
+    /// cache.insert(b"drink", b"whisky", None, Duration::ZERO);
     /// let item = cache.get(b"drink").expect("didn't get item back");
     /// assert_eq!(item.value(), b"whisky");
     /// ```
@@ -112,13 +115,15 @@ impl Seg {
         key: &'a [u8],
         value: &[u8],
         optional: Option<&[u8]>,
-        ttl: CoarseDuration,
+        ttl: std::time::Duration,
     ) -> Result<(), SegError<'a>> {
         // default optional data is empty
         let optional = optional.unwrap_or(&[]);
 
         // calculate size for item
         let size = (((ITEM_HDR_SIZE + key.len() + value.len() + optional.len()) >> 3) + 1) << 3;
+
+        let ttl = Duration::from_secs(min(u32::MAX as u64, ttl.as_secs()) as u32);
 
         // try to get a `ReservedItem`
         let mut retries = RESERVE_RETRIES;
@@ -193,27 +198,28 @@ impl Seg {
     /// matches the current value for that item.
     ///
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg, SegError};
+    /// use seg::{Policy, Seg, SegError};
+    /// use std::time::Duration;
     ///
     /// let mut cache = Seg::builder().build();
     ///
     /// // If the item is not in the cache, CAS will fail as 'NotFound'
     /// assert_eq!(
-    ///     cache.cas(b"drink", b"coffee", None, CoarseDuration::ZERO, 0),
+    ///     cache.cas(b"drink", b"coffee", None, Duration::ZERO, 0),
     ///     Err(SegError::NotFound)
     /// );
     ///
     /// // If a stale CAS value is provided, CAS will fail as 'Exists'
-    /// cache.insert(b"drink", b"coffee", None, CoarseDuration::ZERO);
+    /// cache.insert(b"drink", b"coffee", None, Duration::ZERO);
     /// assert_eq!(
-    ///     cache.cas(b"drink", b"coffee", None, CoarseDuration::ZERO, 0),
+    ///     cache.cas(b"drink", b"coffee", None, Duration::ZERO, 0),
     ///     Err(SegError::Exists)
     /// );
     ///
     /// // Getting the CAS value and then performing the operation ensures
     /// // success in absence of a race with another client
     /// let current = cache.get(b"drink").expect("not found");
-    /// assert!(cache.cas(b"drink", b"whisky", None, CoarseDuration::ZERO, current.cas()).is_ok());
+    /// assert!(cache.cas(b"drink", b"whisky", None, Duration::ZERO, current.cas()).is_ok());
     /// let item = cache.get(b"drink").expect("not found");
     /// assert_eq!(item.value(), b"whisky"); // item is updated
     /// ```
@@ -222,7 +228,7 @@ impl Seg {
         key: &'a [u8],
         value: &[u8],
         optional: Option<&[u8]>,
-        ttl: CoarseDuration,
+        ttl: std::time::Duration,
         cas: u32,
     ) -> Result<(), SegError<'a>> {
         match self.hashtable.try_update_cas(key, cas, &mut self.segments) {
@@ -234,7 +240,8 @@ impl Seg {
     /// Remove the item with the given key, returns a bool indicating if it was
     /// removed.
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg, SegError};
+    /// use seg::{Policy, Seg, SegError};
+    /// use std::time::Duration;
     ///
     /// let mut cache = Seg::builder().build();
     ///
@@ -242,7 +249,7 @@ impl Seg {
     /// assert_eq!(cache.delete(b"coffee"), false);
     ///
     /// // And will return true on success
-    /// cache.insert(b"coffee", b"strong", None, CoarseDuration::ZERO);
+    /// cache.insert(b"coffee", b"strong", None, Duration::ZERO);
     /// assert!(cache.get(b"coffee").is_some());
     /// assert_eq!(cache.delete(b"coffee"), true);
     /// assert!(cache.get(b"coffee").is_none());
@@ -256,18 +263,19 @@ impl Seg {
     /// Loops through the TTL Buckets to handle eager expiration, returns the
     /// number of segments expired
     /// ```
-    /// use seg::{CoarseDuration, Policy, Seg, SegError};
+    /// use seg::{Policy, Seg, SegError};
+    /// use std::time::Duration;
     ///
     /// let mut cache = Seg::builder().build();
     ///
     /// // Insert an item with a short ttl
-    /// cache.insert(b"coffee", b"strong", None, CoarseDuration::from_secs(5));
+    /// cache.insert(b"coffee", b"strong", None, Duration::from_secs(5));
     ///
     /// // The item is still in the cache
     /// assert!(cache.get(b"coffee").is_some());
     ///
     /// // Delay and then trigger expiration
-    /// std::thread::sleep(std::time::Duration::from_secs(6));
+    /// std::thread::sleep(Duration::from_secs(6));
     /// cache.expire();
     ///
     /// // And the expired item is not in the cache

--- a/src/rust/storage/seg/src/segments/header.rs
+++ b/src/rust/storage/seg/src/segments/header.rs
@@ -27,11 +27,9 @@
 //! ```
 
 use super::SEG_MAGIC;
-use common::time::*;
 use core::num::NonZeroU32;
 
-use common::time::CoarseDuration as Duration;
-use common::time::CoarseInstant as Instant;
+use crate::*;
 
 // the minimum age of a segment before it is eligible for eviction
 // TODO(bmartin): this should be parameterized.
@@ -184,13 +182,13 @@ impl SegmentHeader {
 
     #[inline]
     /// Returns the TTL for the segment.
-    pub fn ttl(&self) -> CoarseDuration {
-        CoarseDuration::from_secs(self.ttl)
+    pub fn ttl(&self) -> Duration {
+        Duration::from_secs(self.ttl)
     }
 
     #[inline]
     /// Sets the TTL for the segment.
-    pub fn set_ttl(&mut self, ttl: CoarseDuration) {
+    pub fn set_ttl(&mut self, ttl: Duration) {
         self.ttl = ttl.as_secs();
     }
 
@@ -244,26 +242,26 @@ impl SegmentHeader {
 
     #[inline]
     /// Returns the instant at which the segment was created
-    pub fn create_at(&self) -> CoarseInstant {
+    pub fn create_at(&self) -> Instant {
         self.create_at
     }
 
     #[inline]
     /// Update the created time
     pub fn mark_created(&mut self) {
-        self.create_at = CoarseInstant::recent();
+        self.create_at = Instant::recent();
     }
 
     #[inline]
     /// Returns the instant at which the segment was merged
-    pub fn merge_at(&self) -> CoarseInstant {
+    pub fn merge_at(&self) -> Instant {
         self.merge_at
     }
 
     #[inline]
     /// Update the created time
     pub fn mark_merged(&mut self) {
-        self.merge_at = CoarseInstant::recent();
+        self.merge_at = Instant::recent();
     }
 
     #[inline]

--- a/src/rust/storage/seg/src/segments/segment.rs
+++ b/src/rust/storage/seg/src/segments/segment.rs
@@ -198,19 +198,19 @@ impl<'a> Segment<'a> {
 
     /// Return the segment's TTL
     #[inline]
-    pub fn ttl(&self) -> CoarseDuration {
+    pub fn ttl(&self) -> Duration {
         self.header.ttl()
     }
 
     /// Set the segment's TTL, used when linking it into a TtlBucket
     #[inline]
-    pub fn set_ttl(&mut self, ttl: CoarseDuration) {
+    pub fn set_ttl(&mut self, ttl: Duration) {
         self.header.set_ttl(ttl)
     }
 
     /// Returns the time the segment was last initialized
     #[inline]
-    pub fn create_at(&self) -> CoarseInstant {
+    pub fn create_at(&self) -> Instant {
         self.header.create_at()
     }
 

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -8,7 +8,6 @@ use crate::item::*;
 use crate::seg::{SEGMENT_REQUEST, SEGMENT_REQUEST_SUCCESS};
 use crate::segments::*;
 
-use common::time::CoarseInstant as Instant;
 use core::num::NonZeroU32;
 use metrics::{static_metrics, Counter, Gauge};
 
@@ -39,7 +38,7 @@ pub(crate) struct Segments {
     /// Head of the free segment queue
     free_q: Option<NonZeroU32>,
     /// Time last flushed
-    flush_at: CoarseInstant,
+    flush_at: Instant,
     /// Eviction configuration and state
     evict: Box<Eviction>,
 }
@@ -128,12 +127,12 @@ impl Segments {
     }
 
     /// Returns the time the segments were last flushed
-    pub fn flush_at(&self) -> CoarseInstant {
+    pub fn flush_at(&self) -> Instant {
         self.flush_at
     }
 
     /// Mark the segments as flushed at a given instant
-    pub fn set_flush_at(&mut self, instant: CoarseInstant) {
+    pub fn set_flush_at(&mut self, instant: Instant) {
         self.flush_at = instant;
     }
 
@@ -195,7 +194,7 @@ impl Segments {
         ttl_buckets: &mut TtlBuckets,
         hashtable: &mut HashTable,
     ) -> Result<(), SegmentsError> {
-        let now = CoarseInstant::now();
+        let now = Instant::now();
         match self.evict.policy() {
             Policy::Merge { .. } => {
                 SEGMENT_EVICT.increment();

--- a/src/rust/storage/seg/src/tests.rs
+++ b/src/rust/storage/seg/src/tests.rs
@@ -7,6 +7,8 @@ use crate::hashtable::HashBucket;
 use crate::item::ITEM_HDR_SIZE;
 use core::num::NonZeroU32;
 
+use std::time::Duration;
+
 #[test]
 fn sizes() {
     #[cfg(feature = "magic")]
@@ -53,7 +55,7 @@ fn get_free_seg() {
 
 #[test]
 fn get() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;
@@ -76,7 +78,7 @@ fn get() {
 
 #[test]
 fn cas() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;
@@ -103,7 +105,7 @@ fn cas() {
 
 #[test]
 fn overwrite() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;
@@ -149,7 +151,7 @@ fn overwrite() {
 
 #[test]
 fn delete() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;
@@ -178,7 +180,7 @@ fn delete() {
 
 #[test]
 fn collisions_2() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 64;
     let segments = 2;
     let heap_size = segments * segment_size as usize;
@@ -205,7 +207,7 @@ fn collisions_2() {
 
 #[test]
 fn collisions() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;
@@ -239,7 +241,7 @@ fn collisions() {
 
 #[test]
 fn full_cache_long() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let iters = 1_000_000;
     let segments = 32;
     let segment_size = 1024;
@@ -277,7 +279,7 @@ fn full_cache_long() {
 
 #[test]
 fn full_cache_long_2() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let iters = 10_000_000;
     let segments = 64;
     let segment_size = 2 * 1024;
@@ -330,10 +332,10 @@ fn expiration() {
     assert_eq!(cache.segments.free(), segments);
 
     assert!(cache
-        .insert(b"latte", b"", None, CoarseDuration::from_secs(5))
+        .insert(b"latte", b"", None, Duration::from_secs(5))
         .is_ok());
     assert!(cache
-        .insert(b"espresso", b"", None, CoarseDuration::from_secs(15))
+        .insert(b"espresso", b"", None, Duration::from_secs(15))
         .is_ok());
 
     assert!(cache.get(b"latte").is_some());
@@ -369,7 +371,7 @@ fn expiration() {
 
 #[test]
 fn clear() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let segment_size = 4096;
     let segments = 64;
     let heap_size = segments * segment_size as usize;

--- a/src/rust/storage/seg/src/ttl_buckets/tests.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/tests.rs
@@ -3,31 +3,30 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use super::*;
-
-use common::time::*;
+use crate::*;
 
 #[test]
 fn bucket_index() {
     let ttl_buckets = TtlBuckets::new();
 
     // Zero TTL and max duration both go into the same TtlBucket
-    assert_eq!(ttl_buckets.get_bucket_index(CoarseDuration::ZERO), 1023);
-    assert_eq!(ttl_buckets.get_bucket_index(CoarseDuration::MAX), 1023);
+    assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(0)), 1023);
+    assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(u32::MAX)), 1023);
 
     // first bucket is only 7s wide because 0 is no ttl
     assert_eq!(
-        ttl_buckets.get_bucket_index(CoarseDuration::from_secs(1)),
+        ttl_buckets.get_bucket_index(Duration::from_secs(1)),
         0
     );
     assert_eq!(
-        ttl_buckets.get_bucket_index(CoarseDuration::from_secs(7)),
+        ttl_buckets.get_bucket_index(Duration::from_secs(7)),
         0
     );
 
     // buckets from 8s - 2048s (0..34 minutes) are all 8s wide
     for bucket in 1..256 {
-        let start = CoarseDuration::from_secs(8 * bucket);
-        let end = CoarseDuration::from_secs(8 * bucket + 7);
+        let start = Duration::from_secs(8 * bucket);
+        let end = Duration::from_secs(8 * bucket + 7);
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket,
@@ -44,8 +43,8 @@ fn bucket_index() {
 
     // buckets from 2048s - 32_768s (34 minutes .. 9 hours) are all 128s wide (2 minutes)
     for bucket in 16..256 {
-        let start = CoarseDuration::from_secs(128 * bucket);
-        let end = CoarseDuration::from_secs(128 * bucket + 127);
+        let start = Duration::from_secs(128 * bucket);
+        let end = Duration::from_secs(128 * bucket + 127);
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 256,
@@ -62,8 +61,8 @@ fn bucket_index() {
 
     // buckets from 32_768s - 524_288s (9 hours .. 6 days) are all 2048s wide (34 minutes)
     for bucket in 16..256 {
-        let start = CoarseDuration::from_secs(2048 * bucket);
-        let end = CoarseDuration::from_secs(2048 * bucket + 2047);
+        let start = Duration::from_secs(2048 * bucket);
+        let end = Duration::from_secs(2048 * bucket + 2047);
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 512,
@@ -80,8 +79,8 @@ fn bucket_index() {
 
     // buckets from 524_288s - 8_388_608s (6 days .. 97 days) are all 32_768s wide (9 hours)
     for bucket in 16..256 {
-        let start = CoarseDuration::from_secs(32_768 * bucket);
-        let end = CoarseDuration::from_secs(32_768 * bucket + 32_767);
+        let start = Duration::from_secs(32_768 * bucket);
+        let end = Duration::from_secs(32_768 * bucket + 32_767);
         assert_eq!(
             ttl_buckets.get_bucket_index(start) as u32,
             bucket + 768,
@@ -98,7 +97,7 @@ fn bucket_index() {
 
     // TTLs longer than 97 days are the max TTL
     assert_eq!(
-        ttl_buckets.get_bucket_index(CoarseDuration::from_secs(8_388_608)) as u32,
+        ttl_buckets.get_bucket_index(Duration::from_secs(8_388_608)) as u32,
         1023
     );
 }

--- a/src/rust/storage/seg/src/ttl_buckets/tests.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/tests.rs
@@ -11,17 +11,14 @@ fn bucket_index() {
 
     // Zero TTL and max duration both go into the same TtlBucket
     assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(0)), 1023);
-    assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(u32::MAX)), 1023);
+    assert_eq!(
+        ttl_buckets.get_bucket_index(Duration::from_secs(u32::MAX)),
+        1023
+    );
 
     // first bucket is only 7s wide because 0 is no ttl
-    assert_eq!(
-        ttl_buckets.get_bucket_index(Duration::from_secs(1)),
-        0
-    );
-    assert_eq!(
-        ttl_buckets.get_bucket_index(Duration::from_secs(7)),
-        0
-    );
+    assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(1)), 0);
+    assert_eq!(ttl_buckets.get_bucket_index(Duration::from_secs(7)), 0);
 
     // buckets from 8s - 2048s (0..34 minutes) are all 8s wide
     for bucket in 1..256 {

--- a/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -28,7 +28,6 @@
 
 use super::{SEGMENT_CLEAR, SEGMENT_EXPIRE};
 use crate::*;
-use common::time::CoarseDuration;
 use core::num::NonZeroU32;
 
 /// Each ttl bucket contains a segment chain to store items with a similar TTL
@@ -92,7 +91,7 @@ impl TtlBucket {
             if let Some(seg_id) = seg_id {
                 let flush_at = segments.flush_at();
                 let mut segment = segments.get_mut(seg_id).unwrap();
-                if segment.create_at() + segment.ttl() <= CoarseInstant::recent()
+                if segment.create_at() + segment.ttl() <= Instant::recent()
                     || segment.create_at() < flush_at
                 {
                     if let Some(next) = segment.next_seg() {
@@ -158,7 +157,7 @@ impl TtlBucket {
             let mut segment = segments.get_mut(id).unwrap();
             segment.set_prev_seg(self.tail);
             segment.set_next_seg(None);
-            segment.set_ttl(CoarseDuration::from_secs(self.ttl as u32));
+            segment.set_ttl(Duration::from_secs(self.ttl as u32));
             if self.head.is_none() {
                 debug_assert!(self.tail.is_none());
                 self.head = Some(id);

--- a/src/rust/storage/seg/tests/integration_basic.rs
+++ b/src/rust/storage/seg/tests/integration_basic.rs
@@ -2,12 +2,13 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use common::time::*;
 use seg::*;
+
+use std::time::Duration;
 
 #[test]
 fn integration_basic() {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = Duration::ZERO;
     let heap_size = 2 * 256;
     let segment_size = 256;
     let mut cache = Seg::builder()


### PR DESCRIPTION
Fixes metrics on macos by using a newer version of the linkme
crate within the metrics crate.

Changes time representation to use more expressive types. Changes
the public API to use standard types.