### PR TITLE
rust: move dependencies on rustcommon into one library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,14 +241,16 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "boring",
- "config",
+ "rustcommon-metrics-v2",
  "rustcommon-time",
+ "serde",
 ]
 
 [[package]]
 name = "config"
 version = "0.1.0"
 dependencies = [
+ "common",
  "log",
  "serde",
  "toml",
@@ -366,9 +368,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "entrystore"
 version = "0.0.1"
 dependencies = [
+ "common",
  "config",
  "protocol",
- "rustcommon-time",
  "seg",
 ]
 
@@ -594,11 +596,11 @@ name = "logger"
 version = "0.1.0"
 dependencies = [
  "ahash 0.7.4",
+ "common",
  "config",
  "log",
  "metrics",
  "mpmc",
- "rustcommon-time",
 ]
 
 [[package]]
@@ -647,8 +649,8 @@ dependencies = [
 name = "metrics"
 version = "0.1.0"
 dependencies = [
+ "common",
  "macros",
- "rustcommon-metrics-v2",
  "strum",
  "strum_macros",
 ]
@@ -793,8 +795,6 @@ dependencies = [
  "logger",
  "metrics",
  "protocol",
- "rustcommon-logger",
- "rustcommon-time",
  "server",
 ]
 
@@ -860,7 +860,6 @@ dependencies = [
  "criterion",
  "logger",
  "metrics",
- "rustcommon-time",
  "session",
 ]
 
@@ -1021,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-atomics"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "serde",
 ]
@@ -1029,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-heatmap"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "rustcommon-atomics",
  "rustcommon-histogram",
@@ -1040,25 +1039,16 @@ dependencies = [
 [[package]]
 name = "rustcommon-histogram"
 version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "rustcommon-atomics",
  "thiserror",
 ]
 
 [[package]]
-name = "rustcommon-logger"
-version = "1.0.0"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
-dependencies = [
- "log",
- "rustcommon-time",
-]
-
-[[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1069,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-metrics-v2"
 version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "linkme",
  "once_cell",
@@ -1083,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "rustcommon-time"
 version = "0.0.10"
-source = "git+https://github.com/twitter/rustcommon#cd7411b687150d707a8cda5ec116eee79ef3a50b"
+source = "git+https://github.com/twitter/rustcommon?rev=cd7411b687150d707a8cda5ec116eee79ef3a50b#cd7411b687150d707a8cda5ec116eee79ef3a50b"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1118,14 +1108,14 @@ name = "seg"
 version = "0.1.0"
 dependencies = [
  "ahash 0.7.4",
+ "common",
  "criterion",
+ "logger",
  "memmap2",
  "metrics",
  "rand",
  "rand_chacha",
  "rand_xoshiro",
- "rustcommon-logger",
- "rustcommon-time",
  "thiserror",
 ]
 
@@ -1141,8 +1131,6 @@ dependencies = [
  "logger",
  "metrics",
  "protocol",
- "rustcommon-logger",
- "rustcommon-time",
  "server",
 ]
 
@@ -1214,8 +1202,6 @@ dependencies = [
  "queues",
  "rand",
  "rtrb",
- "rustcommon-logger",
- "rustcommon-time",
  "serde",
  "serde_json",
  "session",
@@ -1233,12 +1219,11 @@ dependencies = [
  "boring",
  "common",
  "config",
+ "logger",
  "metrics",
  "mio",
  "rand",
  "rtrb",
- "rustcommon-logger",
- "rustcommon-time",
  "serde",
  "serde_json",
  "slab",

--- a/src/rust/common/Cargo.toml
+++ b/src/rust/common/Cargo.toml
@@ -12,5 +12,11 @@ license = "Apache-2.0"
 
 [dependencies]
 boring = "1.0.3"
-config = { path = "../config" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "cd7411b687150d707a8cda5ec116eee79ef3a50b" }
+serde = { version = "1.0.117", features = ["derive"] }
+
+[dependencies.rustcommon-metrics]
+git = "https://github.com/twitter/rustcommon"
+package="rustcommon-metrics-v2"
+features = ["heatmap"]
+rev = "cd7411b687150d707a8cda5ec116eee79ef3a50b"

--- a/src/rust/common/src/expiry.rs
+++ b/src/rust/common/src/expiry.rs
@@ -2,10 +2,17 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use config::TimeType;
 use rustcommon_time::{CoarseDuration, Duration};
+use serde::{Deserialize, Serialize};
 
 use std::time::SystemTime;
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum TimeType {
+    Unix = 0,
+    Delta = 1,
+    Memcache = 2,
+}
 
 pub struct Expiry {
     expiry: u32,

--- a/src/rust/common/src/lib.rs
+++ b/src/rust/common/src/lib.rs
@@ -6,3 +6,11 @@ pub mod expiry;
 pub mod signal;
 pub mod ssl;
 pub mod traits;
+
+pub mod metrics {
+    pub use rustcommon_metrics::*;
+}
+
+pub mod time {
+    pub use rustcommon_time::*;
+}

--- a/src/rust/common/src/ssl.rs
+++ b/src/rust/common/src/ssl.rs
@@ -4,14 +4,23 @@
 
 use boring::ssl::*;
 use boring::x509::X509;
-use config::TlsConfig;
 use std::io::{Error, ErrorKind};
+
+pub trait TlsConfig {
+    fn certificate_chain(&self) -> Option<String>;
+
+    fn private_key(&self) -> Option<String>;
+
+    fn certificate(&self) -> Option<String>;
+
+    fn ca_file(&self) -> Option<String>;
+}
 
 /// Create an `SslContext` from the given `TlsConfig`. Returns an error if there
 /// was any issues during initialization. Otherwise, returns a `SslContext`
 /// wrapped in an option, where the `None` variant indicates that TLS should not
 /// be used.
-pub fn ssl_context(config: &TlsConfig) -> Result<Option<SslContext>, std::io::Error> {
+pub fn ssl_context(config: &dyn TlsConfig) -> Result<Option<SslContext>, std::io::Error> {
     let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())?;
 
     // we use xor here to check if we have an under-specified tls configuration

--- a/src/rust/common/src/traits.rs
+++ b/src/rust/common/src/traits.rs
@@ -5,3 +5,13 @@
 pub trait ExtendFromSlice<T> {
     fn extend(&mut self, src: &[T]);
 }
+
+pub trait TlsConfig {
+    fn certificate_chain(&self) -> Option<String>;
+
+    fn private_key(&self) -> Option<String>;
+
+    fn certificate(&self) -> Option<String>;
+
+    fn ca_file(&self) -> Option<String>;
+}

--- a/src/rust/config/Cargo.toml
+++ b/src/rust/config/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+common = { path = "../common" }
 log = "0.4.11"
 serde = { version = "1.0.117", features = ["derive"] }
 toml = "0.5.7"

--- a/src/rust/config/src/time.rs
+++ b/src/rust/config/src/time.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+pub use common::expiry::TimeType;
 use serde::{Deserialize, Serialize};
 
 // TODO(bmartin): set the default back to unix
@@ -15,13 +16,6 @@ fn time_type() -> TimeType {
 }
 
 // definitions
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum TimeType {
-    Unix = 0,
-    Delta = 1,
-    Memcache = 2,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TimeConfig {
     #[serde(default = "time_type")]

--- a/src/rust/config/src/tls.rs
+++ b/src/rust/config/src/tls.rs
@@ -18,20 +18,20 @@ pub struct TlsConfig {
 }
 
 // implementation
-impl TlsConfig {
-    pub fn certificate_chain(&self) -> Option<String> {
+impl common::ssl::TlsConfig for TlsConfig {
+    fn certificate_chain(&self) -> Option<String> {
         self.certificate_chain.clone()
     }
 
-    pub fn private_key(&self) -> Option<String> {
+    fn private_key(&self) -> Option<String> {
         self.private_key.clone()
     }
 
-    pub fn certificate(&self) -> Option<String> {
+    fn certificate(&self) -> Option<String> {
         self.certificate.clone()
     }
 
-    pub fn ca_file(&self) -> Option<String> {
+    fn ca_file(&self) -> Option<String> {
         self.ca_file.clone()
     }
 }

--- a/src/rust/core/server/Cargo.toml
+++ b/src/rust/core/server/Cargo.toml
@@ -26,8 +26,6 @@ protocol = { path = "../../protocol" }
 queues = { path = "../../queues" }
 rand = "0.8.0"
 rtrb = "0.1.3"
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 session = { path = "../../session" }

--- a/src/rust/core/server/src/lib.rs
+++ b/src/rust/core/server/src/lib.rs
@@ -89,7 +89,7 @@
 //! thread.
 
 #[macro_use]
-extern crate rustcommon_logger;
+extern crate logger;
 
 mod poll;
 mod process;

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -212,7 +212,7 @@ impl Admin {
     fn handle_stats_request(session: &mut Session) {
         ADMIN_REQUEST_PARSE.increment();
         let mut data = Vec::new();
-        for metric in &metrics::rustcommon_metrics::metrics() {
+        for metric in &metrics::common::metrics::metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
                 None => {

--- a/src/rust/core/server/src/threads/worker/mod.rs
+++ b/src/rust/core/server/src/threads/worker/mod.rs
@@ -15,9 +15,9 @@ pub use single::SingleWorker;
 
 use super::EventLoop;
 
+use common::time::Duration;
 use metrics::{static_metrics, Counter, Heatmap, Relaxed};
 use mio::Token;
-use rustcommon_time::Duration;
 
 static_metrics! {
     static WORKER_EVENT_LOOP: Counter;

--- a/src/rust/core/server/src/threads/worker/multi.rs
+++ b/src/rust/core/server/src/threads/worker/multi.rs
@@ -13,6 +13,7 @@ use crate::poll::Poll;
 use crate::threads::worker::StorageWorker;
 use crate::threads::worker::TokenWrapper;
 use common::signal::Signal;
+use common::time::Instant;
 use config::WorkerConfig;
 use core::marker::PhantomData;
 use core::time::Duration;
@@ -21,7 +22,6 @@ use mio::event::Event;
 use mio::{Events, Token, Waker};
 use protocol::{Compose, Execute, Parse, ParseError};
 use queues::{QueuePair, QueuePairs, SendError};
-use rustcommon_time::Instant;
 use session::Session;
 use std::io::{BufRead, Write};
 use std::sync::Arc;
@@ -101,7 +101,7 @@ where
 
             WORKER_EVENT_TOTAL.add(events.iter().count() as _);
 
-            rustcommon_time::refresh_clock();
+            common::time::refresh_clock();
 
             // process all events
             for event in events.iter() {

--- a/src/rust/core/server/src/threads/worker/single.rs
+++ b/src/rust/core/server/src/threads/worker/single.rs
@@ -11,6 +11,7 @@ use super::EventLoop;
 use super::*;
 use crate::poll::{Poll, WAKER_TOKEN};
 use common::signal::Signal;
+use common::time::Instant;
 use config::WorkerConfig;
 use core::marker::PhantomData;
 use core::time::Duration;
@@ -22,7 +23,6 @@ use mio::Waker;
 use protocol::{Compose, Execute, Parse, ParseError};
 use queues::QueuePair;
 use queues::QueuePairs;
-use rustcommon_time::Instant;
 use session::Session;
 use std::io::{BufRead, Write};
 use std::sync::Arc;
@@ -89,7 +89,7 @@ where
 
             WORKER_EVENT_TOTAL.add(events.iter().count() as _);
 
-            rustcommon_time::refresh_clock();
+            common::time::refresh_clock();
 
             // process all events
             for event in events.iter() {

--- a/src/rust/core/server/src/threads/worker/storage.rs
+++ b/src/rust/core/server/src/threads/worker/storage.rs
@@ -5,6 +5,7 @@
 use super::*;
 use crate::threads::worker::TokenWrapper;
 use common::signal::Signal;
+use common::time::Instant;
 use config::WorkerConfig;
 use core::time::Duration;
 use entrystore::EntryStore;
@@ -14,7 +15,6 @@ use mio::Token;
 use mio::Waker;
 use protocol::{Compose, Execute};
 use queues::{QueueError, QueuePair, QueuePairs};
-use rustcommon_time::Instant;
 use std::sync::Arc;
 
 // TODO(bmartin): this *should* be plenty safe, the queue should rarely ever be

--- a/src/rust/entrystore/Cargo.toml
+++ b/src/rust/entrystore/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 debug = ["seg/debug"]
 
 [dependencies]
+common = { path = "../common" }
 config = { path = "../config" }
 protocol = { path = "../protocol" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 seg = { path = "../storage/seg" }

--- a/src/rust/entrystore/src/seg/mod.rs
+++ b/src/rust/entrystore/src/seg/mod.rs
@@ -9,9 +9,9 @@
 
 use crate::EntryStore;
 
+use common::time::CoarseDuration;
 use config::seg::Eviction;
 use config::SegConfig;
-use rustcommon_time::CoarseDuration;
 use seg::{Policy, SegError};
 
 mod memcache;

--- a/src/rust/logger/Cargo.toml
+++ b/src/rust/logger/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 
 [dependencies]
 ahash = "0.7.4"
+common = { path = "../common" }
 config = { path = "../config" }
 log = { version = "0.4.14", features = ["std"] }
 metrics = { path = "../metrics" }
 mpmc = "0.1.6"
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }

--- a/src/rust/logger/src/format.rs
+++ b/src/rust/logger/src/format.rs
@@ -4,7 +4,7 @@
 
 use crate::*;
 
-use rustcommon_time::{DateTime, SecondsFormat};
+use common::time::{DateTime, SecondsFormat};
 
 pub type FormatFunction = fn(
     write: &mut dyn std::io::Write,

--- a/src/rust/logger/src/lib.rs
+++ b/src/rust/logger/src/lib.rs
@@ -52,10 +52,10 @@ pub use sampling::*;
 pub use single::*;
 pub use traits::*;
 
+use common::time::recent_utc;
 use config::{DebugConfig, KlogConfig};
 use metrics::{static_metrics, Counter, Gauge};
 use mpmc::Queue;
-use rustcommon_time::recent_utc;
 
 pub(crate) type LogBuffer = Vec<u8>;
 
@@ -93,6 +93,22 @@ impl AsyncLog {
             .expect("failed to start logger");
         self.drain
     }
+}
+
+#[macro_export]
+macro_rules! fatal {
+    () => (
+        error!();
+        std::process::exit(1);
+        );
+    ($fmt:expr) => (
+        error!($fmt);
+        std::process::exit(1);
+        );
+    ($fmt:expr, $($arg:tt)*) => (
+        error!($fmt, $($arg)*);
+        std::process::exit(1);
+        );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/rust/metrics/Cargo.toml
+++ b/src/rust/metrics/Cargo.toml
@@ -11,11 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+common = { path = "../common" }
 macros = { path = "../macros" }
 strum = "0.20.0"
 strum_macros = "0.20.1"
-
-[dependencies.rustcommon-metrics]
-git = "https://github.com/twitter/rustcommon"
-package="rustcommon-metrics-v2"
-features = ["heatmap"]

--- a/src/rust/metrics/src/lib.rs
+++ b/src/rust/metrics/src/lib.rs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-pub use rustcommon_metrics::{metric, Counter, Gauge, Heatmap, Relaxed};
+pub use common::metrics::{metric, Counter, Gauge, Heatmap, Relaxed};
 
 #[doc(hidden)]
-pub extern crate rustcommon_metrics;
+pub extern crate common;
 #[doc(hidden)]
 pub use macros::to_lowercase;
 
@@ -33,7 +33,7 @@ macro_rules! static_metrics {
     )*} => {$(
         #[$crate::metric(
             name = $crate::to_lowercase!($name),
-            crate = $crate::rustcommon_metrics
+            crate = $crate::common::metrics
         )]
         $( #[ $attr ] )*
         $vis static $name : $ty = $crate::static_metrics!(
@@ -54,7 +54,7 @@ macro_rules! test_no_duplicates {
             #[test]
             fn assert_no_duplicate_metric_names() {
                 use std::collections::HashSet;
-                use $crate::rustcommon_metrics::*;
+                use $crate::common::metrics::*;
 
                 let mut seen = HashSet::new();
                 for metric in metrics().static_metrics() {

--- a/src/rust/protocol/Cargo.toml
+++ b/src/rust/protocol/Cargo.toml
@@ -18,7 +18,6 @@ common = { path = "../../rust/common" }
 config = { path = "../../rust/config" }
 logger = { path = "../../rust/logger" }
 metrics = { path = "../../rust/metrics" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 session = { path = "../../rust/session" }
 
 [dev-dependencies]

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -11,8 +11,8 @@ pub use response::*;
 use super::*;
 use crate::*;
 
+use common::time::{Duration, Instant};
 use metrics::{static_metrics, Counter, Heatmap, Relaxed};
-use rustcommon_time::{Duration, Instant};
 
 static_metrics! {
     static GET: Counter;

--- a/src/rust/protocol/src/memcache/wire/request/parse.rs
+++ b/src/rust/protocol/src/memcache/wire/request/parse.rs
@@ -264,7 +264,7 @@ fn parse_set(
     let ttl = if time_type == TimeType::Unix
         || (time_type == TimeType::Memcache && expiry >= 60 * 60 * 24 * 30)
     {
-        Some(expiry.saturating_sub(rustcommon_time::recent_unix()))
+        Some(expiry.saturating_sub(common::time::recent_unix()))
     } else if expiry == 0 {
         None
     } else {

--- a/src/rust/server/pingserver/Cargo.toml
+++ b/src/rust/server/pingserver/Cargo.toml
@@ -39,8 +39,6 @@ entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metrics = { path = "../../metrics" }
 protocol = { path = "../../protocol" }
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/rust/server/pingserver/src/main.rs
+++ b/src/rust/server/pingserver/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
 
         let mut metrics = Vec::new();
 
-        for metric in &metrics::rustcommon_metrics::metrics() {
+        for metric in &metrics::common::metrics::metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
                 None => {

--- a/src/rust/server/segcache/Cargo.toml
+++ b/src/rust/server/segcache/Cargo.toml
@@ -44,8 +44,6 @@ entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metrics = { path = "../../metrics" }
 protocol = { path = "../../protocol" }
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/rust/server/segcache/src/main.rs
+++ b/src/rust/server/segcache/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
 
         let mut metrics = Vec::new();
 
-        for metric in &metrics::rustcommon_metrics::metrics() {
+        for metric in &metrics::common::metrics::metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
                 None => {

--- a/src/rust/session/Cargo.toml
+++ b/src/rust/session/Cargo.toml
@@ -14,12 +14,11 @@ license = "Apache-2.0"
 boring = "1.0.3"
 common = { path = "../common" }
 config = { path = "../config" }
+logger = { path = "../logger" }
 metrics = { path = "../metrics" }
 mio = { version = "0.7.7", features = ["os-poll", "tcp"] }
 rand = "0.8.0"
 rtrb = "0.1.3"
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 slab = "0.4.2"

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -7,25 +7,25 @@
 //! crate.
 
 #[macro_use]
-extern crate rustcommon_logger;
+extern crate logger;
 
 mod buffer;
 mod stream;
 mod tcp_stream;
 
+use common::time::Duration;
 use metrics::Heatmap;
 use metrics::Relaxed;
-use rustcommon_time::Duration;
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp::Ordering;
 use std::io::{BufRead, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 
 use boring::ssl::{MidHandshakeSslStream, SslStream};
+use common::time::Instant;
 use metrics::{static_metrics, Counter, Gauge};
 use mio::event::Source;
 use mio::{Interest, Poll, Token};
-use rustcommon_time::Instant;
 
 use buffer::Buffer;
 use stream::Stream;

--- a/src/rust/storage/seg/Cargo.toml
+++ b/src/rust/storage/seg/Cargo.toml
@@ -26,13 +26,13 @@ default = []
 
 [dependencies]
 ahash = "0.7.2"
+common = { path = "../../common" }
+logger = { path = "../../logger" }
 memmap2 = "0.2.2"
 metrics = { path = "../../metrics" }
 rand = { version = "0.8.3", features = ["small_rng", "getrandom"] }
 rand_chacha = { version = "0.3.0" }
 rand_xoshiro = { version = "0.6.0" }
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
 thiserror = "1.0.24"
 
 [dev-dependencies]

--- a/src/rust/storage/seg/benches/benchmark.rs
+++ b/src/rust/storage/seg/benches/benchmark.rs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use core::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use rand::RngCore;
 use rand::SeedableRng;
-use rustcommon_time::*;
-use seg::Seg;
+use seg::*;
 
 pub const MB: usize = 1024 * 1024;
 
@@ -18,7 +16,7 @@ pub fn rng() -> impl RngCore {
 
 fn get_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("get");
-    group.measurement_time(Duration::from_secs(30));
+    group.measurement_time(core::time::Duration::from_secs(30));
     group.throughput(Throughput::Elements(1));
 
     for key_size in [1, 255].iter() {
@@ -71,9 +69,9 @@ fn key_values(
 }
 
 fn set_benchmark(c: &mut Criterion) {
-    let ttl = CoarseDuration::ZERO;
+    let ttl = common::time::CoarseDuration::MAX;
     let mut group = c.benchmark_group("set");
-    group.measurement_time(Duration::from_secs(30));
+    group.measurement_time(core::time::Duration::from_secs(30));
     group.throughput(Throughput::Elements(1));
 
     for key_size in [1, 255].iter() {

--- a/src/rust/storage/seg/src/eviction/mod.rs
+++ b/src/rust/storage/seg/src/eviction/mod.rs
@@ -8,8 +8,8 @@
 use core::cmp::{max, Ordering};
 use core::num::NonZeroU32;
 
+use common::time::CoarseInstant as Instant;
 use rand::Rng;
-use rustcommon_time::CoarseInstant as Instant;
 
 use crate::rng;
 use crate::segments::*;

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -78,7 +78,7 @@ use ahash::RandomState;
 use core::num::NonZeroU32;
 use metrics::{static_metrics, Counter};
 
-use rustcommon_time::CoarseInstant as Instant;
+use common::time::CoarseInstant as Instant;
 
 mod hash_bucket;
 
@@ -683,7 +683,7 @@ impl HashTable {
                     continue;
                 }
                 if get_seg_id(current_item_info) != Some(segment.id())
-                    || get_offset(current_item_info) != offset as _
+                    || get_offset(current_item_info) != offset as u64
                 {
                     HASH_TAG_COLLISION.increment();
                     continue;

--- a/src/rust/storage/seg/src/lib.rs
+++ b/src/rust/storage/seg/src/lib.rs
@@ -24,10 +24,10 @@
 
 // macro includes
 #[macro_use]
-extern crate rustcommon_logger;
+extern crate logger;
 
 // external crate includes
-use rustcommon_time::*;
+use common::time::*;
 
 // includes from core/std
 use core::hash::{BuildHasher, Hasher};
@@ -57,7 +57,7 @@ pub use eviction::Policy;
 pub use item::Item;
 
 // publicly exported items from external crates
-pub use rustcommon_time::CoarseDuration;
+pub use common::time::CoarseDuration;
 
 // items from submodules which are imported for convenience to the crate level
 pub(crate) use crate::rand::*;

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -274,13 +274,13 @@ impl Seg {
     /// assert!(cache.get(b"coffee").is_none());
     /// ```
     pub fn expire(&mut self) -> usize {
-        rustcommon_time::refresh_clock();
+        common::time::refresh_clock();
         self.ttl_buckets
             .expire(&mut self.hashtable, &mut self.segments)
     }
 
     pub fn clear(&mut self) -> usize {
-        rustcommon_time::refresh_clock();
+        common::time::refresh_clock();
         self.ttl_buckets
             .clear(&mut self.hashtable, &mut self.segments)
     }

--- a/src/rust/storage/seg/src/segments/header.rs
+++ b/src/rust/storage/seg/src/segments/header.rs
@@ -27,11 +27,11 @@
 //! ```
 
 use super::SEG_MAGIC;
+use common::time::*;
 use core::num::NonZeroU32;
-use rustcommon_time::*;
 
-use rustcommon_time::CoarseDuration as Duration;
-use rustcommon_time::CoarseInstant as Instant;
+use common::time::CoarseDuration as Duration;
+use common::time::CoarseInstant as Instant;
 
 // the minimum age of a segment before it is eligible for eviction
 // TODO(bmartin): this should be parameterized.

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -8,9 +8,9 @@ use crate::item::*;
 use crate::seg::{SEGMENT_REQUEST, SEGMENT_REQUEST_SUCCESS};
 use crate::segments::*;
 
+use common::time::CoarseInstant as Instant;
 use core::num::NonZeroU32;
 use metrics::{static_metrics, Counter, Gauge};
-use rustcommon_time::CoarseInstant as Instant;
 
 static_metrics! {
     static EVICT_TIME: Gauge;
@@ -432,7 +432,7 @@ impl Segments {
                 self.headers[id_idx].write_offset()
             );
 
-            rustcommon_time::refresh_clock();
+            common::time::refresh_clock();
             self.headers[id_idx].mark_created();
             self.headers[id_idx].mark_merged();
 

--- a/src/rust/storage/seg/src/ttl_buckets/tests.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/tests.rs
@@ -3,7 +3,8 @@
 // http://www.apache.org/licenses/LICENSE-2.0
 
 use super::*;
-use rustcommon_time::CoarseDuration;
+
+use common::time::*;
 
 #[test]
 fn bucket_index() {

--- a/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -28,6 +28,7 @@
 
 use super::{SEGMENT_CLEAR, SEGMENT_EXPIRE};
 use crate::*;
+use common::time::CoarseDuration;
 use core::num::NonZeroU32;
 
 /// Each ttl bucket contains a segment chain to store items with a similar TTL

--- a/src/rust/storage/seg/tests/integration_basic.rs
+++ b/src/rust/storage/seg/tests/integration_basic.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use rustcommon_time::*;
+use common::time::*;
 use seg::*;
 
 #[test]


### PR DESCRIPTION
Currently, we face some versioning challenges between the Pelikan
workspace and the fuzz testing suite. The fuzz test suite is
excluded from the Pelikan workspace, so does not share the same
lock file. This means that dependencies are not necessarily in
lockstep with the main code.

This change centralizes the dependencies on rustcommon into the
`common` library within the Pelikan workspace. This allows us to
have a single spot to specify an exact revision of rustcommon for
our dependency.

Includes a bit of refactoring so that the `config` crate depends
on `common` and not the other way around.