### PR TITLE
protocol/ping: make request and response symmetric

### DIFF
--- a/src/rust/entrystore/src/noop/ping.rs
+++ b/src/rust/entrystore/src/noop/ping.rs
@@ -10,10 +10,10 @@ use protocol_ping::*;
 
 impl PingStorage for Noop {}
 
-impl Execute<PingRequest, PingResponse> for Noop {
-    fn execute(&mut self, request: PingRequest) -> Option<PingResponse> {
+impl Execute<Request, Response> for Noop {
+    fn execute(&mut self, request: Request) -> Option<Response> {
         let response = match request {
-            PingRequest::Ping => PingResponse::Pong,
+            Request::Ping => Response::Pong,
         };
 
         Some(response)

--- a/src/rust/protocol/admin/src/admin.rs
+++ b/src/rust/protocol/admin/src/admin.rs
@@ -42,7 +42,7 @@ impl Parse<AdminRequest> for AdminRequestParser {
                 // remove the need for ignoring this lint.
                 #[allow(clippy::match_single_binding)]
                 match command_verb {
-                    _ => Err(ParseError::UnknownCommand),
+                    _ => Err(ParseError::Unknown),
                 }
             } else {
                 match &buffer[0..command_end] {
@@ -56,7 +56,7 @@ impl Parse<AdminRequest> for AdminRequestParser {
                         AdminRequest::Version,
                         command_end + CRLF.len(),
                     )),
-                    _ => Err(ParseError::UnknownCommand),
+                    _ => Err(ParseError::Unknown),
                 }
             }
         } else {

--- a/src/rust/protocol/common/src/lib.rs
+++ b/src/rust/protocol/common/src/lib.rs
@@ -22,7 +22,7 @@ pub trait Execute<Request, Response> {
 pub enum ParseError {
     Invalid,
     Incomplete,
-    UnknownCommand,
+    Unknown,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/rust/protocol/memcache/src/memcache/wire/request/command.rs
+++ b/src/rust/protocol/memcache/src/memcache/wire/request/command.rs
@@ -44,7 +44,7 @@ impl TryFrom<&[u8]> for MemcacheCommand {
             b"quit" => MemcacheCommand::Quit,
             b"flush_all" => MemcacheCommand::FlushAll,
             _ => {
-                return Err(ParseError::UnknownCommand);
+                return Err(ParseError::Unknown);
             }
         };
         Ok(cmd)

--- a/src/rust/protocol/ping/Cargo.toml
+++ b/src/rust/protocol/ping/Cargo.toml
@@ -24,3 +24,8 @@ storage-types = { path = "../../storage/types" }
 
 [dev-dependencies]
 criterion = "0.3.4"
+
+[features]
+default = []
+client = []
+server = []

--- a/src/rust/protocol/ping/benches/ping.rs
+++ b/src/rust/protocol/ping/benches/ping.rs
@@ -14,7 +14,7 @@ const BUFFER_SIZE: usize = 16 * KB;
 const DURATION: u64 = 30; // seconds
 
 fn ping(c: &mut Criterion) {
-    let parser = PingRequestParser::new();
+    let parser = RequestParser::new();
 
     let mut group = c.benchmark_group("ping");
     group.measurement_time(Duration::from_secs(DURATION));

--- a/src/rust/protocol/ping/fuzz/fuzz_targets/ping.rs
+++ b/src/rust/protocol/ping/fuzz/fuzz_targets/ping.rs
@@ -10,7 +10,7 @@ use libfuzzer_sys::fuzz_target;
 
 use protocol_ping::*;
 
-const PARSER: PingRequestParser = PingRequestParser {};
+const PARSER: RequestParser = RequestParser {};
 
 fuzz_target!(|data: &[u8]| {
     let _ = PARSER.parse(data);

--- a/src/rust/protocol/ping/src/ping/mod.rs
+++ b/src/rust/protocol/ping/src/ping/mod.rs
@@ -8,4 +8,4 @@ mod storage;
 mod wire;
 
 pub use storage::PingStorage;
-pub use wire::{PingRequest, PingRequestParser, PingResponse};
+pub use wire::{Request, RequestParser, Response, ResponseParser};

--- a/src/rust/protocol/ping/src/ping/wire/mod.rs
+++ b/src/rust/protocol/ping/src/ping/wire/mod.rs
@@ -10,8 +10,15 @@ mod response;
 pub use request::*;
 pub use response::*;
 
+#[allow(unused_imports)]
 use metrics::{static_metrics, Counter};
 
+#[cfg(feature = "server")]
 static_metrics! {
     static PING: Counter;
+}
+
+#[cfg(feature = "client")]
+static_metrics! {
+    static PONG: Counter;
 }

--- a/src/rust/protocol/ping/src/ping/wire/request/compose.rs
+++ b/src/rust/protocol/ping/src/ping/wire/request/compose.rs
@@ -1,0 +1,20 @@
+use crate::Compose;
+use crate::Request;
+use session::Session;
+use std::io::Write;
+
+// TODO(bmartin): consider a different trait bound here when reworking buffers.
+// We ignore the unused result warnings here because we know we're using a
+// buffer with infallible writes (growable buffer). This is *not* guaranteed by
+// the current trait bound.
+
+#[allow(unused_must_use)]
+impl Compose for Request {
+    fn compose(self, dst: &mut Session) {
+        match self {
+            Self::Ping => {
+                dst.write_all(b"ping\r\n");
+            }
+        }
+    }
+}

--- a/src/rust/protocol/ping/src/ping/wire/request/keyword.rs
+++ b/src/rust/protocol/ping/src/ping/wire/request/keyword.rs
@@ -7,21 +7,21 @@
 use crate::ParseError;
 use core::convert::TryFrom;
 
-/// Ping protocol commands
-pub enum PingCommand {
+/// Ping request keywords
+pub enum Keyword {
     Ping,
 }
 
-impl TryFrom<&[u8]> for PingCommand {
+impl TryFrom<&[u8]> for Keyword {
     type Error = ParseError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let cmd = match value {
+        let keyword = match value {
             b"ping" | b"PING" => Self::Ping,
             _ => {
-                return Err(ParseError::UnknownCommand);
+                return Err(ParseError::Unknown);
             }
         };
-        Ok(cmd)
+        Ok(keyword)
     }
 }

--- a/src/rust/protocol/ping/src/ping/wire/request/mod.rs
+++ b/src/rust/protocol/ping/src/ping/wire/request/mod.rs
@@ -4,17 +4,19 @@
 
 //! Implements all request parsing and validation for the `Ping` protocol.
 
-mod command;
+mod compose;
+mod keyword;
 mod parse;
 
 #[cfg(test)]
 mod test;
 
-pub use command::PingCommand;
-pub use parse::PingRequestParser;
+pub use keyword::Keyword;
+
+pub use parse::Parser as RequestParser;
 
 #[derive(Debug)]
 /// A collection of all possible `Ping` request types.
-pub enum PingRequest {
+pub enum Request {
     Ping,
 }

--- a/src/rust/protocol/ping/src/ping/wire/request/parse.rs
+++ b/src/rust/protocol/ping/src/ping/wire/request/parse.rs
@@ -8,8 +8,8 @@
 use super::super::*;
 use crate::*;
 
-use core::slice::Windows;
 use core::convert::TryFrom;
+use core::slice::Windows;
 
 #[derive(Default, Copy, Clone)]
 pub struct Parser {}

--- a/src/rust/protocol/ping/src/ping/wire/response/compose.rs
+++ b/src/rust/protocol/ping/src/ping/wire/response/compose.rs
@@ -1,0 +1,20 @@
+use crate::Compose;
+use crate::Response;
+use session::Session;
+use std::io::Write;
+
+// TODO(bmartin): consider a different trait bound here when reworking buffers.
+// We ignore the unused result warnings here because we know we're using a
+// buffer with infallible writes (growable buffer). This is *not* guaranteed by
+// the current trait bound.
+
+#[allow(unused_must_use)]
+impl Compose for Response {
+    fn compose(self, dst: &mut Session) {
+        match self {
+            Self::Pong => {
+                dst.write_all(b"PONG\r\n");
+            }
+        }
+    }
+}

--- a/src/rust/protocol/ping/src/ping/wire/response/keyword.rs
+++ b/src/rust/protocol/ping/src/ping/wire/response/keyword.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+//! This module defines all possible `Ping` commands.
+
+use crate::ParseError;
+use core::convert::TryFrom;
+
+/// Ping response keywords
+pub enum Keyword {
+    Pong,
+}
+
+impl TryFrom<&[u8]> for Keyword {
+    type Error = ParseError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let cmd = match value {
+            b"pong" | b"PONG" => Self::Pong,
+            _ => {
+                return Err(ParseError::Unknown);
+            }
+        };
+        Ok(cmd)
+    }
+}

--- a/src/rust/protocol/ping/src/ping/wire/response/mod.rs
+++ b/src/rust/protocol/ping/src/ping/wire/response/mod.rs
@@ -5,26 +5,16 @@
 //! Implements the serialization of `Ping` protocol responses into the wire
 //! representation.
 
-use crate::Compose;
-use session::Session;
-use std::io::Write;
+mod compose;
+mod keyword;
+mod parse;
+
+#[cfg(test)]
+mod test;
+
+pub use parse::Parser as ResponseParser;
 
 /// A collection of all possible `Ping` responses
-pub enum PingResponse {
+pub enum Response {
     Pong,
-}
-
-// TODO(bmartin): consider a different trait bound here when reworking buffers.
-// We ignore the unused result warnings here because we know we're using a
-// buffer with infallible writes (growable buffer). This is *not* guaranteed by
-// the current trait bound.
-#[allow(unused_must_use)]
-impl Compose for PingResponse {
-    fn compose(self, dst: &mut Session) {
-        match self {
-            Self::Pong => {
-                dst.write_all(b"PONG\r\n");
-            }
-        }
-    }
 }

--- a/src/rust/protocol/ping/src/ping/wire/response/parse.rs
+++ b/src/rust/protocol/ping/src/ping/wire/response/parse.rs
@@ -6,10 +6,11 @@
 //! into a request object.
 
 use super::super::*;
+use crate::ping::wire::response::keyword::Keyword;
 use crate::*;
 
 use core::slice::Windows;
-use core::convert::TryFrom;
+use std::convert::TryFrom;
 
 #[derive(Default, Copy, Clone)]
 pub struct Parser {}
@@ -20,10 +21,10 @@ impl Parser {
     }
 }
 
-impl Parse<Request> for Parser {
-    fn parse(&self, buffer: &[u8]) -> Result<ParseOk<Request>, ParseError> {
+impl Parse<Response> for Parser {
+    fn parse(&self, buffer: &[u8]) -> Result<ParseOk<Response>, ParseError> {
         match parse_keyword(buffer)? {
-            Keyword::Ping => parse_ping(buffer),
+            Keyword::Pong => parse_pong(buffer),
         }
     }
 }
@@ -70,7 +71,7 @@ fn parse_keyword(buffer: &[u8]) -> Result<Keyword, ParseError> {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn parse_ping(buffer: &[u8]) -> Result<ParseOk<Request>, ParseError> {
+fn parse_pong(buffer: &[u8]) -> Result<ParseOk<Response>, ParseError> {
     let mut parse_state = ParseState::new(buffer);
 
     // this was already checked for when determining the command
@@ -78,10 +79,10 @@ fn parse_ping(buffer: &[u8]) -> Result<ParseOk<Request>, ParseError> {
 
     let consumed = line_end + CRLF.len();
 
-    let message = Request::Ping;
+    let message = Response::Pong;
 
-    #[cfg(feature = "server")]
-    PING.increment();
+    #[cfg(feature = "client")]
+    PONG.increment();
 
     Ok(ParseOk::new(message, consumed))
 }

--- a/src/rust/protocol/ping/src/ping/wire/response/test.rs
+++ b/src/rust/protocol/ping/src/ping/wire/response/test.rs
@@ -4,22 +4,22 @@
 
 //! Tests for the `Ping` protocol implementation.
 
-use crate::RequestParser;
+use crate::ping::ResponseParser;
 use crate::*;
 
 #[test]
 fn ping() {
-    let parser = RequestParser::new();
+    let parser = ResponseParser::new();
 
-    assert!(parser.parse(b"ping\r\n").is_ok());
-    assert!(parser.parse(b"PING\r\n").is_ok());
+    assert!(parser.parse(b"pong\r\n").is_ok());
+    assert!(parser.parse(b"PONG\r\n").is_ok());
 }
 
 #[test]
 fn incomplete() {
-    let parser = RequestParser::new();
+    let parser = ResponseParser::new();
 
-    if let Err(e) = parser.parse(b"ping") {
+    if let Err(e) = parser.parse(b"pong") {
         if e != ParseError::Incomplete {
             panic!("invalid parse result");
         }
@@ -30,14 +30,14 @@ fn incomplete() {
 
 #[test]
 fn trailing_whitespace() {
-    let parser = RequestParser::new();
+    let parser = ResponseParser::new();
 
-    assert!(parser.parse(b"ping \r\n").is_ok())
+    assert!(parser.parse(b"pong \r\n").is_ok())
 }
 
 #[test]
 fn unknown() {
-    let parser = RequestParser::new();
+    let parser = ResponseParser::new();
 
     for request in &["unknown\r\n"] {
         if let Err(e) = parser.parse(request.as_bytes()) {
@@ -52,7 +52,7 @@ fn unknown() {
 
 #[test]
 fn pipelined() {
-    let parser = RequestParser::new();
+    let parser = ResponseParser::new();
 
-    assert!(parser.parse(b"ping\r\nping\r\n").is_ok());
+    assert!(parser.parse(b"pong\r\npong\r\n").is_ok());
 }

--- a/src/rust/server/pingserver/Cargo.toml
+++ b/src/rust/server/pingserver/Cargo.toml
@@ -38,7 +38,7 @@ config = { path = "../../config" }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 metrics = { path = "../../metrics" }
-protocol-ping = { path = "../../protocol/ping" }
+protocol-ping = { path = "../../protocol/ping", features = ["server"] }
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/rust/server/pingserver/src/lib.rs
+++ b/src/rust/server/pingserver/src/lib.rs
@@ -12,12 +12,10 @@
 use config::*;
 use entrystore::Noop;
 use logger::*;
-use protocol_ping::{PingRequest, PingRequestParser, PingResponse};
+use protocol_ping::{Request, RequestParser, Response};
 use server::{Process, ProcessBuilder};
 
-type Parser = PingRequestParser;
-type Request = PingRequest;
-type Response = PingResponse;
+type Parser = RequestParser;
 type Storage = Noop;
 
 /// This structure represents a running `Pingserver` process.


### PR DESCRIPTION
We need to implement request composition and response parsing so
that a proxy is able to be protocol aware. This also makes it
possible to use this protocol crate for a client.