### PR TITLE
feat: #368 make admin protocol parsing tolerant of leading/trailing whitespace

### DIFF
--- a/src/rust/common/src/bytes.rs
+++ b/src/rust/common/src/bytes.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+pub trait SliceExtension {
+    ///Trims a type by skipping contiguous whitespace from the beginning and end
+    fn trim(&self) -> &Self;
+}
+
+impl SliceExtension for [u8] {
+    ///Trims an &[u8] by skipping contiguous whitespace from the beginning and end
+    fn trim(&self) -> &[u8] {
+        let first = self.iter().position(|c| !c.is_ascii_whitespace());
+        let last = self.iter().rposition(|c| !c.is_ascii_whitespace());
+        match (first, last) {
+            (Some(first), Some(last)) => &self[first..=last],
+            _ => Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::bytes::SliceExtension;
+
+    #[test]
+    fn it_can_trim_byteslice() {
+        assert_eq!(b" foobar ".trim(), b"foobar");
+        assert_eq!(b"\nfoobar\n ".trim(), b"foobar");
+        assert_eq!(b"foo bar".trim(), b"foo bar");
+        assert_eq!(b"foobar".trim(), b"foobar");
+        assert_eq!(b"".trim(), b"");
+        assert_eq!(b" ".trim(), b"");
+        assert_eq!(b"    ".trim(), b"");
+        assert_eq!(b"  \n\t ".trim(), b"");
+    }
+}

--- a/src/rust/common/src/lib.rs
+++ b/src/rust/common/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+pub mod bytes;
 pub mod expiry;
 pub mod signal;
 pub mod ssl;


### PR DESCRIPTION
fixes #368 by trimming the command of leading/trailing whitespace before matching

I'm assuming this is what is intended based on reading the C code, but I might be wrong