### PR TITLE
rust: add support for increment and decrement

### DIFF
--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -130,12 +130,22 @@ impl MemcacheStorage for Seg {
         }
     }
 
-    fn incr(&mut self, _key: &[u8], _value: u64) -> Result<u64, MemcacheStorageError> {
-        Err(MemcacheStorageError::NotSupported)
+    fn incr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
+        match self.data.increment(key, value) {
+            Ok(count) => Ok(count),
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::NotNumeric),
+            Err(_) => Err(MemcacheStorageError::NotSupported),
+        }
     }
 
-    fn decr(&mut self, _key: &[u8], _value: u64) -> Result<u64, MemcacheStorageError> {
-        Err(MemcacheStorageError::NotSupported)
+    fn decr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
+        match self.data.decrement(key, value) {
+            Ok(count) => Ok(count),
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::NotNumeric),
+            Err(_) => Err(MemcacheStorageError::NotSupported),
+        }
     }
 
     fn cas(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {

--- a/src/rust/protocol/src/memcache/storage/mod.rs
+++ b/src/rust/protocol/src/memcache/storage/mod.rs
@@ -12,6 +12,7 @@ pub enum MemcacheStorageError {
     NotFound,
     NotStored,
     NotSupported,
+    NotNumeric,
 }
 
 /// Defines operations that arbitrary storage must be able to handle to be used

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -181,6 +181,7 @@ where
                 let response = match self.incr(key, value) {
                     Ok(count) => MemcacheResult::Count(count),
                     Err(MemcacheStorageError::NotFound) => MemcacheResult::NotFound,
+                    Err(MemcacheStorageError::NotNumeric) => MemcacheResult::ClientError,
                     Err(MemcacheStorageError::NotSupported) => MemcacheResult::Error,
                     _ => {
                         unreachable!()
@@ -199,6 +200,7 @@ where
                 let response = match self.decr(key, value) {
                     Ok(count) => MemcacheResult::Count(count),
                     Err(MemcacheStorageError::NotFound) => MemcacheResult::NotFound,
+                    Err(MemcacheStorageError::NotNumeric) => MemcacheResult::ClientError,
                     Err(MemcacheStorageError::NotSupported) => MemcacheResult::Error,
                     _ => {
                         unreachable!()

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -76,6 +76,40 @@ pub fn tests() {
     );
     test("get value (key: 2)", &[("get 2\r\n", Some("END\r\n"))]);
 
+    // test incr/decr
+    test(
+        "set value (key: 0)",
+        &[("set 0 0 100 1\r\n1\r\n", Some("STORED\r\n"))],
+    );
+    test(
+        "set value (key: key)",
+        &[("set key 0 100 1\r\na\r\n", Some("STORED\r\n"))],
+    );
+    test(
+        "incr (key: 0)",
+        &[("incr 0 1\r\n", Some("2\r\n"))]
+    );
+    test(
+        "decr (key: 0)",
+        &[("decr 0 1\r\n", Some("1\r\n"))]
+    );
+    test(
+        "incr (key: key)",
+        &[("incr key 1\r\n", Some("CLIENT_ERROR\r\n"))]
+    );
+    test(
+        "decr (key: key)",
+        &[("decr key 1\r\n", Some("CLIENT_ERROR\r\n"))]
+    );
+    test(
+        "incr (key: 9)",
+        &[("incr 9 1\r\n", Some("NOT_FOUND\r\n"))]
+    );
+    test(
+        "decr (key: 9)",
+        &[("decr 9 1\r\n", Some("NOT_FOUND\r\n"))]
+    );
+
     // test storing and retrieving flags
     test(
         "set value (key: 3)",
@@ -120,8 +154,6 @@ pub fn tests() {
         "prepend (key: 8)",
         &[("prepend 8 0 0 1\r\n0\r\n", Some("ERROR\r\n"))],
     );
-    test("incr (key: 9)", &[("incr 9 1\r\n", Some("ERROR\r\n"))]);
-    test("decr (key: 9)", &[("decr 9 1\r\n", Some("ERROR\r\n"))]);
 
     std::thread::sleep(Duration::from_millis(500));
 }

--- a/src/rust/storage/seg/src/error.rs
+++ b/src/rust/storage/seg/src/error.rs
@@ -23,4 +23,6 @@ pub enum SegError<'a> {
     NotFound,
     #[error("data corruption detected")]
     DataCorrupted,
+    #[error("item is not numeric")]
+    NotNumeric,
 }

--- a/src/rust/storage/seg/src/item/mod.rs
+++ b/src/rust/storage/seg/src/item/mod.rs
@@ -11,7 +11,7 @@ mod reserved;
 #[cfg(any(feature = "magic", feature = "debug"))]
 pub(crate) use header::ITEM_MAGIC_SIZE;
 
-use crate::Value;
+use crate::{Value, SegError};
 
 pub(crate) use header::{ItemHeader, ITEM_HDR_SIZE};
 pub(crate) use raw::RawItem;
@@ -58,6 +58,14 @@ impl Item {
     /// Borrow the optional data
     pub fn optional(&self) -> Option<&[u8]> {
         self.raw.optional()
+    }
+
+    pub(crate) fn increment(&mut self, rhs: u64) -> Result<u64, SegError> {
+        self.raw.increment(rhs)
+    }
+
+    pub(crate) fn decrement(&mut self, rhs: u64) -> Result<u64, SegError> {
+        self.raw.decrement(rhs)
     }
 }
 

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -240,6 +240,22 @@ impl Seg {
         }
     }
 
+    pub fn increment(&mut self, key: &[u8], rhs: u64) -> Result<u64, SegError> {
+        if let Some(mut item) = self.get(key) {
+            item.increment(rhs).map_err(|_| SegError::NotNumeric)
+        } else {
+            Err(SegError::NotFound)
+        }
+    }
+
+    pub fn decrement(&mut self, key: &[u8], rhs: u64) -> Result<u64, SegError> {
+        if let Some(mut item) = self.get(key) {
+            item.decrement(rhs).map_err(|_| SegError::NotNumeric)
+        } else {
+            Err(SegError::NotFound)
+        }
+    }
+
     /// Remove the item with the given key, returns a bool indicating if it was
     /// removed.
     /// ```

--- a/src/rust/storage/seg/src/tests.rs
+++ b/src/rust/storage/seg/src/tests.rs
@@ -173,9 +173,46 @@ fn delete() {
     let value = item.value();
     assert_eq!(value, b"coffee", "item is: {:?}", item);
 
-    assert_eq!(cache.delete(b"drink"), true);
+    assert!(cache.delete(b"drink"));
     assert_eq!(cache.segments.free(), 63);
     assert_eq!(cache.items(), 0);
+}
+
+#[test]
+fn incr_decr() {
+    let ttl = Duration::ZERO;
+    let segment_size = 4096;
+    let segments = 64;
+    let heap_size = segments * segment_size as usize;
+
+    let mut cache = Seg::builder()
+        .segment_size(segment_size)
+        .heap_size(heap_size)
+        .build();
+    assert_eq!(cache.items(), 0);
+    assert_eq!(cache.segments.free(), 64);
+    assert!(cache.insert(b"coffee", 0, None, ttl).is_ok());
+    assert_eq!(cache.segments.free(), 63);
+    assert_eq!(cache.items(), 1);
+    assert!(cache.get(b"coffee").is_some());
+
+    let item = cache.get(b"coffee").unwrap();
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache.increment(b"coffee", 1).expect("failed to increment");
+    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    cache.increment(b"coffee", u64::MAX - 1).expect("failed to increment");
+    assert_eq!(item.value(), u64::MAX, "item is: {:?}", item);
+    cache.increment(b"coffee", 1).expect("failed to increment");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache.increment(b"coffee", 2).expect("failed to increment");
+    assert_eq!(item.value(), 2, "item is: {:?}", item);
+
+    cache.decrement(b"coffee", 1).expect("failed to decrement");
+    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    cache.decrement(b"coffee", 2).expect("failed to decrement");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache.decrement(b"coffee", 1).expect("failed to decrement");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
 }
 
 #[test]
@@ -233,7 +270,7 @@ fn collisions() {
     let v = b"8";
     assert!(cache.insert(v, v, None, ttl).is_err());
     assert_eq!(cache.items(), 7);
-    assert_eq!(cache.delete(b"0"), true);
+    assert!(cache.delete(b"0"));
     assert_eq!(cache.items(), 6);
     assert!(cache.insert(v, v, None, ttl).is_ok());
     assert_eq!(cache.items(), 7);

--- a/src/rust/storage/types/src/lib.rs
+++ b/src/rust/storage/types/src/lib.rs
@@ -99,6 +99,15 @@ impl<'a> PartialEq<[u8]> for Value<'a> {
     }
 }
 
+impl PartialEq<u64> for Value<'_> {
+    fn eq(&self, rhs: &u64) -> bool {
+        match self {
+            Value::Bytes(_) => false,
+            Value::U64(v) => *v == *rhs,
+        }
+    }
+}
+
 impl<'a> core::fmt::Debug for Value<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match &self {


### PR DESCRIPTION
Picking up where https://github.com/twitter/pelikan/pull/383 left off.
@brayniac @thinkingfish 

---
Notes:
- Display `CLIENT_ERROR` for cases when incrementing/decrementing a key with value type that is not`U64`. 
- Updated tests

Testing:
```
% telnet localhost 12321
...
set key 0 100 3
200
STORED
incr key 5
205
decr key 100
105
incr key2 5
NOT_FOUND
set key 0 100 3
val
STORED
incr key 10
CLIENT_ERROR
```

