### PR TITLE
core/server: fix how latencies are calculated

### DIFF
--- a/src/core/server/src/threads/workers/mod.rs
+++ b/src/core/server/src/threads/workers/mod.rs
@@ -45,6 +45,7 @@ heatmap!(STORAGE_QUEUE_DEPTH, 1_000_000);
 
 counter!(PROCESS_REQ);
 
+type Instant = common::time::Instant<common::time::Nanoseconds<u64>>;
 type WrappedResult<Request, Response> = TokenWrapper<Box<dyn ExecutionResult<Request, Response>>>;
 
 pub struct TokenWrapper<T> {

--- a/src/core/server/src/threads/workers/multi.rs
+++ b/src/core/server/src/threads/workers/multi.rs
@@ -117,19 +117,15 @@ where
                 error!("Error polling");
             }
 
+            let timestamp = Instant::now();
+
             let count = events.iter().count();
             WORKER_EVENT_TOTAL.add(count as _);
             if count == self.nevent {
                 WORKER_EVENT_MAX_REACHED.increment();
             } else {
-                WORKER_EVENT_DEPTH.increment(
-                    common::time::Instant::<common::time::Nanoseconds<u64>>::now(),
-                    count as _,
-                    1,
-                );
+                WORKER_EVENT_DEPTH.increment(timestamp, count as _, 1);
             }
-
-            common::time::refresh_clock();
 
             // process all events
             for event in events.iter() {
@@ -153,7 +149,7 @@ where
                         }
                     }
                     _ => {
-                        self.handle_event(event);
+                        self.handle_event(event, timestamp);
                     }
                 }
             }
@@ -163,7 +159,7 @@ where
         }
     }
 
-    fn handle_event(&mut self, event: &Event) {
+    fn handle_event(&mut self, event: &Event, timestamp: Instant) {
         let token = event.token();
 
         // handle error events first
@@ -183,9 +179,7 @@ where
         if event.is_readable() {
             WORKER_EVENT_READ.increment();
             if let Ok(session) = self.poll.get_mut_session(token) {
-                session.set_timestamp(
-                    common::time::Instant::<common::time::Nanoseconds<u64>>::recent(),
-                );
+                session.set_timestamp(timestamp);
             }
             let _ = self.do_read(token);
         }

--- a/src/core/server/src/threads/workers/storage.rs
+++ b/src/core/server/src/threads/workers/storage.rs
@@ -96,16 +96,14 @@ where
                 error!("Error polling");
             }
 
+            let timestamp = Instant::now();
+
             if !events.is_empty() {
                 trace!("handling events");
 
                 self.storage_queue.try_recv_all(&mut requests);
 
-                STORAGE_QUEUE_DEPTH.increment(
-                    common::time::Instant::<common::time::Nanoseconds<u64>>::now(),
-                    requests.len() as _,
-                    1,
-                );
+                STORAGE_QUEUE_DEPTH.increment(timestamp, requests.len() as _, 1);
 
                 for request in requests.drain(..) {
                     let sender = request.sender();


### PR DESCRIPTION
Previously, we used `Instant::recent()` to get a cached view of the
monotonic clock and used that to set the timestamp for the
sessions. This could result in incorrect latency reporting if the
cached value is sufficiently stale or if another thread refreshes
the cached value while a thread is processing many events.

This change corrects how the latency is being measured by using
`Instant::now()` when poll returns as the timestamp for all events
being processed in that loop iteration.