### PR TITLE
fix: memcache command log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "criterion",
+ "logger",
  "nom 5.1.2",
  "protocol-common",
  "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",

--- a/src/protocol/memcache/Cargo.toml
+++ b/src/protocol/memcache/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [dependencies]
 common = { path = "../../common" }
+logger = { path = "../../logger" }
 nom = "5.1.2"
 protocol-common = { path = "../../protocol/common" }
 rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }

--- a/src/protocol/memcache/src/lib.rs
+++ b/src/protocol/memcache/src/lib.rs
@@ -76,10 +76,12 @@ counter!(DELETE_NOT_FOUND);
 
 counter!(INCR);
 counter!(INCR_EX);
+counter!(INCR_STORED);
 counter!(INCR_NOT_FOUND);
 
 counter!(DECR);
 counter!(DECR_EX);
+counter!(DECR_STORED);
 counter!(DECR_NOT_FOUND);
 
 counter!(CAS);

--- a/src/protocol/memcache/src/response/client_error.rs
+++ b/src/protocol/memcache/src/response/client_error.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"CLIENT_ERROR ";
+const MSG_PREFIX: &[u8] = b"CLIENT_ERROR ";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientError {
@@ -17,13 +17,13 @@ impl ClientError {
     }
 
     pub fn len(&self) -> usize {
-        BYTES.len() + self.inner.len() + 2
+        MSG_PREFIX.len() + self.inner.len() + 2
     }
 }
 
 impl Compose for ClientError {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(BYTES);
+        let _ = session.write_all(MSG_PREFIX);
         let _ = session.write_all(self.inner.as_bytes());
         let _ = session.write_all(b"\r\n");
     }

--- a/src/protocol/memcache/src/response/client_error.rs
+++ b/src/protocol/memcache/src/response/client_error.rs
@@ -4,14 +4,26 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"CLIENT_ERROR ";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientError {
     pub(crate) inner: String,
 }
 
+impl ClientError {
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    pub fn len(&self) -> usize {
+        BYTES.len() + self.inner.len() + 2
+    }
+}
+
 impl Compose for ClientError {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(b"CLIENT_ERROR ");
+        let _ = session.write_all(BYTES);
         let _ = session.write_all(self.inner.as_bytes());
         let _ = session.write_all(b"\r\n");
     }

--- a/src/protocol/memcache/src/response/deleted.rs
+++ b/src/protocol/memcache/src/response/deleted.rs
@@ -4,6 +4,8 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"DELETED\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Deleted {
     noreply: bool,
@@ -13,12 +15,24 @@ impl Deleted {
     pub fn new(noreply: bool) -> Self {
         Self { noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            BYTES.len()
+        }
+    }
 }
 
 impl Compose for Deleted {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(b"DELETED\r\n");
+            let _ = session.write_all(BYTES);
         }
     }
 }

--- a/src/protocol/memcache/src/response/deleted.rs
+++ b/src/protocol/memcache/src/response/deleted.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"DELETED\r\n";
+const MSG: &[u8] = b"DELETED\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Deleted {
@@ -24,7 +24,7 @@ impl Deleted {
         if self.noreply {
             0
         } else {
-            BYTES.len()
+            MSG.len()
         }
     }
 }
@@ -32,7 +32,7 @@ impl Deleted {
 impl Compose for Deleted {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(BYTES);
+            let _ = session.write_all(MSG);
         }
     }
 }

--- a/src/protocol/memcache/src/response/error.rs
+++ b/src/protocol/memcache/src/response/error.rs
@@ -4,12 +4,34 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"ERROR\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error {}
 
+impl Default for Error {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Error {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    pub fn len(&self) -> usize {
+        BYTES.len()
+    }
+}
+
 impl Compose for Error {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(b"ERROR\r\n");
+        let _ = session.write_all(BYTES);
     }
 }
 

