### PR TITLE
add http admin port to rust servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +206,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clang-sys"
@@ -437,6 +449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +516,17 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "instant"
@@ -633,6 +666,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -795,6 +834,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pingserver"
@@ -1258,6 +1303,7 @@ dependencies = [
  "strum_macros",
  "sysconf",
  "thiserror",
+ "tiny_http",
 ]
 
 [[package]]
@@ -1395,6 +1441,26 @@ checksum = "cde1cf55178e0293453ba2cca0d5f8392a922e52aa958aee9c28ed02becc6d03"
 dependencies = [
  "itoa",
  "libc",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+
+[[package]]
+name = "tiny_http"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1408,12 +1474,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1433,6 +1529,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/config/segcache.toml
+++ b/config/segcache.toml
@@ -6,6 +6,13 @@ host = "0.0.0.0"
 # port listening on
 port = "9999"
 
+# enable the http admin port?
+http_enabled = true
+# http listening interface
+http_host = "0.0.0.0"
+# http listening port
+http_port = "9998"
+
 [server]
 # interfaces listening on
 host = "0.0.0.0"

--- a/src/rust/config/src/admin.rs
+++ b/src/rust/config/src/admin.rs
@@ -9,6 +9,9 @@ use serde::{Deserialize, Serialize};
 // constants to define default values
 const ADMIN_HOST: &str = "127.0.0.1";
 const ADMIN_PORT: &str = "9999";
+const ADMIN_HTTP_ENABLED: bool = false;
+const ADMIN_HTTP_HOST: &str = "127.0.0.1";
+const ADMIN_HTTP_PORT: &str = "9998";
 const ADMIN_TIMEOUT: usize = 100;
 const ADMIN_NEVENT: usize = 1024;
 const ADMIN_TW_TICK: usize = 10;
@@ -23,6 +26,18 @@ fn host() -> String {
 
 fn port() -> String {
     ADMIN_PORT.to_string()
+}
+
+fn http_enabled() -> bool {
+    ADMIN_HTTP_ENABLED
+}
+
+fn http_host() -> String {
+    ADMIN_HTTP_HOST.to_string()
+}
+
+fn http_port() -> String {
+    ADMIN_HTTP_PORT.to_string()
 }
 
 fn timeout() -> usize {
@@ -56,6 +71,12 @@ pub struct Admin {
     host: String,
     #[serde(default = "port")]
     port: String,
+    #[serde(default = "http_enabled")]
+    http_enabled: bool,
+    #[serde(default = "http_host")]
+    http_host: String,
+    #[serde(default = "http_port")]
+    http_port: String,
     #[serde(default = "timeout")]
     timeout: usize,
     #[serde(default = "nevent")]
@@ -78,6 +99,14 @@ impl Admin {
 
     pub fn port(&self) -> String {
         self.port.clone()
+    }
+
+    pub fn http_enabled(&self) -> bool {
+        self.http_enabled
+    }
+
+    pub fn http_socket_addr(&self) -> Result<SocketAddr, AddrParseError> {
+        format!("{}:{}", self.http_host, self.http_port).parse()
     }
 
     pub fn timeout(&self) -> usize {
@@ -117,6 +146,9 @@ impl Default for Admin {
         Self {
             host: host(),
             port: port(),
+            http_enabled: http_enabled(),
+            http_host: http_host(),
+            http_port: http_port(),
             timeout: timeout(),
             nevent: nevent(),
             tw_tick: tw_tick(),

--- a/src/rust/config/src/admin.rs
+++ b/src/rust/config/src/admin.rs
@@ -19,6 +19,13 @@ const ADMIN_TW_CAP: usize = 1000;
 const ADMIN_TW_NTICK: usize = 100;
 const ADMIN_USE_TLS: bool = false;
 
+// TODO(bmartin): we will eventually migrate to HTTP by default and make the
+// legacy admin port as optional. At that time, we should consider consolidating
+// the host and port parameters into a single listen address parameter. By using
+// Option<> types, we can also eliminate the use of a separate bool to enable
+// the legacy admin port, the presence or absence of a listen address being
+// enough to determine the desired behavior.
+
 // helper functions for default values
 fn host() -> String {
     ADMIN_HOST.to_string()

--- a/src/rust/core/server/Cargo.toml
+++ b/src/rust/core/server/Cargo.toml
@@ -35,6 +35,7 @@ strum = "0.20.0"
 strum_macros = "0.20.1"
 sysconf = "0.3.4"
 thiserror = "1.0.23"
+tiny_http = "0.11.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/rust/core/server/src/threads/admin.rs
+++ b/src/rust/core/server/src/threads/admin.rs
@@ -275,7 +275,7 @@ impl Admin {
     /// appears on its own line with a CR+LF used as end of line symbol. The
     /// stats appear in sorted order.
     ///
-    /// ```
+    /// ```text
     /// STAT get 0
     /// STAT get_cardinality_p25 0
     /// STAT get_cardinality_p50 0
@@ -375,7 +375,7 @@ impl Admin {
     /// A "human-readable" exposition format which outputs one stat per line,
     /// with a LF used as the end of line symbol.
     ///
-    /// ```
+    /// ```text
     /// get: 0
     /// get_cardinality_p25: 0
     /// get_cardinality_p50: 0
@@ -422,7 +422,7 @@ impl Admin {
     /// about the Finagle / TwitterServer format see:
     /// https://twitter.github.io/twitter-server/Features.html#metrics
     ///
-    /// ```
+    /// ```text
     /// {"get": 0,"get_cardinality_p25": 0,"get_cardinality_p50": 0, ... }
     /// ```
     fn json_stats(&self) -> String {
@@ -462,7 +462,7 @@ impl Admin {
     /// annotated with a type. Percentiles use the label 'percentile' to
     /// indicate which percentile corresponds to the value:
     ///
-    /// ```
+    /// ```text
     /// # TYPE get counter
     /// get 0
     /// # TYPE get_cardinality gauge


### PR DESCRIPTION
Adds a http admin port to the rust servers to expose statistics in
human, json, and prometheus formats.