### PR TITLE
consolidate TTL conversion logic

### DIFF
--- a/src/protocol/memcache/src/lib.rs
+++ b/src/protocol/memcache/src/lib.rs
@@ -18,10 +18,9 @@ pub use storage::*;
 
 pub use protocol_common::*;
 
+use common::expiry::TimeType;
 use logger::Klog;
 use rustcommon_metrics::*;
-
-// use common::expiry::TimeType;
 
 const CRLF: &[u8] = b"\r\n";
 

--- a/src/protocol/memcache/src/request/add.rs
+++ b/src/protocol/memcache/src/request/add.rs
@@ -9,7 +9,7 @@ pub struct Add {
     pub(crate) key: Box<[u8]>,
     pub(crate) value: Box<[u8]>,
     pub(crate) flags: u32,
-    pub(crate) ttl: Option<u32>,
+    pub(crate) ttl: Ttl,
     pub(crate) noreply: bool,
 }
 
@@ -22,7 +22,7 @@ impl Add {
         &self.value
     }
 
-    pub fn ttl(&self) -> Option<u32> {
+    pub fn ttl(&self) -> Ttl {
         self.ttl
     }
 
@@ -68,7 +68,7 @@ impl Compose for Add {
     fn compose(&self, session: &mut dyn BufMut) -> usize {
         let verb = b"add ";
         let flags = format!(" {}", self.flags).into_bytes();
-        let ttl = convert_ttl(self.ttl);
+        let ttl = format!(" {}", self.ttl.get().unwrap_or(0)).into_bytes();
         let vlen = format!(" {}", self.value.len()).into_bytes();
         let header_end = if self.noreply {
             " noreply\r\n".as_bytes()
@@ -102,11 +102,6 @@ impl Klog for Add {
     type Response = Response;
 
     fn klog(&self, response: &Self::Response) {
-        let ttl: i64 = match self.ttl() {
-            None => 0,
-            Some(0) => -1,
-            Some(t) => t as _,
-        };
         let (code, len) = match response {
             Response::Stored(ref res) => {
                 ADD_STORED.increment();
@@ -124,7 +119,7 @@ impl Klog for Add {
             "\"add {} {} {} {}\" {} {}",
             string_key(self.key()),
             self.flags(),
-            ttl,
+            self.ttl.get().unwrap_or(0),
             self.value().len(),
             code,
             len
@@ -149,7 +144,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: false,
                 })
             ))
@@ -164,7 +159,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: true,
                 })
             ))

--- a/src/protocol/memcache/src/request/append.rs
+++ b/src/protocol/memcache/src/request/append.rs
@@ -9,7 +9,7 @@ pub struct Append {
     pub(crate) key: Box<[u8]>,
     pub(crate) value: Box<[u8]>,
     pub(crate) flags: u32,
-    pub(crate) ttl: Option<u32>,
+    pub(crate) ttl: Ttl,
     pub(crate) noreply: bool,
 }
 
@@ -22,7 +22,7 @@ impl Append {
         &self.value
     }
 
-    pub fn ttl(&self) -> Option<u32> {
+    pub fn ttl(&self) -> Ttl {
         self.ttl
     }
 
@@ -68,7 +68,7 @@ impl Compose for Append {
     fn compose(&self, session: &mut dyn BufMut) -> usize {
         let verb = b"append ";
         let flags = format!(" {}", self.flags).into_bytes();
-        let ttl = convert_ttl(self.ttl);
+        let ttl = format!(" {}", self.ttl.get().unwrap_or(0)).into_bytes();
         let vlen = format!(" {}", self.value.len());
         let header_end = if self.noreply {
             " noreply\r\n".as_bytes()
@@ -102,11 +102,6 @@ impl Klog for Append {
     type Response = Response;
 
     fn klog(&self, response: &Self::Response) {
-        let ttl: i64 = match self.ttl() {
-            None => 0,
-            Some(0) => -1,
-            Some(t) => t as _,
-        };
         let (code, len) = match response {
             Response::Stored(ref res) => {
                 APPEND_STORED.increment();
@@ -124,7 +119,7 @@ impl Klog for Append {
             "\"append {} {} {} {}\" {} {}",
             string_key(self.key()),
             self.flags(),
-            ttl,
+            self.ttl.get().unwrap_or(0),
             self.value().len(),
             code,
             len
@@ -149,7 +144,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: false,
                 })
             ))
@@ -164,7 +159,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: true,
                 })
             ))

--- a/src/protocol/memcache/src/request/mod.rs
+++ b/src/protocol/memcache/src/request/mod.rs
@@ -329,13 +329,13 @@ impl Ttl {
 
         // all zero values are treated as no expiration
         if exptime == 0 {
-            return Self {
-                inner: None
-            }
+            return Self { inner: None };
         }
 
         // normalize all expiration times into delta
-        let exptime = if time_type == TimeType::Unix || (time_type == TimeType::Memcache && exptime > 60 * 60 * 24 * 30) {
+        let exptime = if time_type == TimeType::Unix
+            || (time_type == TimeType::Memcache && exptime > 60 * 60 * 24 * 30)
+        {
             // treat it as a unix timestamp
 
             // clamp to a valid u32
@@ -354,7 +354,7 @@ impl Ttl {
             // zero would be immediate expiration, early return
             if seconds == 0 {
                 return Self {
-                    inner: NonZeroI32::new(-1)
+                    inner: NonZeroI32::new(-1),
                 };
             }
 
@@ -366,11 +366,11 @@ impl Ttl {
         // clamp long TTLs
         if exptime > i32::MAX as i64 {
             Self {
-                inner: NonZeroI32::new(i32::MAX)
+                inner: NonZeroI32::new(i32::MAX),
             }
         } else {
-             Self {
-                inner: NonZeroI32::new(exptime as i32)
+            Self {
+                inner: NonZeroI32::new(exptime as i32),
             }
         }
     }
@@ -384,9 +384,7 @@ impl Ttl {
     }
 
     pub fn none() -> Self {
-        Self {
-            inner: None
-        }
+        Self { inner: None }
     }
 }
 

--- a/src/protocol/memcache/src/request/replace.rs
+++ b/src/protocol/memcache/src/request/replace.rs
@@ -9,7 +9,7 @@ pub struct Replace {
     pub(crate) key: Box<[u8]>,
     pub(crate) value: Box<[u8]>,
     pub(crate) flags: u32,
-    pub(crate) ttl: Option<u32>,
+    pub(crate) ttl: Ttl,
     pub(crate) noreply: bool,
 }
 
@@ -22,7 +22,7 @@ impl Replace {
         &self.value
     }
 
-    pub fn ttl(&self) -> Option<u32> {
+    pub fn ttl(&self) -> Ttl {
         self.ttl
     }
 
@@ -68,7 +68,7 @@ impl Compose for Replace {
     fn compose(&self, session: &mut dyn BufMut) -> usize {
         let verb = b"replace ";
         let flags = format!(" {}", self.flags).into_bytes();
-        let ttl = convert_ttl(self.ttl);
+        let ttl = format!(" {}", self.ttl.get().unwrap_or(0)).into_bytes();
         let vlen = format!(" {}", self.value.len()).into_bytes();
         let header_end = if self.noreply {
             " noreply\r\n".as_bytes()
@@ -102,11 +102,6 @@ impl Klog for Replace {
     type Response = Response;
 
     fn klog(&self, response: &Self::Response) {
-        let ttl: i64 = match self.ttl() {
-            None => 0,
-            Some(0) => -1,
-            Some(t) => t as _,
-        };
         let (code, len) = match response {
             Response::Stored(ref res) => {
                 REPLACE_STORED.increment();
@@ -124,7 +119,7 @@ impl Klog for Replace {
             "\"replace {} {} {} {}\" {} {}",
             string_key(self.key()),
             self.flags(),
-            ttl,
+            self.ttl.get().unwrap_or(0),
             self.value().len(),
             code,
             len
@@ -149,7 +144,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: false,
                 })
             ))
@@ -164,7 +159,7 @@ mod tests {
                     key: b"0".to_vec().into_boxed_slice(),
                     value: b"0".to_vec().into_boxed_slice(),
                     flags: 0,
-                    ttl: None,
+                    ttl: Ttl::none(),
                     noreply: true,
                 })
             ))

--- a/src/protocol/memcache/src/util.rs
+++ b/src/protocol/memcache/src/util.rs
@@ -5,10 +5,13 @@
 pub use nom::bytes::streaming::*;
 pub use nom::character::streaming::*;
 pub use nom::error::ErrorKind;
-use nom::error::ParseError;
 pub use nom::{AsChar, Err, IResult, InputTakeAtPosition, Needed};
 pub use protocol_common::Compose;
 pub use std::io::Write;
+
+use crate::{TimeType, Ttl};
+
+use nom::error::ParseError;
 
 // consumes one or more literal spaces
 pub fn space1(input: &[u8]) -> IResult<&[u8], &[u8]> {
@@ -104,6 +107,14 @@ pub fn parse_i64(input: &[u8]) -> IResult<&[u8], i64> {
     let value = value
         .parse::<i64>()
         .map_err(|_| nom::Err::Failure((input, nom::error::ErrorKind::Tag)))?;
+    Ok((input, value))
+}
+
+pub fn parse_ttl(input: &[u8], time_type: TimeType) -> IResult<&[u8], Ttl> {
+    let (input, value) = parse_i64(input)?;
+
+    let value = Ttl::new(value, time_type);
+
     Ok((input, value))
 }
 

--- a/src/proxy/momento/src/klog.rs
+++ b/src/proxy/momento/src/klog.rs
@@ -13,7 +13,7 @@ pub(crate) fn klog_get(key: &str, response_len: usize) {
 pub fn klog_set(
     key: &str,
     flags: u32,
-    ttl: u32,
+    ttl: i32,
     value_len: usize,
     result_code: usize,
     response_len: usize,

--- a/src/proxy/momento/src/protocol/memcache/set.rs
+++ b/src/proxy/momento/src/protocol/memcache/set.rs
@@ -41,8 +41,12 @@ pub async fn set(
 
         BACKEND_REQUEST.increment();
 
-        let ttl = if let Some(ttl) = request.ttl() {
-            NonZeroU64::new(ttl as u64)
+        let ttl = if let Some(ttl) = request.ttl().get() {
+            if ttl < 0 {
+                NonZeroU64::new(1)
+            } else {
+                NonZeroU64::new(ttl as u64)
+            }
         } else {
             None
         };
@@ -61,7 +65,7 @@ pub async fn set(
                             klog_set(
                                 key,
                                 request.flags(),
-                                request.ttl().unwrap_or(0),
+                                request.ttl().get().unwrap_or(0),
                                 value.len(),
                                 5,
                                 0,
@@ -70,7 +74,7 @@ pub async fn set(
                             klog_set(
                                 key,
                                 request.flags(),
-                                request.ttl().unwrap_or(0),
+                                request.ttl().get().unwrap_or(0),
                                 value.len(),
                                 5,
                                 8,
@@ -91,7 +95,7 @@ pub async fn set(
                             klog_set(
                                 key,
                                 request.flags(),
-                                request.ttl().unwrap_or(0),
+                                request.ttl().get().unwrap_or(0),
                                 value.len(),
                                 9,
                                 0,
@@ -100,7 +104,7 @@ pub async fn set(
                             klog_set(
                                 key,
                                 request.flags(),
-                                request.ttl().unwrap_or(0),
+                                request.ttl().get().unwrap_or(0),
                                 value.len(),
                                 9,
                                 12,

--- a/src/proxy/momento/src/protocol/resp/set.rs
+++ b/src/proxy/momento/src/protocol/resp/set.rs
@@ -66,7 +66,7 @@ pub async fn set(
                         klog_set(
                             key,
                             0,
-                            ttl.map(|v| v.get()).unwrap_or(0) as u32,
+                            ttl.map(|v| v.get()).unwrap_or(0) as i32,
                             value.len(),
                             5,
                             8,
@@ -86,7 +86,7 @@ pub async fn set(
                         klog_set(
                             key,
                             0,
-                            ttl.map(|v| v.get()).unwrap_or(0) as u32,
+                            ttl.map(|v| v.get()).unwrap_or(0) as i32,
                             value.len(),
                             9,
                             12,


### PR DESCRIPTION
Adds a new type `Ttl` to be used throughout the memcache protocol crate. This allows us to define and document the conversion between external and internal representations of the TTL.

Fixes #456 