--- a/src/protocol/memcache/src/response/error.rs
+++ b/src/protocol/memcache/src/response/error.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"ERROR\r\n";
+const MSG: &[u8] = b"ERROR\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Error {}
@@ -25,13 +25,13 @@ impl Error {
     }
 
     pub fn len(&self) -> usize {
-        BYTES.len()
+        MSG.len()
     }
 }
 
 impl Compose for Error {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(BYTES);
+        let _ = session.write_all(MSG);
     }
 }
 

--- a/src/protocol/memcache/src/response/exists.rs
+++ b/src/protocol/memcache/src/response/exists.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"EXISTS\r\n";
+const MSG: &[u8] = b"EXISTS\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exists {
@@ -24,7 +24,7 @@ impl Exists {
         if self.noreply {
             0
         } else {
-            BYTES.len()
+            MSG.len()
         }
     }
 }
@@ -32,7 +32,7 @@ impl Exists {
 impl Compose for Exists {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(BYTES);
+            let _ = session.write_all(MSG);
         }
     }
 }

--- a/src/protocol/memcache/src/response/exists.rs
+++ b/src/protocol/memcache/src/response/exists.rs
@@ -4,6 +4,8 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"EXISTS\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Exists {
     noreply: bool,
@@ -13,12 +15,24 @@ impl Exists {
     pub fn new(noreply: bool) -> Self {
         Self { noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            BYTES.len()
+        }
+    }
 }
 
 impl Compose for Exists {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(b"EXISTS\r\n");
+            let _ = session.write_all(BYTES);
         }
     }
 }

--- a/src/protocol/memcache/src/response/not_found.rs
+++ b/src/protocol/memcache/src/response/not_found.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"NOT_FOUND\r\n";
+const MSG: &[u8] = b"NOT_FOUND\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NotFound {
@@ -24,7 +24,7 @@ impl NotFound {
         if self.noreply {
             0
         } else {
-            BYTES.len()
+            MSG.len()
         }
     }
 }
@@ -32,7 +32,7 @@ impl NotFound {
 impl Compose for NotFound {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(BYTES);
+            let _ = session.write_all(MSG);
         }
     }
 }

--- a/src/protocol/memcache/src/response/not_found.rs
+++ b/src/protocol/memcache/src/response/not_found.rs
@@ -4,6 +4,8 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"NOT_FOUND\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct NotFound {
     noreply: bool,
@@ -13,12 +15,24 @@ impl NotFound {
     pub fn new(noreply: bool) -> Self {
         Self { noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            BYTES.len()
+        }
+    }
 }
 
 impl Compose for NotFound {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(b"NOT_FOUND\r\n");
+            let _ = session.write_all(BYTES);
         }
     }
 }

--- a/src/protocol/memcache/src/response/not_stored.rs
+++ b/src/protocol/memcache/src/response/not_stored.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"NOT_STORED\r\n";
+const MSG: &[u8] = b"NOT_STORED\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NotStored {
@@ -24,7 +24,7 @@ impl NotStored {
         if self.noreply {
             0
         } else {
-            BYTES.len()
+            MSG.len()
         }
     }
 }
@@ -32,7 +32,7 @@ impl NotStored {
 impl Compose for NotStored {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(BYTES);
+            let _ = session.write_all(MSG);
         }
     }
 }

--- a/src/protocol/memcache/src/response/not_stored.rs
+++ b/src/protocol/memcache/src/response/not_stored.rs
@@ -4,6 +4,8 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"NOT_STORED\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct NotStored {
     noreply: bool,
@@ -13,12 +15,24 @@ impl NotStored {
     pub fn new(noreply: bool) -> Self {
         Self { noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            BYTES.len()
+        }
+    }
 }
 
 impl Compose for NotStored {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(b"NOT_STORED\r\n");
+            let _ = session.write_all(BYTES);
         }
     }
 }

