### PR TITLE
segcache: make item header immutable

### DIFF
--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -163,13 +163,12 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
         let curr_ts = (time - self.started).as_secs() & PROC_TS_MASK;
         if curr_ts != get_ts(bucket.data[0]) as u32 {
             bucket.data[0] = (bucket.data[0] & !TS_MASK) | (curr_ts as u64);
 
-            loop {
+            for chain_idx in 0..=chain_len {
                 let n_item_slot = if chain_idx == chain_len {
                     N_BUCKET_SLOT
                 } else {
@@ -187,15 +186,13 @@ impl HashTable {
                     break;
                 }
                 bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-                chain_idx += 1;
             }
 
             // reset to start of chain
-            chain_idx = 0;
             bucket = &mut self.data[bucket_id as usize];
         }
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -243,7 +240,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         None
@@ -259,9 +255,8 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -295,7 +290,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         None
@@ -309,9 +303,8 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -339,7 +332,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         None
@@ -361,11 +353,10 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
         let mut updated = false;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -399,7 +390,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         if updated {
@@ -417,9 +407,8 @@ impl HashTable {
 
         let mut bucket = &self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -445,7 +434,6 @@ impl HashTable {
                 break;
             }
             bucket = &self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         false
@@ -468,14 +456,13 @@ impl HashTable {
         let tag = tag_from_hash(hash);
         let mut bucket_id = (hash & self.mask) as usize;
         let chain_len = chain_len(self.data[bucket_id].data[0]);
-        let mut chain_idx = 0;
 
         // check the item magic
         item.check_magic();
 
         let mut insert_item_info = build_item_info(tag, seg, offset);
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -510,7 +497,6 @@ impl HashTable {
                 break;
             }
             bucket_id = self.data[bucket_id].data[N_BUCKET_SLOT - 1] as usize;
-            chain_idx += 1;
         }
 
         if insert_item_info != 0
@@ -557,9 +543,8 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -605,7 +590,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         Err(SegError::NotFound)
@@ -622,11 +606,10 @@ impl HashTable {
         let tag = tag_from_hash(hash);
         let mut bucket_id = (hash & self.mask) as usize;
         let chain_len = chain_len(self.data[bucket_id].data[0]);
-        let mut chain_idx = 0;
 
         let mut deleted = false;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -656,7 +639,6 @@ impl HashTable {
                 break;
             }
             bucket_id = self.data[bucket_id].data[N_BUCKET_SLOT - 1] as usize;
-            chain_idx += 1;
         }
 
         if deleted {
@@ -692,14 +674,13 @@ impl HashTable {
 
         let mut bucket = &mut self.data[bucket_id as usize];
         let chain_len = chain_len(bucket.data[0]);
-        let mut chain_idx = 0;
 
         let evict_item_info = build_item_info(tag, segment.id(), offset as u64);
 
         let mut evicted = false;
         let mut first_match = true;
 
-        loop {
+        for chain_idx in 0..=chain_len {
             let n_item_slot = if chain_idx == chain_len {
                 N_BUCKET_SLOT
             } else {
@@ -740,7 +721,6 @@ impl HashTable {
                 break;
             }
             bucket = &mut self.data[bucket.data[N_BUCKET_SLOT - 1] as usize];
-            chain_idx += 1;
         }
 
         evicted

--- a/src/rust/storage/seg/src/item/header.rs
+++ b/src/rust/storage/seg/src/item/header.rs
@@ -19,7 +19,7 @@
 //! Flags:
 //! ```text
 //! ┌──────────────┬──────────────┬──────────────────────────────┐
-//! │    TYPED?    │   DELETED?   │             OLEN             │
+//! │    TYPED?    │   PADDING    │             OLEN             │
 //! │              │              │                              │
 //! │    1 bit     │    1 bit     │            6 bit             │
 //! │              │              │                              │
@@ -50,7 +50,6 @@ const KLEN_MASK: u32 = 0x000000FF;
 /// A mask used to get the bits containing the item value length from the item
 /// header's length field
 const VLEN_MASK: u32 = 0xFFFFFF00;
-
 /// The number of bits to shift the length field masked with the value length
 /// mask to get the actual value length
 const VLEN_SHIFT: u32 = 8;
@@ -64,9 +63,6 @@ const TYPE_SHIFT: u32 = 24;
 /// A mask to get the optional data length in bytes from the item header's flags
 /// field
 const OLEN_MASK: u8 = 0b00111111;
-/// A mask to get the bit indicating the item has been deleted from the item
-/// header's flags field
-const DEL_MASK: u8 = 0b01000000;
 /// A mask to get the bit indicating the item value should be treated as a
 /// typed value from the item header's flags field
 const TYPED_MASK: u8 = 0b10000000;
@@ -191,12 +187,6 @@ impl ItemHeader {
         }
     }
 
-    /// Is the item deleted?
-    #[inline]
-    pub fn is_deleted(&self) -> bool {
-        self.flags & DEL_MASK != 0
-    }
-
     /// Set the key length by changing just the low byte
     #[inline]
     pub fn set_klen(&mut self, len: u8) {
@@ -210,16 +200,6 @@ impl ItemHeader {
         if !self.is_typed() {
             debug_assert!(len <= (u32::MAX >> VLEN_SHIFT));
             self.len = (self.len & !VLEN_MASK) | (len << VLEN_SHIFT);
-        }
-    }
-
-    /// Mark the item as deleted
-    #[inline]
-    pub fn set_deleted(&mut self, deleted: bool) {
-        if deleted {
-            self.flags |= DEL_MASK
-        } else {
-            self.flags &= !DEL_MASK
         }
     }
 
@@ -248,7 +228,6 @@ impl std::fmt::Debug for ItemHeader {
             .field("klen", &self.klen())
             .field("vlen", &self.vlen())
             .field("type", &self.value_type())
-            .field("deleted", &self.is_deleted())
             .field("olen", &self.olen())
             .finish()
     }
@@ -263,7 +242,6 @@ impl std::fmt::Debug for ItemHeader {
             .field("klen", &self.klen())
             .field("vlen", &self.vlen())
             .field("typed", &self.is_typed())
-            .field("deleted", &self.is_deleted())
             .field("olen", &self.olen())
             .finish()
     }

--- a/src/rust/storage/seg/src/item/raw.rs
+++ b/src/rust/storage/seg/src/item/raw.rs
@@ -121,7 +121,6 @@ impl RawItem {
         match value {
             Value::Bytes(value) => unsafe {
                 self.set_magic();
-                (*self.header_mut()).set_deleted(false);
                 (*self.header_mut()).set_type(None);
                 (*self.header_mut()).set_olen(optional.len() as u8);
                 std::ptr::copy_nonoverlapping(
@@ -144,7 +143,6 @@ impl RawItem {
             },
             Value::U64(value) => unsafe {
                 self.set_magic();
-                (*self.header_mut()).set_deleted(false);
                 (*self.header_mut()).set_type(Some(ValueType::U64));
                 (*self.header_mut()).set_olen(optional.len() as u8);
                 std::ptr::copy_nonoverlapping(
@@ -192,16 +190,6 @@ impl RawItem {
             >> 3)
             + 1)
             << 3
-    }
-
-    /// Sets the tombstone
-    pub(crate) fn tombstone(&mut self) {
-        unsafe { (*self.header_mut()).set_deleted(true) }
-    }
-
-    /// Checks if the item is deleted
-    pub(crate) fn deleted(&self) -> bool {
-        self.header().is_deleted()
     }
 
     pub(crate) fn wrapping_add(&mut self, rhs: u64) -> Result<(), SegError> {

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -185,10 +185,10 @@ impl Seg {
             )
             .is_err()
         {
+            // this just needs to alter the segment header and update stats
             let _ = self.segments.remove_at(
                 reserved.seg(),
                 reserved.offset(),
-                false,
                 &mut self.ttl_buckets,
                 &mut self.hashtable,
             );
@@ -303,7 +303,7 @@ impl Seg {
     /// *NOTE*: this operation is relatively expensive
     #[cfg(feature = "debug")]
     pub fn check_integrity(&mut self) -> Result<(), SegError> {
-        if self.segments.check_integrity() {
+        if self.segments.check_integrity(&self.hashtable) {
             Ok(())
         } else {
             Err(SegError::DataCorrupted)

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -502,37 +502,33 @@ impl Segments {
         }
     }
 
-    /// Remove a single item from a segment based on the item_info, optionally
-    /// setting tombstone
+    /// Remove a single item from a segment based on the item_info
     pub(crate) fn remove_item(
         &mut self,
         item_info: u64,
-        tombstone: bool,
         ttl_buckets: &mut TtlBuckets,
         hashtable: &mut HashTable,
     ) -> Result<(), SegmentsError> {
         if let Some(seg_id) = get_seg_id(item_info) {
             let offset = get_offset(item_info) as usize;
-            self.remove_at(seg_id, offset, tombstone, ttl_buckets, hashtable)
+            self.remove_at(seg_id, offset, ttl_buckets, hashtable)
         } else {
             Err(SegmentsError::BadSegmentId)
         }
     }
 
     /// Remove a single item from a segment based on the segment id and offset.
-    /// Optionally, sets the item tombstone.
     pub(crate) fn remove_at(
         &mut self,
         seg_id: NonZeroU32,
         offset: usize,
-        tombstone: bool,
         ttl_buckets: &mut TtlBuckets,
         hashtable: &mut HashTable,
     ) -> Result<(), SegmentsError> {
         // remove the item
         {
             let mut segment = self.get_mut(seg_id)?;
-            segment.remove_item_at(offset, tombstone);
+            segment.remove_item_at(offset);
 
             // regardless of eviction policy, we can evict the segment if its now
             // empty and would be evictable. if we evict, we must return early
@@ -625,13 +621,13 @@ impl Segments {
     }
 
     #[cfg(feature = "debug")]
-    pub(crate) fn check_integrity(&mut self) -> bool {
+    pub(crate) fn check_integrity(&mut self, hashtable: &HashTable) -> bool {
         let mut integrity = true;
         for id in 0..self.cap {
             if !self
                 .get_mut(NonZeroU32::new(id + 1).unwrap())
                 .unwrap()
-                .check_integrity()
+                .check_integrity(hashtable)
             {
                 integrity = false;
             }


### PR DESCRIPTION
Makes the item header immutable in the Rust implementation of
Segcache by removing use of the `deleted` bit in the item header.

Since the Rust implementation of segment storage is not concurrent,
there is no need for the `deleted` bit in the item header. Instead,
we can check the hashtable to confirm if the item is located within
a given segment at a specified offset. By removing the use of the
`deleted` bit, we make the item header immutable. This is
beneficial in that it removes the need to perform random updates
within the segments.