### PR TITLE
segcache-rs: add incr/decr support

### DIFF
--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -132,25 +132,25 @@ impl MemcacheStorage for Seg {
 
     fn incr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
         match self.data.wrapping_add(key, value) {
-            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
-            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
-            Err(_) => Err(MemcacheStorageError::ServerError),
             Ok(item) => match item.value() {
                 Value::U64(v) => Ok(v),
                 _ => Err(MemcacheStorageError::ServerError),
             },
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
+            Err(_) => Err(MemcacheStorageError::ServerError),
         }
     }
 
     fn decr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
         match self.data.saturating_sub(key, value) {
-            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
-            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
-            Err(_) => Err(MemcacheStorageError::ServerError),
             Ok(item) => match item.value() {
                 Value::U64(v) => Ok(v),
                 _ => Err(MemcacheStorageError::ServerError),
             },
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
+            Err(_) => Err(MemcacheStorageError::ServerError),
         }
     }
 

--- a/src/rust/entrystore/src/seg/memcache.rs
+++ b/src/rust/entrystore/src/seg/memcache.rs
@@ -130,12 +130,28 @@ impl MemcacheStorage for Seg {
         }
     }
 
-    fn incr(&mut self, _key: &[u8], _value: u64) -> Result<u64, MemcacheStorageError> {
-        Err(MemcacheStorageError::NotSupported)
+    fn incr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
+        match self.data.wrapping_add(key, value) {
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
+            Err(_) => Err(MemcacheStorageError::ServerError),
+            Ok(item) => match item.value() {
+                Value::U64(v) => Ok(v),
+                _ => Err(MemcacheStorageError::ServerError),
+            },
+        }
     }
 
