### PR TITLE
Squelch devtoolset-11 compile errors

### DIFF
--- a/src/core/context.h
+++ b/src/core/context.h
@@ -11,6 +11,6 @@ struct context {
     int timeout;
 };
 
-bool admin_init;
-bool server_init;
-bool worker_init;
+extern bool admin_init;
+extern bool server_init;
+extern bool worker_init;

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -9,6 +9,10 @@
 #include <string.h>
 #include <sysexits.h>
 
+bool admin_init;
+bool server_init;
+bool worker_init;
+
 void
 core_run(void *arg_worker)
 {


### PR DESCRIPTION
Minor header changes to get the core module to compile/link correctly with gcc 11.