### PR TITLE
rust: update boringssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "boring"
-version = "1.1.6"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45976d3e185902843f8ac67fcdc3f10f47cb96e275a545218273bf09a592f6"
+checksum = "6953f3fea6f9f20c15e81b3f4ef2217ea06cc05652a0db49c0abb35626b0fad1"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -408,18 +408,30 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
 
 [[package]]
 name = "gcc"
@@ -1199,7 +1211,6 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.6.3",
  "backtrace",
- "boring",
  "bytes",
  "common",
  "config",
@@ -1230,7 +1241,6 @@ dependencies = [
 name = "session"
 version = "0.0.2"
 dependencies = [
- "boring",
  "common",
  "config",
  "metrics",

--- a/src/rust/common/Cargo.toml
+++ b/src/rust/common/Cargo.toml
@@ -11,6 +11,6 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-boring = "1.0.3"
+boring = "2.0.0"
 config = { path = "../config" }
 rustcommon-time = { git = "https://github.com/twitter/rustcommon" }

--- a/src/rust/common/src/ssl.rs
+++ b/src/rust/common/src/ssl.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use boring::ssl::*;
+pub use boring::ssl::*;
 use boring::x509::X509;
 use config::TlsConfig;
 use std::io::{Error, ErrorKind};

--- a/src/rust/core/server/Cargo.toml
+++ b/src/rust/core/server/Cargo.toml
@@ -13,7 +13,6 @@ license = "Apache-2.0"
 [dependencies]
 ahash = "0.6.2"
 backtrace = "0.3.56"
-boring = "1.0.3"
 bytes = "1.0.1"
 common = { path = "../../common" }
 config = { path = "../../config" }

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -8,7 +8,7 @@
 use super::EventLoop;
 use crate::poll::{Poll, LISTENER_TOKEN, WAKER_TOKEN};
 use crate::TCP_ACCEPT_EX;
-use boring::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
+use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use common::signal::Signal;
 use config::AdminConfig;
 use logger::*;

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -8,8 +8,8 @@
 use super::EventLoop;
 use crate::poll::{Poll, LISTENER_TOKEN, WAKER_TOKEN};
 use crate::TCP_ACCEPT_EX;
-use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use common::signal::Signal;
+use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use config::AdminConfig;
 use logger::*;
 use metrics::{static_metrics, Counter, Gauge, Heatmap};

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -8,8 +8,8 @@
 use super::EventLoop;
 use crate::poll::{Poll, LISTENER_TOKEN, WAKER_TOKEN};
 use crate::TCP_ACCEPT_EX;
-use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use common::signal::Signal;
+use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use config::ServerConfig;
 use metrics::{static_metrics, Counter};
 use mio::event::Event;

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -8,7 +8,7 @@
 use super::EventLoop;
 use crate::poll::{Poll, LISTENER_TOKEN, WAKER_TOKEN};
 use crate::TCP_ACCEPT_EX;
-use boring::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
+use common::ssl::{HandshakeError, MidHandshakeSslStream, Ssl, SslContext, SslStream};
 use common::signal::Signal;
 use config::ServerConfig;
 use metrics::{static_metrics, Counter};

--- a/src/rust/session/Cargo.toml
+++ b/src/rust/session/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-boring = "1.0.3"
 common = { path = "../common" }
 config = { path = "../config" }
 metrics = { path = "../metrics" }

--- a/src/rust/session/src/lib.rs
+++ b/src/rust/session/src/lib.rs
@@ -21,7 +21,7 @@ use std::cmp::Ordering;
 use std::io::{BufRead, ErrorKind, Read, Write};
 use std::net::SocketAddr;
 
-use boring::ssl::{MidHandshakeSslStream, SslStream};
+use common::ssl::{MidHandshakeSslStream, SslStream};
 use metrics::{static_metrics, Counter, Gauge};
 use mio::event::Source;
 use mio::{Interest, Poll, Token};

--- a/src/rust/session/src/stream.rs
+++ b/src/rust/session/src/stream.rs
@@ -8,7 +8,7 @@ use std::io::{Error, ErrorKind};
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 
-use boring::ssl::{HandshakeError, MidHandshakeSslStream, SslStream};
+use common::ssl::{HandshakeError, MidHandshakeSslStream, SslStream};
 
 use super::TcpStream;
 use crate::{TCP_CLOSE, TCP_CONN_CURR};


### PR DESCRIPTION
Updates `boring` crate to 2.0.0 which uses the same version of
boringssl but has improvements in the rust wrapper.

Centralizes dependency in the common crate