-    fn decr(&mut self, _key: &[u8], _value: u64) -> Result<u64, MemcacheStorageError> {
-        Err(MemcacheStorageError::NotSupported)
+    fn decr(&mut self, key: &[u8], value: u64) -> Result<u64, MemcacheStorageError> {
+        match self.data.saturating_sub(key, value) {
+            Err(SegError::NotFound) => Err(MemcacheStorageError::NotFound),
+            Err(SegError::NotNumeric) => Err(MemcacheStorageError::Error),
+            Err(_) => Err(MemcacheStorageError::ServerError),
+            Ok(item) => match item.value() {
+                Value::U64(v) => Ok(v),
+                _ => Err(MemcacheStorageError::ServerError),
+            },
+        }
     }
 
     fn cas(&mut self, entry: &MemcacheEntry) -> Result<(), MemcacheStorageError> {

--- a/src/rust/entrystore/src/seg/mod.rs
+++ b/src/rust/entrystore/src/seg/mod.rs
@@ -10,7 +10,7 @@ use crate::EntryStore;
 
 use config::seg::Eviction;
 use config::SegConfig;
-use seg::{Policy, SegError};
+use seg::{Policy, SegError, Value};
 
 mod memcache;
 

--- a/src/rust/protocol/src/memcache/storage/mod.rs
+++ b/src/rust/protocol/src/memcache/storage/mod.rs
@@ -12,6 +12,9 @@ pub enum MemcacheStorageError {
     NotFound,
     NotStored,
     NotSupported,
+    ServerError,
+    ClientError,
+    Error,
 }
 
 /// Defines operations that arbitrary storage must be able to handle to be used

--- a/src/rust/protocol/src/memcache/wire/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/mod.rs
@@ -182,6 +182,7 @@ where
                     Ok(count) => MemcacheResult::Count(count),
                     Err(MemcacheStorageError::NotFound) => MemcacheResult::NotFound,
                     Err(MemcacheStorageError::NotSupported) => MemcacheResult::Error,
+                    Err(MemcacheStorageError::Error) => MemcacheResult::Error,
                     _ => {
                         unreachable!()
                     }
@@ -200,6 +201,7 @@ where
                     Ok(count) => MemcacheResult::Count(count),
                     Err(MemcacheStorageError::NotFound) => MemcacheResult::NotFound,
                     Err(MemcacheStorageError::NotSupported) => MemcacheResult::Error,
+                    Err(MemcacheStorageError::Error) => MemcacheResult::Error,
                     _ => {
                         unreachable!()
                     }

--- a/src/rust/protocol/src/memcache/wire/response/mod.rs
+++ b/src/rust/protocol/src/memcache/wire/response/mod.rs
@@ -202,6 +202,7 @@ impl Compose for MemcacheResponse {
                     MemcacheResult::Error => {
                         INCR_EX.increment();
                     }
+                    MemcacheResult::Count { .. } => {}
                     _ => {
                         error!("didn't expect: {:?} for {:?}", self.result, self.request);
                         unreachable!()
@@ -217,6 +218,7 @@ impl Compose for MemcacheResponse {
                     MemcacheResult::Error => {
                         DECR_EX.increment();
                     }
+                    MemcacheResult::Count { .. } => {}
                     _ => {
                         error!("didn't expect: {:?} for {:?}", self.result, self.request);
                         unreachable!()

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -111,6 +111,42 @@ pub fn tests() {
         )],
     );
 
+    // test increment
+    test("incr (key: 9)", &[("incr 9 1\r\n", Some("NOT_FOUND\r\n"))]);
+    test(
+        "set value (key: 9)",
+        &[("set 9 0 0 1\r\n0\r\n", Some("STORED\r\n"))],
+    );
+    test("incr (key: 9)", &[("incr 9 1\r\n", Some("1\r\n"))]);
+    test("incr (key: 9)", &[("incr 9 2\r\n", Some("3\r\n"))]);
+    test(
+        "incr (key: 9)",
+        &[(&format!("incr 9 {}\r\n", u64::MAX), Some("2\r\n"))],
+    );
+    test(
+        "set value (key: 9)",
+        &[("set 9 0 0 1\r\na\r\n", Some("STORED\r\n"))],
+    );
+    test("incr (key: 9)", &[("incr 9 1\r\n", Some("ERROR\r\n"))]);
+
+    // test decrement
+    test(
+        "decr (key: 10)",
+        &[("decr 10 1\r\n", Some("NOT_FOUND\r\n"))],
+    );
+    test(
+        "set value (key: 10)",
+        &[("set 10 0 0 2\r\n10\r\n", Some("STORED\r\n"))],
+    );
+    test("decr (key: 10)", &[("decr 10 1\r\n", Some("9\r\n"))]);
+    test("decr (key: 10)", &[("decr 10 2\r\n", Some("7\r\n"))]);
+    test("decr (key: 10)", &[("decr 10 8\r\n", Some("0\r\n"))]);
+    test(
+        "set value (key: 10)",
+        &[("set 10 0 0 1\r\na\r\n", Some("STORED\r\n"))],
+    );
+    test("decr (key: 10)", &[("decr 10 1\r\n", Some("ERROR\r\n"))]);
+
     // test unsupported commands
     test(
         "append (key: 7)",
@@ -120,8 +156,6 @@ pub fn tests() {
         "prepend (key: 8)",
         &[("prepend 8 0 0 1\r\n0\r\n", Some("ERROR\r\n"))],
     );
-    test("incr (key: 9)", &[("incr 9 1\r\n", Some("ERROR\r\n"))]);
-    test("decr (key: 9)", &[("decr 9 1\r\n", Some("ERROR\r\n"))]);
 
     std::thread::sleep(Duration::from_millis(500));
 }

--- a/src/rust/storage/seg/src/error.rs
+++ b/src/rust/storage/seg/src/error.rs
@@ -6,15 +6,15 @@
 
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq, Copy, Clone)]
 /// Possible errors returned by the top-level API
-pub enum SegError<'a> {
+pub enum SegError {
     #[error("hashtable insert exception")]
     HashTableInsertEx,
     #[error("eviction exception")]
     EvictionEx,
-    #[error("item oversized ({size:?} bytes) for key: {key:?}")]
-    ItemOversized { size: usize, key: &'a [u8] },
+    #[error("item oversized ({size:?} bytes)")]
+    ItemOversized { size: usize },
     #[error("no free segments")]
     NoFreeSegments,
     #[error("item exists")]
@@ -23,4 +23,6 @@ pub enum SegError<'a> {
     NotFound,
     #[error("data corruption detected")]
     DataCorrupted,
+    #[error("item is not numeric")]
+    NotNumeric,
 }

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -513,7 +513,7 @@ impl HashTable {
         key: &'a [u8],
         cas: u32,
         segments: &mut Segments,
-    ) -> Result<(), SegError<'a>> {
+    ) -> Result<(), SegError> {
         let hash = self.hash(key);
         let tag = tag_from_hash(hash);
         let bucket_id = hash & self.mask;

--- a/src/rust/storage/seg/src/item/mod.rs
+++ b/src/rust/storage/seg/src/item/mod.rs
@@ -11,6 +11,7 @@ mod reserved;
 #[cfg(any(feature = "magic", feature = "debug"))]
 pub(crate) use header::ITEM_MAGIC_SIZE;
 
+use crate::SegError;
 use crate::Value;
 
 pub(crate) use header::{ItemHeader, ITEM_HDR_SIZE};
@@ -58,6 +59,18 @@ impl Item {
     /// Borrow the optional data
     pub fn optional(&self) -> Option<&[u8]> {
         self.raw.optional()
+    }
+
+    /// Perform a wrapping addition on the value. Returns an error if the item
+    /// is not a numeric type.
+    pub fn wrapping_add(&mut self, rhs: u64) -> Result<(), SegError> {
+        self.raw.wrapping_add(rhs)
+    }
+
+    /// Perform a saturating subtraction on the value. Returns an error if the
+    /// item is not a numeric type.
+    pub fn saturating_sub(&mut self, rhs: u64) -> Result<(), SegError> {
+        self.raw.saturating_sub(rhs)
     }
 }
 

--- a/src/rust/storage/seg/src/tests.rs
+++ b/src/rust/storage/seg/src/tests.rs
@@ -396,3 +396,75 @@ fn clear() {
     assert_eq!(cache.items(), 0);
     assert!(cache.get(b"coffee").is_none());
 }
+
+#[test]
+fn wrapping_add() {
+    let ttl = Duration::ZERO;
+    let segment_size = 4096;
+    let segments = 64;
+    let heap_size = segments * segment_size as usize;
+
+    let mut cache = Seg::builder()
+        .segment_size(segment_size)
+        .heap_size(heap_size)
+        .build();
+    assert_eq!(cache.items(), 0);
+    assert_eq!(cache.segments.free(), 64);
+    assert!(cache.insert(b"coffee", 0, None, ttl).is_ok());
+    assert_eq!(cache.segments.free(), 63);
+    assert_eq!(cache.items(), 1);
+    assert!(cache.get(b"coffee").is_some());
+
+    let item = cache.get(b"coffee").unwrap();
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache
+        .wrapping_add(b"coffee", 1)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    cache
+        .wrapping_add(b"coffee", u64::MAX - 1)
+        .expect("failed to increment");
+    assert_eq!(item.value(), u64::MAX, "item is: {:?}", item);
+    cache
+        .wrapping_add(b"coffee", 1)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache
+        .wrapping_add(b"coffee", 2)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 2, "item is: {:?}", item);
+}
+
+#[test]
+fn saturating_sub() {
+    let ttl = Duration::ZERO;
+    let segment_size = 4096;
+    let segments = 64;
+    let heap_size = segments * segment_size as usize;
+
+    let mut cache = Seg::builder()
+        .segment_size(segment_size)
+        .heap_size(heap_size)
+        .build();
+    assert_eq!(cache.items(), 0);
+    assert_eq!(cache.segments.free(), 64);
+    assert!(cache.insert(b"coffee", 3, None, ttl).is_ok());
+    assert_eq!(cache.segments.free(), 63);
+    assert_eq!(cache.items(), 1);
+    assert!(cache.get(b"coffee").is_some());
+
+    let item = cache.get(b"coffee").unwrap();
+    assert_eq!(item.value(), 3, "item is: {:?}", item);
+    cache
+        .saturating_sub(b"coffee", 2)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 1, "item is: {:?}", item);
+    cache
+        .saturating_sub(b"coffee", 1)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+    cache
+        .saturating_sub(b"coffee", 1)
+        .expect("failed to increment");
+    assert_eq!(item.value(), 0, "item is: {:?}", item);
+}

--- a/src/rust/storage/types/src/lib.rs
+++ b/src/rust/storage/types/src/lib.rs
@@ -99,6 +99,15 @@ impl<'a> PartialEq<[u8]> for Value<'a> {
     }
 }
 
+impl<'a> PartialEq<u64> for Value<'a> {
+    fn eq(&self, rhs: &u64) -> bool {
+        match self {
+            Value::Bytes(_) => false,
+            Value::U64(v) => *v == *rhs,
+        }
+    }
+}
+
 impl<'a> core::fmt::Debug for Value<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         match &self {


### PR DESCRIPTION
Adds support for incr/decr commands to segcache-rs.

In the storage library, we explicitly implement these commands
as wrapping_add() and saturating_sub(). This allows us to choose
the behaviors at higher-levels and potentially make additional
operations available in different protocols.

The implementation in segcache-rs aims to be memcached
compatible and returns "ERROR" when numeric operations are
attempted on non-numeric values.

Replaces #383 and #395