### PR TITLE
fix: update crossbeam-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",


### PR DESCRIPTION
Updates crossbeam-utils to 0.8.8 to fix crossbeam-rs/crossbeam#781