### PR TITLE
fix: incorrect logic when removing and replacing items

### DIFF
--- a/src/rust/storage/seg/src/segments/segment.rs
+++ b/src/rust/storage/seg/src/segments/segment.rs
@@ -669,7 +669,10 @@ impl<'a> Segment<'a> {
         // skips over seg_wait_refcount and evict retry, because no threading
 
         if self.live_items() > 0 {
-            error!("segment not empty after clearing, still contains: {} items", self.live_items());
+            error!(
+                "segment not empty after clearing, still contains: {} items",
+                self.live_items()
+            );
             panic!();
         }
 

--- a/src/rust/storage/seg/src/segments/segment.rs
+++ b/src/rust/storage/seg/src/segments/segment.rs
@@ -668,8 +668,9 @@ impl<'a> Segment<'a> {
 
         // skips over seg_wait_refcount and evict retry, because no threading
 
-        if self.live_items() != 0 {
-            assert_eq!(self.live_items(), 0, "segment not empty after clearing");
+        if self.live_items() > 0 {
+            error!("segment not empty after clearing, still contains: {} items", self.live_items());
+            panic!();
         }
 
         let expected_size = if cfg!(feature = "magic") {
@@ -678,11 +679,8 @@ impl<'a> Segment<'a> {
             0
         };
         if self.live_bytes() != expected_size {
-            assert_eq!(
-                self.live_bytes(),
-                expected_size,
-                "segment size incorrect after clearing"
-            );
+            error!("segment size incorrect after clearing");
+            panic!();
         }
 
         self.set_write_offset(self.live_bytes());


### PR DESCRIPTION
The logic during removing an item is incorrect. This change fixes
and simplifies the logic when making changes to the item info
entries. Since this implementation is not concurrent, we can
guarantee that the only time we may have a stale item is during an
insert. As the insert logic cleans up the stale item, all other
functions can trust that the first match is the current item.