--- a/src/protocol/memcache/src/response/numeric.rs
+++ b/src/protocol/memcache/src/response/numeric.rs
@@ -14,6 +14,18 @@ impl Numeric {
     pub fn new(value: u64, noreply: bool) -> Self {
         Self { value, noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            format!("{}\r\n", self.value).len()
+        }
+    }
 }
 
 impl Compose for Numeric {

--- a/src/protocol/memcache/src/response/server_error.rs
+++ b/src/protocol/memcache/src/response/server_error.rs
@@ -4,14 +4,26 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"SERVER_ERROR ";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerError {
     pub(crate) inner: String,
 }
 
+impl ServerError {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        BYTES.len() + self.inner.len() + 2
+    }
+}
+
 impl Compose for ServerError {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(b"SERVER_ERROR ");
+        let _ = session.write_all(BYTES);
         let _ = session.write_all(self.inner.as_bytes());
         let _ = session.write_all(b"\r\n");
     }

--- a/src/protocol/memcache/src/response/server_error.rs
+++ b/src/protocol/memcache/src/response/server_error.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"SERVER_ERROR ";
+const MSG_PREFIX: &[u8] = b"SERVER_ERROR ";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerError {
@@ -17,13 +17,13 @@ impl ServerError {
     }
 
     pub fn len(&self) -> usize {
-        BYTES.len() + self.inner.len() + 2
+        MSG_PREFIX.len() + self.inner.len() + 2
     }
 }
 
 impl Compose for ServerError {
     fn compose(&self, session: &mut session::Session) {
-        let _ = session.write_all(BYTES);
+        let _ = session.write_all(MSG_PREFIX);
         let _ = session.write_all(self.inner.as_bytes());
         let _ = session.write_all(b"\r\n");
     }

--- a/src/protocol/memcache/src/response/stored.rs
+++ b/src/protocol/memcache/src/response/stored.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BYTES: &[u8] = b"STORED\r\n";
+const MSG: &[u8] = b"STORED\r\n";
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Stored {
@@ -24,7 +24,7 @@ impl Stored {
         if self.noreply {
             0
         } else {
-            BYTES.len()
+            MSG.len()
         }
     }
 }
@@ -32,7 +32,7 @@ impl Stored {
 impl Compose for Stored {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(BYTES);
+            let _ = session.write_all(MSG);
         }
     }
 }

--- a/src/protocol/memcache/src/response/stored.rs
+++ b/src/protocol/memcache/src/response/stored.rs
@@ -4,6 +4,8 @@
 
 use super::*;
 
