### PR TITLE
refactor: use iterators in seg hashtable

### DIFF
--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -212,7 +212,7 @@ pub(crate) struct HashTable {
     data: Box<[HashBucket]>,
     started: Instant,
     next_to_chain: u64,
-    _pad: [u8; 8]
+    _pad: [u8; 8],
 }
 
 impl HashTable {

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -210,9 +210,9 @@ pub(crate) struct HashTable {
     power: u64,
     mask: u64,
     data: Box<[HashBucket]>,
-    rng: Box<Random>,
     started: Instant,
     next_to_chain: u64,
+    _pad: [u8; 8]
 }
 
 impl HashTable {
@@ -255,9 +255,9 @@ impl HashTable {
             power: power.into(),
             mask,
             data: data.into_boxed_slice(),
-            rng: Box::new(rng()),
             started: Instant::now(),
             next_to_chain: buckets as u64,
+            _pad: [0; 8],
         }
     }
 
@@ -280,8 +280,6 @@ impl HashTable {
             }
         }
 
-        let rand: u64 = self.rng.gen();
-
         let iter = IterMut::new(self, hash);
 
         for item_info in iter {
@@ -293,6 +291,7 @@ impl HashTable {
                     // update item frequency
                     let mut freq = get_freq(*item_info);
                     if freq < 127 {
+                        let rand = thread_rng().gen::<u64>();
                         if freq <= 16 || rand % freq == 0 {
                             freq = ((freq + 1) | 0x80) << FREQ_BIT_SHIFT;
                         } else {
@@ -521,8 +520,6 @@ impl HashTable {
         let tag = tag_from_hash(hash);
         let bucket_id = hash & self.mask;
 
-        let rand: u64 = self.rng.gen();
-
         let iter = IterMut::new(self, hash);
 
         for item_info in iter {
@@ -534,6 +531,7 @@ impl HashTable {
                     // update item frequency
                     let mut freq = get_freq(*item_info);
                     if freq < 127 {
+                        let rand = thread_rng().gen::<u64>();
                         if freq <= 16 || rand % freq == 0 {
                             freq = ((freq + 1) | 0x80) << FREQ_BIT_SHIFT;
                         } else {

--- a/src/rust/storage/seg/src/hashtable/mod.rs
+++ b/src/rust/storage/seg/src/hashtable/mod.rs
@@ -541,7 +541,6 @@ impl HashTable {
                     }
 
                     if cas == get_cas(self.data[bucket_id as usize].data[0]) {
-                        // TODO(bmartin): what is expected on overflow of the cas bits?
                         self.data[bucket_id as usize].data[0] += 1 << CAS_BIT_SHIFT;
                         return Ok(());
                     } else {

--- a/src/rust/storage/seg/src/rand.rs
+++ b/src/rust/storage/seg/src/rand.rs
@@ -4,17 +4,15 @@
 
 //! Random number generator initialization
 
-
-
 pub use inner::*;
 
 pub use rand::Rng as RandRng;
 pub use rand::RngCore as RandRngCore;
 
-use std::rc::Rc;
 use core::cell::UnsafeCell;
-use rand::RngCore;
 use rand::Error;
+use rand::RngCore;
+use std::rc::Rc;
 
 pub struct ThreadRng {
     // Rc is explicitly !Send and !Sync
@@ -66,7 +64,6 @@ impl RngCore for ThreadRng {
         rng.try_fill_bytes(dest)
     }
 }
-
 
 #[cfg(test)]
 mod inner {

--- a/src/rust/storage/seg/src/seg.rs
+++ b/src/rust/storage/seg/src/seg.rs
@@ -303,7 +303,7 @@ impl Seg {
     /// *NOTE*: this operation is relatively expensive
     #[cfg(feature = "debug")]
     pub fn check_integrity(&mut self) -> Result<(), SegError> {
-        if self.segments.check_integrity(&self.hashtable) {
+        if self.segments.check_integrity(&mut self.hashtable) {
             Ok(())
         } else {
             Err(SegError::DataCorrupted)

--- a/src/rust/storage/seg/src/segments/segment.rs
+++ b/src/rust/storage/seg/src/segments/segment.rs
@@ -95,7 +95,7 @@ impl<'a> Segment<'a> {
     /// This function may panic if the segment is corrupted or has been
     /// constructed from invalid bytes.
     #[cfg(feature = "debug")]
-    pub(crate) fn check_integrity(&mut self, hashtable: &HashTable) -> bool {
+    pub(crate) fn check_integrity(&mut self, hashtable: &mut HashTable) -> bool {
         self.check_magic();
 
         let mut integrity = true;

--- a/src/rust/storage/seg/src/segments/segments.rs
+++ b/src/rust/storage/seg/src/segments/segments.rs
@@ -621,7 +621,7 @@ impl Segments {
     }
 
     #[cfg(feature = "debug")]
-    pub(crate) fn check_integrity(&mut self, hashtable: &HashTable) -> bool {
+    pub(crate) fn check_integrity(&mut self, hashtable: &mut HashTable) -> bool {
         let mut integrity = true;
         for id in 0..self.cap {
             if !self


### PR DESCRIPTION
As noted in #414, we can use iterators to reduce code duplication
within the hashtable module.

This change adds two iterator types to the hashtable, allowing us
to iterate through item info entries for a given hash.