### PR TITLE
segcache optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,7 +933,7 @@ dependencies = [
 name = "queues"
 version = "0.2.0"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-queue",
  "mio",
  "rand",
  "rand_chacha",

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -241,7 +241,8 @@ impl Listener {
                         self.do_accept();
                     }
                     WAKER_TOKEN => {
-                        while let Some(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
+                        while let Some(signal) =
+                            self.signal_queue.try_recv().map(|v| v.into_inner())
                         {
                             match signal {
                                 Signal::FlushAll => {}

--- a/src/rust/core/server/src/threads/listener.rs
+++ b/src/rust/core/server/src/threads/listener.rs
@@ -241,7 +241,7 @@ impl Listener {
                         self.do_accept();
                     }
                     WAKER_TOKEN => {
-                        while let Ok(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
+                        while let Some(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
                         {
                             match signal {
                                 Signal::FlushAll => {}

--- a/src/rust/core/server/src/threads/workers/multi.rs
+++ b/src/rust/core/server/src/threads/workers/multi.rs
@@ -129,7 +129,7 @@ where
                         self.handle_storage_queue(&mut responses);
 
                         // check if we received any signals from the admin thread
-                        while let Ok(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
+                        while let Some(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
                         {
                             match signal {
                                 Signal::FlushAll => {}

--- a/src/rust/core/server/src/threads/workers/multi.rs
+++ b/src/rust/core/server/src/threads/workers/multi.rs
@@ -129,7 +129,8 @@ where
                         self.handle_storage_queue(&mut responses);
 
                         // check if we received any signals from the admin thread
-                        while let Some(signal) = self.signal_queue.try_recv().map(|v| v.into_inner())
+                        while let Some(signal) =
+                            self.signal_queue.try_recv().map(|v| v.into_inner())
                         {
                             match signal {
                                 Signal::FlushAll => {}

--- a/src/rust/core/server/src/threads/workers/single.rs
+++ b/src/rust/core/server/src/threads/workers/single.rs
@@ -129,7 +129,7 @@ where
                         self.handle_new_sessions();
 
                         // check if we received any signals from the admin thread
-                        while let Ok(signal) = self.signal_queue.try_recv() {
+                        while let Some(signal) = self.signal_queue.try_recv() {
                             match signal.into_inner() {
                                 Signal::FlushAll => {
                                     warn!("received flush_all");
@@ -152,7 +152,7 @@ where
     }
 
     fn handle_new_sessions(&mut self) {
-        while let Ok(session) = self.session_queue.try_recv().map(|v| v.into_inner()) {
+        while let Some(session) = self.session_queue.try_recv().map(|v| v.into_inner()) {
             let pending = session.read_pending();
             trace!(
                 "new session: {:?} with {} bytes pending in read buffer",

--- a/src/rust/core/server/src/threads/workers/storage.rs
+++ b/src/rust/core/server/src/threads/workers/storage.rs
@@ -130,7 +130,7 @@ where
                 let _ = self.storage_queue.wake();
 
                 // check if we received any signals from the admin thread
-                while let Ok(s) = self.signal_queue.try_recv().map(|v| v.into_inner()) {
+                while let Some(s) = self.signal_queue.try_recv().map(|v| v.into_inner()) {
                     match s {
                         Signal::FlushAll => {
                             warn!("received flush_all");

--- a/src/rust/queues/Cargo.toml
+++ b/src/rust/queues/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-channel = "0.5.2"
+crossbeam-queue = "0.3.5"
 mio = { version = "0.8.0", features = ["os-poll", "net"] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/src/rust/storage/seg/src/builder.rs
+++ b/src/rust/storage/seg/src/builder.rs
@@ -167,6 +167,7 @@ impl Builder {
             hashtable,
             segments,
             ttl_buckets,
+            time: Instant::recent(),
         }
     }
 }

--- a/src/rust/storage/seg/src/eviction/mod.rs
+++ b/src/rust/storage/seg/src/eviction/mod.rs
@@ -40,7 +40,7 @@ impl Eviction {
 
         Self {
             policy,
-            last_update_time: Instant::recent(),
+            last_update_time: Instant::now(),
             ranked_segs,
             index: 0,
             rng: Box::new(rng()),

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -488,7 +488,7 @@ impl HashTable {
         }
 
         if insert_item_info == 0 {
-            self.data[(hash & self.mask) as usize].data[0] += 1 << 32;
+            self.data[(hash & self.mask) as usize].data[0] += 1 << CAS_BIT_SHIFT;
             Ok(())
         } else {
             HASH_INSERT_EX.increment();
@@ -551,7 +551,7 @@ impl HashTable {
 
                         if cas == get_cas(bucket.data[0]) {
                             // TODO(bmartin): what is expected on overflow of the cas bits?
-                            self.data[(hash & self.mask) as usize].data[0] += 1 << 32;
+                            self.data[bucket_id as usize].data[0] += 1 << CAS_BIT_SHIFT;
                             return Ok(());
                         } else {
                             return Err(SegError::Exists);

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -109,7 +109,7 @@ impl Segments {
             free: segments as u32,
             free_q: NonZeroU32::new(1),
             data,
-            flush_at: Instant::recent(),
+            flush_at: Instant::now(),
             evict: Box::new(Eviction::new(segments, evict_policy)),
         }
     }

--- a/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -92,9 +92,7 @@ impl TtlBucket {
             if let Some(seg_id) = seg_id {
                 let flush_at = segments.flush_at();
                 let mut segment = segments.get_mut(seg_id).unwrap();
-                if segment.create_at() + segment.ttl() <= ts
-                    || segment.create_at() < flush_at
-                {
+                if segment.create_at() + segment.ttl() <= ts || segment.create_at() < flush_at {
                     if let Some(next) = segment.next_seg() {
                         self.head = Some(next);
                     } else {

--- a/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/rust/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -85,13 +85,14 @@ impl TtlBucket {
         }
 
         let mut expired = 0;
+        let ts = Instant::recent();
 
         loop {
             let seg_id = self.head;
             if let Some(seg_id) = seg_id {
                 let flush_at = segments.flush_at();
                 let mut segment = segments.get_mut(seg_id).unwrap();
-                if segment.create_at() + segment.ttl() <= Instant::recent()
+                if segment.create_at() + segment.ttl() <= ts
                     || segment.create_at() < flush_at
                 {
                     if let Some(next) = segment.next_seg() {


### PR DESCRIPTION
Some optimizations for segcache performance. On a test system this
gives somewhere around 2% more performance. Benefit may vary
depending on config and workload.

- Reduce calls to Instant::recent() to reduce atomics in hot path.
- Remove trace logging in hot path.
- Change ordering of fields to optimize hot path.
- Use crossbeam_queue instead of crossbeam_channel to remove
  unnecessary channel level wake.