+const BYTES: &[u8] = b"STORED\r\n";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Stored {
     noreply: bool,
@@ -13,12 +15,24 @@ impl Stored {
     pub fn new(noreply: bool) -> Self {
         Self { noreply }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.noreply {
+            0
+        } else {
+            BYTES.len()
+        }
+    }
 }
 
 impl Compose for Stored {
     fn compose(&self, session: &mut session::Session) {
         if !self.noreply {
-            let _ = session.write_all(b"STORED\r\n");
+            let _ = session.write_all(BYTES);
         }
     }
 }

--- a/src/protocol/memcache/src/response/values.rs
+++ b/src/protocol/memcache/src/response/values.rs
@@ -13,6 +13,10 @@ impl Values {
     pub fn new(values: Box<[Value]>) -> Self {
         Self { values }
     }
+
+    pub fn values(&self) -> &[Value] {
+        &self.values
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -31,6 +35,10 @@ impl Value {
             cas,
             data: data.to_owned().into_boxed_slice(),
         }
+    }
+
+    pub fn key(&self) -> &[u8] {
+        &self.key
     }
 }
 

--- a/src/protocol/memcache/src/result/mod.rs
+++ b/src/protocol/memcache/src/result/mod.rs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::ops::Deref;
-use std::borrow::Cow;
 use crate::*;
+use logger::*;
 use protocol_common::ExecutionResult;
 use session::Session;
-use logger::*;
+use std::borrow::Cow;
+use std::ops::Deref;
 
 // response codes for klog
 const MISS: u8 = 0;
@@ -52,7 +52,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
 
                     let values = res.values();
                     let mut value_index = 0;
-                    
+
                     for key in req.keys() {
                         let key = key.deref();
                         // if we are out of values or the keys don't match, it's a miss
@@ -81,7 +81,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
 
                     let values = res.values();
                     let mut value_index = 0;
-                    
+
                     for key in req.keys() {
                         let key = key.deref();
                         // if we are out of values or the keys don't match, it's a miss
@@ -117,8 +117,16 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"set {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
-            },
+                klog!(
+                    "\"set {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    code,
+                    len
+                );
+            }
             Request::Add(ref req) => {
                 let ttl: i64 = match req.ttl() {
                     None => 0,
@@ -136,8 +144,16 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"add {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
-            },
+                klog!(
+                    "\"add {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    code,
+                    len
+                );
+            }
             Request::Replace(ref req) => {
                 let ttl: i64 = match req.ttl() {
                     None => 0,
@@ -155,8 +171,16 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"replace {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
-            },
+                klog!(
+                    "\"replace {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    code,
+                    len
+                );
+            }
             Request::Cas(ref req) => {
                 let ttl: i64 = match req.ttl() {
                     None => 0,
@@ -178,8 +202,17 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"cas {} {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), req.cas(), code, len);
-            },
+                klog!(
+                    "\"cas {} {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    req.cas(),
+                    code,
+                    len
+                );
+            }
             Request::Append(ref req) => {
                 let ttl: i64 = match req.ttl() {
                     None => 0,
@@ -197,8 +230,16 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"append {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
-            },
+                klog!(
+                    "\"append {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    code,
+                    len
+                );
+            }
             Request::Prepend(ref req) => {
                 let ttl: i64 = match req.ttl() {
                     None => 0,
@@ -216,8 +257,16 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"prepend {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
-            },
+                klog!(
+                    "\"prepend {} {} {} {}\" {} {}",
+                    string_key(req.key()),
+                    req.flags(),
+                    ttl,
+                    req.value().len(),
+                    code,
+                    len
+                );
+            }
             Request::Incr(ref req) => {
                 let (code, len) = match self.response {
                     Response::Numeric(ref res) => {
@@ -231,7 +280,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     _ => return Error {}.compose(dst),
                 };
                 klog!("\"incr {}\" {} {}", string_key(req.key()), code, len);
-            },
+            }
             Request::Decr(ref req) => {
                 let (code, len) = match self.response {
                     Response::Numeric(ref res) => {
@@ -245,7 +294,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     _ => return Error {}.compose(dst),
                 };
                 klog!("\"decr {}\" {} {}", string_key(req.key()), code, len);
-            },
+            }
             Request::Delete(ref req) => {
                 let (code, len) = match self.response {
                     Response::Deleted(ref res) => {
@@ -259,7 +308,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     _ => return Error {}.compose(dst),
                 };
                 klog!("\"delete {}\" {} {}", string_key(req.key()), code, len);
-            },
+            }
             Request::FlushAll(_) => {}
             Request::Quit(_) => {}
         }

--- a/src/protocol/memcache/src/result/mod.rs
+++ b/src/protocol/memcache/src/result/mod.rs
@@ -2,9 +2,21 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
+use std::ops::Deref;
+use std::borrow::Cow;
 use crate::*;
 use protocol_common::ExecutionResult;
 use session::Session;
+use logger::*;
+
+// response codes for klog
+const MISS: u8 = 0;
+const HIT: u8 = 4;
+const STORED: u8 = 5;
+const EXISTS: u8 = 6;
+const DELETED: u8 = 7;
+const NOT_FOUND: u8 = 8;
+const NOT_STORED: u8 = 9;
 
 pub struct MemcacheExecutionResult<Request, Response> {
     pub(crate) request: Request,
@@ -37,6 +49,25 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     let miss_keys = total_keys - hit_keys;
                     GET_KEY_HIT.add(hit_keys as _);
                     GET_KEY_MISS.add(miss_keys as _);
+
+                    let values = res.values();
+                    let mut value_index = 0;
+                    
+                    for key in req.keys() {
+                        let key = key.deref();
+                        // if we are out of values or the keys don't match, it's a miss
+                        if value_index >= values.len() || values[value_index].key() != key {
+                            klog!("\"get {}\" 0 0", String::from_utf8_lossy(key));
+                        } else {
+                            let start = dst.write_pending();
+                            values[value_index].compose(dst);
+                            let size = dst.write_pending() - start;
+                            klog!("\"get {}\" 4 {}", String::from_utf8_lossy(key), size);
+                            value_index += 1;
+                        }
+                    }
+
+                    return;
                 }
                 _ => return Error {}.compose(dst),
             },
