### PR TITLE
feat: #331 Prints the configuration in use for the server and then exits

### DIFF
--- a/src/rust/config/src/segcache.rs
+++ b/src/rust/config/src/segcache.rs
@@ -93,6 +93,17 @@ impl SegcacheConfig {
     pub fn dlog_interval(&self) -> usize {
         self.dlog_interval
     }
+
+    /// Prints the configuration
+    pub fn print(&self) {
+        let config_toml = self.render_config();
+        println!("Segcache configuration:\n\n{}", config_toml);
+    }
+
+    /// Renders the configuration as a printable string
+    fn render_config(&self) -> String {
+        toml::to_string_pretty(&self).expect("wasn't able to TOML-render config for printing")
+    }
 }
 
 impl AdminConfig for SegcacheConfig {
@@ -185,6 +196,30 @@ impl Default for SegcacheConfig {
             sockio: Default::default(),
             tcp: Default::default(),
             tls: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::SegcacheConfig;
+
+    #[test]
+    fn it_should_render_the_config_with_some_expected_keys() {
+        let config: SegcacheConfig = Default::default();
+        let rendered_config = config.render_config();
+        let expected_keys = vec![
+            "hash_power",
+            "overflow_factor",
+            "heap_size",
+            "segment_size",
+            "eviction",
+            "merge_target",
+            "merge_max",
+            "compact_target",
+        ];
+        for key in expected_keys {
+            assert!(rendered_config.contains(key));
         }
     }
 }

--- a/src/rust/server/segcache/src/main.rs
+++ b/src/rust/server/segcache/src/main.rs
@@ -55,6 +55,12 @@ fn main() {
                 .help("Server configuration file")
                 .index(1),
         )
+        .arg(
+            Arg::with_name("print-config")
+                .help("List all options in config")
+                .long("config")
+                .short("c"),
+        )
         .get_matches();
 
     // output stats descriptions and exit if the `stats` option was provided
@@ -104,6 +110,11 @@ fn main() {
     } else {
         Default::default()
     };
+
+    if matches.is_present("print-config") {
+        config.print();
+        std::process::exit(0);
+    }
 
     // launch segcache
     Segcache::new(config).wait()


### PR DESCRIPTION
debatably fixes #331

I could see this needing to be a bit more self-describing in the future, but this will at least make it easy for the enduser to see the precise configuration in use.

I tried doing this with as minimal investment as possible, hence using Serde/TOML, which seems sensible enough given that that's seemingly the configuration language of choice in the Rust part of Pelikan.

Screenshots:
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/833575/165779822-de57abd2-2f0b-4a57-8043-38f33e86d362.png">
<img width="967" alt="image" src="https://user-images.githubusercontent.com/833575/165779901-04a351aa-6a7d-4515-8066-c72bfd590395.png">
