### PR TITLE
fix reported version numbers

### DIFF
--- a/src/rust/core/server/src/process/mod.rs
+++ b/src/rust/core/server/src/process/mod.rs
@@ -88,6 +88,11 @@ where
         }
     }
 
+    pub fn version(mut self, version: &str) -> Self {
+        self.admin.version(version);
+        self
+    }
+
     /// Convert the `ProcessBuilder` to a running `Process` by spawning the
     /// threads for each component. Returns a `Process` which serves as a
     /// control handle for the threads.

--- a/src/rust/server/pingserver/src/lib.rs
+++ b/src/rust/server/pingserver/src/lib.rs
@@ -48,7 +48,8 @@ impl Pingserver {
             max_buffer_size,
             parser,
             log_drain,
-        );
+        )
+        .version(env!("CARGO_PKG_VERSION"));
 
         // spawn threads
         let process = process_builder.spawn();

--- a/src/rust/server/segcache/src/lib.rs
+++ b/src/rust/server/segcache/src/lib.rs
@@ -53,7 +53,8 @@ impl Segcache {
             max_buffer_size,
             parser,
             log_drain,
-        );
+        )
+        .version(env!("CARGO_PKG_VERSION"));
 
         // spawn threads
         let process = process_builder.spawn();

--- a/src/rust/server/segcache/tests/common.rs
+++ b/src/rust/server/segcache/tests/common.rs
@@ -226,3 +226,82 @@ fn test(name: &str, data: &[(&str, Option<&str>)]) {
     }
     info!("status: passed\n");
 }
+
+pub fn admin_tests() {
+    debug!("beginning admin tests");
+    println!();
+
+    admin_test(
+        "version",
+        &[(
+            "version\r\n",
+            Some(&format!("VERSION {}\r\n", env!("CARGO_PKG_VERSION"))),
+        )],
+    );
+}
+
+// opens a new connection to the admin port, sends a request, and checks the response.
+fn admin_test(name: &str, data: &[(&str, Option<&str>)]) {
+    info!("testing: {}", name);
+    debug!("connecting to server");
+    let mut stream = TcpStream::connect("127.0.0.1:9999").expect("failed to connect");
+    stream
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .expect("failed to set read timeout");
+    stream
+        .set_write_timeout(Some(Duration::from_millis(250)))
+        .expect("failed to set write timeout");
+
+    debug!("sending request");
+    for (request, response) in data {
+        match stream.write(request.as_bytes()) {
+            Ok(bytes) => {
+                if bytes == request.len() {
+                    debug!("full request sent");
+                } else {
+                    error!("incomplete write");
+                    panic!("status: failed\n");
+                }
+            }
+            Err(_) => {
+                error!("error sending request");
+                panic!("status: failed\n");
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+        let mut buf = vec![0; 4096];
+
+        if let Some(response) = response {
+            if stream.read(&mut buf).is_err() {
+                std::thread::sleep(Duration::from_millis(500));
+                panic!("error reading response");
+            } else if response.as_bytes() != &buf[0..response.len()] {
+                error!("expected: {:?}", response.as_bytes());
+                error!("received: {:?}", &buf[0..response.len()]);
+                std::thread::sleep(Duration::from_millis(500));
+                panic!("status: failed\n");
+            } else {
+                debug!("correct response");
+            }
+            assert_eq!(response.as_bytes(), &buf[0..response.len()]);
+        } else if let Err(e) = stream.read(&mut buf) {
+            if e.kind() == std::io::ErrorKind::WouldBlock {
+                debug!("got no response");
+            } else {
+                error!("error reading response");
+                std::thread::sleep(Duration::from_millis(500));
+                panic!("status: failed\n");
+            }
+        } else {
+            error!("expected no response");
+            std::thread::sleep(Duration::from_millis(500));
+            panic!("status: failed\n");
+        }
+
+        if data.len() > 1 {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+    info!("status: passed\n");
+}

--- a/src/rust/server/segcache/tests/integration.rs
+++ b/src/rust/server/segcache/tests/integration.rs
@@ -27,6 +27,8 @@ fn main() {
 
     tests();
 
+    admin_tests();
+
     // shutdown server and join
     info!("shutdown...");
     let _ = server.shutdown();

--- a/src/rust/server/segcache/tests/integration_multi.rs
+++ b/src/rust/server/segcache/tests/integration_multi.rs
@@ -29,6 +29,8 @@ fn main() {
 
     tests();
 
+    admin_tests();
+
     // shutdown server and join
     info!("shutdown...");
     let _ = server.shutdown();


### PR DESCRIPTION
For the rust servers, the version number reported on the admin port
reflects that of the 'core/server' crate instead of the actual
version number for the binary.

Changes the process and admin builders to allow setting a version
number. Updates the pingserver and segcache binary crates to set
the version number based on their cargo metadata.