### PR TITLE
core/server: increase inter-thread queue sizes

### DIFF
--- a/src/core/server/src/lib.rs
+++ b/src/core/server/src/lib.rs
@@ -118,6 +118,6 @@ const ADMIN_MAX_BUFFER_SIZE: usize = 2 * 1024 * 1024; // 1MB
 const QUEUE_RETRIES: usize = 3;
 
 const THREAD_PREFIX: &str = "pelikan";
-const QUEUE_CAPACITY: usize = 1024;
+const QUEUE_CAPACITY: usize = 64 * 1024;
 
 common::metrics::test_no_duplicates!();


### PR DESCRIPTION
Increases the size of the inter-thread queues from 1k to 64k
entries. This helps absorb traffic spikes particularly when there
is a large number of connections to the server.