### PR TITLE
Add metric for tracking epoll max events in proxy

### DIFF
--- a/src/rust/core/proxy/src/backend.rs
+++ b/src/rust/core/proxy/src/backend.rs
@@ -25,6 +25,10 @@ const SESSION_BUFFER_MAX: usize = 1024 * KB;
 counter!(BACKEND_EVENT_ERROR);
 counter!(BACKEND_EVENT_READ);
 counter!(BACKEND_EVENT_WRITE);
+counter!(
+    BACKEND_EVENT_MAX_REACHED,
+    "the number of times the maximum number of events was returned"
+);
 
 pub const QUEUE_RETRIES: usize = 3;
 
@@ -131,6 +135,9 @@ where
                         self.handle_event(event);
                     }
                 }
+            }
+            if events.iter().count() == self.nevent {
+                BACKEND_EVENT_MAX_REACHED.increment();
             }
             let _ = self.queues.wake();
         }

--- a/src/rust/core/proxy/src/frontend.rs
+++ b/src/rust/core/proxy/src/frontend.rs
@@ -20,6 +20,10 @@ use rustcommon_metrics::*;
 counter!(FRONTEND_EVENT_ERROR);
 counter!(FRONTEND_EVENT_READ);
 counter!(FRONTEND_EVENT_WRITE);
+counter!(
+    FRONTEND_EVENT_MAX_REACHED,
+    "the number of times the maximum number of events was returned"
+);
 
 pub const QUEUE_RETRIES: usize = 3;
 
@@ -125,6 +129,9 @@ where
                         self.handle_event(event);
                     }
                 }
+            }
+            if events.iter().count() == self.nevent {
+                FRONTEND_EVENT_MAX_REACHED.increment();
             }
             let _ = self.data_queues.wake();
         }


### PR DESCRIPTION
Add counter for tracking epoll returns max events in proxy frontend and backend