### PR TITLE
rust: update mio to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",

--- a/src/rust/core/server/Cargo.toml
+++ b/src/rust/core/server/Cargo.toml
@@ -20,7 +20,7 @@ crossbeam-channel = "0.5.0"
 libc = "0.2.83"
 logger = { path = "../../logger" }
 metrics = { path = "../../metrics" }
-mio = { version = "0.7.7", features = ["os-poll", "tcp"] }
+mio = { version = "0.8.0", features = ["os-poll", "net"] }
 protocol = { path = "../../protocol" }
 queues = { path = "../../queues" }
 rand = "0.8.0"

--- a/src/rust/queues/Cargo.toml
+++ b/src/rust/queues/Cargo.toml
@@ -12,5 +12,5 @@ license = "Apache-2.0"
 
 [dependencies]
 crossbeam-channel = "0.5.0"
-mio = { version = "0.7.7", features = ["os-poll", "tcp"] }
+mio = { version = "0.8.0", features = ["os-poll", "net"] }
 rtrb = "0.1.3"

--- a/src/rust/session/Cargo.toml
+++ b/src/rust/session/Cargo.toml
@@ -15,7 +15,7 @@ common = { path = "../common" }
 config = { path = "../config" }
 logger = { path = "../logger" }
 metrics = { path = "../metrics" }
-mio = { version = "0.7.7", features = ["os-poll", "tcp"] }
+mio = { version = "0.8.0", features = ["os-poll", "net"] }
 rand = "0.8.0"
 rtrb = "0.1.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Updates mio to 0.8.0. See changelog for details (https://github.com/tokio-rs/mio/blob/master/CHANGELOG.md). No performance change detected in testing with pingserver