@@ -47,92 +78,195 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     let miss_keys = total_keys - hit_keys;
                     GETS_KEY_HIT.add(hit_keys as _);
                     GETS_KEY_MISS.add(miss_keys as _);
+
+                    let values = res.values();
+                    let mut value_index = 0;
+                    
+                    for key in req.keys() {
+                        let key = key.deref();
+                        // if we are out of values or the keys don't match, it's a miss
+                        if value_index >= values.len() || values[value_index].key() != key {
+                            klog!("\"gets {}\" {} 0", String::from_utf8_lossy(key), MISS);
+                        } else {
+                            let start = dst.write_pending();
+                            values[value_index].compose(dst);
+                            let size = dst.write_pending() - start;
+                            klog!("\"gets {}\" {} {}", String::from_utf8_lossy(key), HIT, size);
+                            value_index += 1;
+                        }
+                    }
+
+                    return;
                 }
                 _ => return Error {}.compose(dst),
             },
-            Request::Set(_) => match self.response {
-                Response::Stored(_) => {
-                    SET_STORED.increment();
-                }
-                Response::NotStored(_) => {
-                    SET_NOT_STORED.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Set(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        SET_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        SET_NOT_STORED.increment();
+                        (NOT_STORED, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"set {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
             },
-            Request::Add(_) => match self.response {
-                Response::Stored(_) => {
-                    ADD_STORED.increment();
-                }
-                Response::NotStored(_) => {
-                    ADD_NOT_STORED.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Add(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        ADD_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        ADD_NOT_STORED.increment();
+                        (NOT_STORED, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"add {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
             },
-            Request::Replace(_) => match self.response {
-                Response::Stored(_) => {
-                    REPLACE_STORED.increment();
-                }
-                Response::NotStored(_) => {
-                    REPLACE_NOT_STORED.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Replace(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        REPLACE_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        REPLACE_NOT_STORED.increment();
+                        (NOT_STORED, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"replace {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
             },
-            Request::Cas(_) => match self.response {
-                Response::Stored(_) => {
-                    CAS_STORED.increment();
-                }
-                Response::Exists(_) => {
-                    CAS_EXISTS.increment();
-                }
-                Response::NotFound(_) => {
-                    CAS_NOT_FOUND.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Cas(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        CAS_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::Exists(ref res) => {
+                        CAS_EXISTS.increment();
+                        (EXISTS, res.len())
+                    }
+                    Response::NotFound(ref res) => {
+                        CAS_NOT_FOUND.increment();
+                        (NOT_FOUND, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"replace {} {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), req.cas(), code, len);
             },
-            Request::Append(_) => match self.response {
-                Response::Stored(_) => {
-                    APPEND_STORED.increment();
-                }
-                Response::NotStored(_) => {
-                    APPEND_NOT_STORED.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Append(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        APPEND_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        APPEND_NOT_STORED.increment();
+                        (NOT_STORED, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"append {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
             },
-            Request::Prepend(_) => match self.response {
-                Response::Stored(_) => {
-                    PREPEND_STORED.increment();
-                }
-                Response::NotStored(_) => {
-                    PREPEND_NOT_STORED.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Prepend(ref req) => {
+                let ttl: i64 = match req.ttl() {
+                    None => 0,
+                    Some(0) => -1,
+                    Some(t) => t as _,
+                };
+                let (code, len) = match self.response {
+                    Response::Stored(ref res) => {
+                        PREPEND_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        PREPEND_NOT_STORED.increment();
+                        (NOT_STORED, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"prepend {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), code, len);
             },
-            Request::Incr(_) => match self.response {
-                Response::Numeric(_) => {}
-                Response::NotFound(_) => {
-                    INCR_NOT_FOUND.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Incr(ref req) => {
+                let (code, len) = match self.response {
+                    Response::Numeric(ref res) => {
+                        INCR_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        INCR_NOT_FOUND.increment();
+                        (NOT_FOUND, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"incr {}\" {} {}", string_key(req.key()), code, len);
             },
-            Request::Decr(_) => match self.response {
-                Response::Numeric(_) => {}
-                Response::NotFound(_) => {
-                    DECR_NOT_FOUND.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Decr(ref req) => {
+                let (code, len) = match self.response {
+                    Response::Numeric(ref res) => {
+                        DECR_STORED.increment();
+                        (STORED, res.len())
+                    }
+                    Response::NotStored(ref res) => {
+                        DECR_NOT_FOUND.increment();
+                        (NOT_FOUND, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"decr {}\" {} {}", string_key(req.key()), code, len);
             },
-            Request::Delete(_) => match self.response {
-                Response::Deleted(_) => {
-                    DELETE_DELETED.increment();
-                }
-                Response::NotFound(_) => {
-                    DELETE_NOT_FOUND.increment();
-                }
-                _ => return Error {}.compose(dst),
+            Request::Delete(ref req) => {
+                let (code, len) = match self.response {
+                    Response::Deleted(ref res) => {
+                        DELETE_DELETED.increment();
+                        (DELETED, res.len())
+                    }
+                    Response::NotFound(ref res) => {
+                        DELETE_NOT_FOUND.increment();
+                        (NOT_FOUND, res.len())
+                    }
+                    _ => return Error {}.compose(dst),
+                };
+                klog!("\"delete {}\" {} {}", string_key(req.key()), code, len);
             },
             Request::FlushAll(_) => {}
             Request::Quit(_) => {}
         }
         self.response.compose(dst)
     }
+}
+
+fn string_key(key: &[u8]) -> Cow<'_, str> {
+    String::from_utf8_lossy(key)
 }

--- a/src/protocol/memcache/src/result/mod.rs
+++ b/src/protocol/memcache/src/result/mod.rs
@@ -67,6 +67,8 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                         }
                     }
 
+                    let _ = dst.write_all(b"END\r\n");
+
                     return;
                 }
                 _ => return Error {}.compose(dst),
@@ -95,6 +97,8 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                             value_index += 1;
                         }
                     }
+
+                    let _ = dst.write_all(b"END\r\n");
 
                     return;
                 }
@@ -273,7 +277,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                         INCR_STORED.increment();
                         (STORED, res.len())
                     }
-                    Response::NotStored(ref res) => {
+                    Response::NotFound(ref res) => {
                         INCR_NOT_FOUND.increment();
                         (NOT_FOUND, res.len())
                     }
@@ -287,7 +291,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                         DECR_STORED.increment();
                         (STORED, res.len())
                     }
-                    Response::NotStored(ref res) => {
+                    Response::NotFound(ref res) => {
                         DECR_NOT_FOUND.increment();
                         (NOT_FOUND, res.len())
                     }

--- a/src/protocol/memcache/src/result/mod.rs
+++ b/src/protocol/memcache/src/result/mod.rs
@@ -178,7 +178,7 @@ impl Compose for MemcacheExecutionResult<Request, Response> {
                     }
                     _ => return Error {}.compose(dst),
                 };
-                klog!("\"replace {} {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), req.cas(), code, len);
+                klog!("\"cas {} {} {} {} {}\" {} {}", string_key(req.key()), req.flags(), ttl, req.value().len(), req.cas(), code, len);
             },
             Request::Append(ref req) => {
                 let ttl: i64 = match req.ttl() {


### PR DESCRIPTION
The memcache command log (klog) was missing following the protocol
refactor in #430.

This change adds the command log back for the memcache protocol.