### PR TITLE
Some update for JSegcache

### DIFF
--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -405,7 +405,6 @@ impl HashTable {
                         item_info,
                         get_cas(self.data[(hash & self.mask) as usize].data[0]),
                     );
-                    assert!(item.verify_hashtable_entry()); 
                     item.check_magic();
 
                     return Some(item);

--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -393,9 +393,11 @@ impl HashTable {
                             freq = (freq | 0x80) << FREQ_BIT_SHIFT;
                         }
                         // TODO: this needs to be atomic
+                        // worse case new item insert fails
                         *item_info = (*item_info & !FREQ_MASK) | freq;
                     }
 
+                    println!("{} == {}", item_info_val, *item_info);
                     let age = segments.get_age(item_info_val).unwrap();
                     let item = RichItem::new(
                         current_item,
@@ -404,6 +406,7 @@ impl HashTable {
                         item_info,
                         get_cas(self.data[(hash & self.mask) as usize].data[0]),
                     );
+                    assert!(item.verify_hashtable_entry()); 
                     item.check_magic();
 
                     return Some(item);

--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -397,12 +397,11 @@ impl HashTable {
                         *item_info = (*item_info & !FREQ_MASK) | freq;
                     }
 
-                    println!("{} == {}", item_info_val, *item_info);
                     let age = segments.get_age(item_info_val).unwrap();
                     let item = RichItem::new(
                         current_item,
                         age,
-                        item_info_val,
+                        item_info_val & !FREQ_MASK,
                         item_info,
                         get_cas(self.data[(hash & self.mask) as usize].data[0]),
                     );

--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -308,8 +308,10 @@ impl HashTable {
                         *item_info = (*item_info & !FREQ_MASK) | freq;
                     }
 
+                    let age = segments.get_age(*item_info).unwrap();
                     let item = Item::new(
                         current_item,
+                        age, 
                         get_cas(self.data[(hash & self.mask) as usize].data[0]),
                     );
                     item.check_magic();
@@ -359,8 +361,10 @@ impl HashTable {
                 if current_item.key() != key {
                     HASH_TAG_COLLISION.increment();
                 } else {
+                    let age = segments.get_age(*item_info).unwrap();
                     let item = Item::new(
                         current_item,
+                        age, 
                         get_cas(self.data[(hash & self.mask) as usize].data[0]),
                     );
                     item.check_magic();

--- a/src/storage/seg/src/hashtable/mod.rs
+++ b/src/storage/seg/src/hashtable/mod.rs
@@ -322,6 +322,27 @@ impl HashTable {
         None
     }
 
+    /// Lookup an item by key and return it
+    pub fn get_age(&mut self, key: &[u8], segments: &mut Segments) -> Option<u32> {
+        let hash = self.hash(key);
+        let tag = tag_from_hash(hash);
+
+        let iter = IterMut::new(self, hash);
+
+        for item_info in iter {
+            if get_tag(*item_info) == tag {
+                let current_item = segments.get_item(*item_info).unwrap();
+                if current_item.key() != key {
+                    HASH_TAG_COLLISION.increment();
+                } else {
+                    return segments.get_age(*item_info);
+                }
+            }
+        }
+
+        None
+    }
+
     /// Lookup an item by key and return it without incrementing the item
     /// frequency. This may be used to compose higher-level functions which do
     /// not want a successful item lookup to count as a hit for that item.

--- a/src/storage/seg/src/item/mod.rs
+++ b/src/storage/seg/src/item/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use header::ITEM_MAGIC_SIZE;
 
 use crate::SegError;
 use crate::Value;
+use crate::hashtable::FREQ_MASK;
 
 pub(crate) use header::{ItemHeader, ITEM_HDR_SIZE};
 pub(crate) use raw::RawItem;
@@ -151,7 +152,7 @@ impl RichItem {
     // used to support multi readers and single writer
     pub fn verify_hashtable_entry(&self) -> bool {
         unsafe {
-            return self.item_info == *self.item_info_ptr
+            return self.item_info == *self.item_info_ptr & !FREQ_MASK
         }
     }
 

--- a/src/storage/seg/src/item/mod.rs
+++ b/src/storage/seg/src/item/mod.rs
@@ -88,6 +88,87 @@ impl std::fmt::Debug for Item {
     }
 }
 
+/// Items are the base unit of data stored within the cache.
+pub struct RichItem {
+    cas: u32,
+    age: u32,
+    item_info: u64,
+    item_info_ptr: *const u64,
+    raw: RawItem,
+}
+
+impl RichItem {
+    /// Creates a new `Item` from its parts
+    pub(crate) fn new(raw: RawItem, age: u32, item_info: u64, item_info_ptr: *const u64, cas: u32) -> Self {
+        RichItem { cas, age, item_info, item_info_ptr, raw }
+    }
+
+    /// If the `magic` or `debug` features are enabled, this allows for checking
+    /// that the magic bytes at the start of an item match the expected value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the magic bytes are incorrect, indicating that the data has
+    /// become corrupted or the item was loaded from the wrong offset.
+    pub(crate) fn check_magic(&self) {
+        self.raw.check_magic()
+    }
+
+    /// Borrow the item key
+    pub fn key(&self) -> &[u8] {
+        self.raw.key()
+    }
+
+    /// Borrow the item value
+    pub fn value(&self) -> Value {
+        self.raw.value()
+    }
+
+    /// CAS value for the item
+    pub fn cas(&self) -> u32 {
+        self.cas
+    }
+
+    pub fn age(&self) -> u32 {
+        self.age
+    }
+
+    // used to support multi readers and single writer
+    pub fn verify_hashtable_entry(&self) -> bool {
+        unsafe {
+            return self.item_info == *self.item_info_ptr
+        }
+    }
+
+    /// Borrow the optional data
+    pub fn optional(&self) -> Option<&[u8]> {
+        self.raw.optional()
+    }
+
+    /// Perform a wrapping addition on the value. Returns an error if the item
+    /// is not a numeric type.
+    pub fn wrapping_add(&mut self, rhs: u64) -> Result<(), SegError> {
+        self.raw.wrapping_add(rhs)
+    }
+
+    /// Perform a saturating subtraction on the value. Returns an error if the
+    /// item is not a numeric type.
+    pub fn saturating_sub(&mut self, rhs: u64) -> Result<(), SegError> {
+        self.raw.saturating_sub(rhs)
+    }
+}
+
+impl std::fmt::Debug for RichItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        f.debug_struct("Item")
+            .field("cas", &self.cas())
+            .field("raw", &self.raw)
+            .field("item_info", &self.item_info)
+            .field("item_info_ptr", &self.item_info_ptr)
+            .finish()
+    }
+}
+
 pub fn size_of(value: &Value) -> usize {
     match value {
         Value::Bytes(v) => v.len(),

--- a/src/storage/seg/src/item/mod.rs
+++ b/src/storage/seg/src/item/mod.rs
@@ -135,22 +135,9 @@ impl RichItem {
     }
 
     // used to support multi readers and single writer
-    pub fn item_info(&self) -> u64 {
-        return self.item_info; 
-    }
-
-    pub fn item_info_ptr(&self) -> *const u64 {
-        return self.item_info_ptr;
-    }
-
-    pub fn item_info_ptr_val(&self) -> u64 {
-        unsafe {
-            return *self.item_info_ptr;
-        }
-    }
-
-    // used to support multi readers and single writer
-    pub fn verify_hashtable_entry(&self) -> bool {
+    // return true, if the item is evicted/updated since being 
+    // read from the hash table
+    pub fn is_not_changed(&self) -> bool {
         unsafe {
             return self.item_info == *self.item_info_ptr & !FREQ_MASK
         }

--- a/src/storage/seg/src/item/mod.rs
+++ b/src/storage/seg/src/item/mod.rs
@@ -21,13 +21,14 @@ pub(crate) use reserved::ReservedItem;
 /// Items are the base unit of data stored within the cache.
 pub struct Item {
     cas: u32,
+    age: u32,
     raw: RawItem,
 }
 
 impl Item {
     /// Creates a new `Item` from its parts
-    pub(crate) fn new(raw: RawItem, cas: u32) -> Self {
-        Item { cas, raw }
+    pub(crate) fn new(raw: RawItem, age: u32, cas: u32) -> Self {
+        Item { cas, age, raw }
     }
 
     /// If the `magic` or `debug` features are enabled, this allows for checking
@@ -54,6 +55,10 @@ impl Item {
     /// CAS value for the item
     pub fn cas(&self) -> u32 {
         self.cas
+    }
+
+    pub fn age(&self) -> u32 {
+        self.age
     }
 
     /// Borrow the optional data

--- a/src/storage/seg/src/item/mod.rs
+++ b/src/storage/seg/src/item/mod.rs
@@ -134,6 +134,21 @@ impl RichItem {
     }
 
     // used to support multi readers and single writer
+    pub fn item_info(&self) -> u64 {
+        return self.item_info; 
+    }
+
+    pub fn item_info_ptr(&self) -> *const u64 {
+        return self.item_info_ptr;
+    }
+
+    pub fn item_info_ptr_val(&self) -> u64 {
+        unsafe {
+            return *self.item_info_ptr;
+        }
+    }
+
+    // used to support multi readers and single writer
     pub fn verify_hashtable_entry(&self) -> bool {
         unsafe {
             return self.item_info == *self.item_info_ptr

--- a/src/storage/seg/src/seg.rs
+++ b/src/storage/seg/src/seg.rs
@@ -84,6 +84,10 @@ impl Seg {
         self.hashtable.get(key, self.time, &mut self.segments)
     }
 
+    pub fn get_age(&mut self, key: &[u8]) -> Option<u32> {
+        self.hashtable.get_age(key, &mut self.segments)
+    }
+
     /// Get the item in the `Seg` with the provided key without
     /// increasing the item frequency - useful for combined operations that
     /// check for presence - eg replace is a get + set

--- a/src/storage/seg/src/seg.rs
+++ b/src/storage/seg/src/seg.rs
@@ -176,6 +176,8 @@ impl Seg {
 
         // try to get a `ReservedItem`
         let mut retries = RESERVE_RETRIES;
+        let mut has_removed_expired = false; 
+        
         let reserved;
         loop {
             match self
@@ -192,6 +194,11 @@ impl Seg {
                     return Err(SegError::ItemOversized { size });
                 }
                 Err(TtlBucketsError::NoFreeSegments) => {
+                    if !has_removed_expired {
+                        self.expire();
+                        has_removed_expired = true;
+                        continue;
+                    }
                     if self
                         .segments
                         .evict(&mut self.ttl_buckets, &mut self.hashtable)

--- a/src/storage/seg/src/seg.rs
+++ b/src/storage/seg/src/seg.rs
@@ -119,9 +119,9 @@ impl Seg {
     /// cache.insert(b"coffee", b"strong", None, Duration::ZERO);
     /// let item = cache.get_with_item_info(b"coffee").expect("didn't get item back");
     /// assert_eq!(item.value(), b"strong");
-    /// assert!(item.verify_hashtable_entry());
+    /// assert!(item.is_not_changed());
     /// cache.insert(b"coffee", b"notStrong", None, Duration::ZERO);
-    /// assert!(!item.verify_hashtable_entry()); 
+    /// assert!(!item.is_not_changed());
     /// ```
     pub fn get_with_item_info(&mut self, key: &[u8]) -> Option<RichItem> {
         self.hashtable.get_with_item_info(key, self.time, &mut self.segments)

--- a/src/storage/seg/src/segments/segments.rs
+++ b/src/storage/seg/src/segments/segments.rs
@@ -147,6 +147,11 @@ impl Segments {
         self.get_item_at(seg_id, offset)
     }
 
+    pub(crate) fn get_age(&self, item_info: u64) -> Option<u32> {
+        let seg_id = get_seg_id(item_info).map(|v| v.get())?;
+        return Some(self.headers[seg_id as usize - 1].create_at().elapsed().as_secs());
+    }
+
     /// Retrieve a `RawItem` from a specific segment id at the given offset
     // TODO(bmartin): consider changing the return type here and removing asserts?
     pub(crate) fn get_item_at(


### PR DESCRIPTION
This PR contains multiple things (let me know if you want to split them)
1. Add `get_age` in segments, then add a new field `age` in `Item` so that we can return age to caller. 
2. Add `RichItem` to return `item_info` and `item_info_ptr`, these two are used to support opportunistic concurrency control. Not sure adding a new struct is better than adding the fields to `Item`, but given there might be fields (like these) that we often do not need, creating a new struct might be better. 
3. add a call to expire before we evict, this avoids the problem that users may forget to call `expire`. 