### PR TITLE
Add a bloom filter storage module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +208,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bloom"
+version = "0.1.0"
+dependencies = [
+ "bitvec",
+ "criterion 0.4.0",
+ "metrohash",
+ "rand",
+ "twox-hash",
 ]
 
 [[package]]
@@ -293,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +375,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,9 +422,30 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -428,9 +511,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
- "cast",
- "clap",
- "criterion-plot",
+ "cast 0.2.7",
+ "clap 2.34.0",
+ "criterion-plot 0.4.4",
  "csv",
  "itertools",
  "lazy_static",
@@ -448,12 +531,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast 0.3.0",
+ "ciborium",
+ "clap 3.2.22",
+ "criterion-plot 0.5.0",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
- "cast",
+ "cast 0.2.7",
+ "itertools",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast 0.3.0",
  "itertools",
 ]
 
@@ -657,6 +776,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1089,6 +1214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrohash"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ba553cb19e2acbc54baa16faef215126243fe45e53357a3b2e9f4ebc7b0506c"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,7 +1314,7 @@ name = "momento_proxy"
 version = "0.1.0"
 dependencies = [
  "backtrace",
- "clap",
+ "clap 2.34.0",
  "common",
  "config",
  "libc",
@@ -1332,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,7 +1559,7 @@ name = "pingproxy"
 version = "0.0.1"
 dependencies = [
  "backtrace",
- "clap",
+ "clap 2.34.0",
  "common",
  "config",
  "logger",
@@ -1436,10 +1573,10 @@ name = "pingserver"
 version = "0.2.0"
 dependencies = [
  "backtrace",
- "clap",
+ "clap 2.34.0",
  "common",
  "config",
- "criterion",
+ "criterion 0.3.5",
  "entrystore",
  "logger",
  "protocol-ping",
@@ -1559,7 +1696,7 @@ version = "0.0.1"
 dependencies = [
  "common",
  "config",
- "criterion",
+ "criterion 0.3.5",
  "logger",
  "protocol-common",
  "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
@@ -1573,7 +1710,7 @@ dependencies = [
  "bytes 1.1.0",
  "common",
  "config",
- "criterion",
+ "criterion 0.3.5",
  "logger",
  "storage-types",
 ]
@@ -1583,7 +1720,7 @@ name = "protocol-memcache"
 version = "0.2.0"
 dependencies = [
  "common",
- "criterion",
+ "criterion 0.3.5",
  "logger",
  "nom 5.1.2",
  "protocol-common",
@@ -1596,7 +1733,7 @@ version = "0.0.2"
 dependencies = [
  "common",
  "config",
- "criterion",
+ "criterion 0.3.5",
  "logger",
  "protocol-common",
  "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
@@ -1662,6 +1799,12 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2040,7 +2183,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "common",
- "criterion",
+ "criterion 0.3.5",
  "datapool",
  "logger",
  "memmap2 0.2.3",
@@ -2057,10 +2200,10 @@ name = "segcache"
 version = "0.2.0"
 dependencies = [
  "backtrace",
- "clap",
+ "clap 2.34.0",
  "common",
  "config",
- "criterion",
+ "criterion 0.3.5",
  "entrystore",
  "logger",
  "protocol-memcache",
@@ -2242,6 +2385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2412,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -2289,7 +2444,7 @@ name = "thriftproxy"
 version = "0.0.1"
 dependencies = [
  "backtrace",
- "clap",
+ "clap 2.34.0",
  "common",
  "config",
  "logger",
@@ -2594,6 +2749,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +3055,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "src/server/pingserver",
     "src/server/segcache",
     "src/session",
+    "src/storage/bloom",
     "src/storage/datapool",
     "src/storage/seg",
     "src/storage/types",

--- a/src/storage/bloom/Cargo.toml
+++ b/src/storage/bloom/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bloom"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["rand"]
+
+[dependencies]
+bitvec = "1.0.1"
+metrohash = "1.0.6"
+twox-hash = { version = "1.6.3", default-features = false }
+
+rand = { version = "0.8.5", optional = true }
+
+[dev-dependencies]
+criterion = "0.4"
+
+[[bench]]
+name = "bloom"
+harness = false

--- a/src/storage/bloom/benches/bloom.rs
+++ b/src/storage/bloom/benches/bloom.rs
@@ -1,0 +1,46 @@
+use bloom::BloomFilter;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+const MB: usize = 1024 * 1024;
+
+fn small_key(c: &mut Criterion) {
+    c.bench_function("unit", |b| {
+        let mut bloom = BloomFilter::new(MB * 8, 64);
+
+        b.iter(|| bloom.insert(black_box(&())));
+    });
+
+    c.bench_function("u64", |b| {
+        let mut bloom = BloomFilter::new(MB * 8, 64);
+        let mut counter: u64 = 0;
+
+        b.iter(|| {
+            bloom.insert(black_box(&counter));
+            counter = counter.wrapping_add(1);
+        })
+    });
+
+    c.bench_function("small_slice", |b| {
+        let mut bloom = BloomFilter::new(MB * 8, 64);
+        let mut slice = vec![77u64; 64];
+
+        b.iter(|| {
+            bloom.insert(black_box(&slice));
+            slice[7] = slice[7].wrapping_add(77);
+        });
+    });
+
+    c.bench_function("large_slice", |b| {
+        let mut bloom = BloomFilter::new(MB * 8, 64);
+        let mut slice = vec![77u64; 16384];
+
+        b.iter(|| {
+            bloom.insert(black_box(&slice));
+            slice[7] = slice[7].wrapping_add(77);
+            slice[9001] = slice[9001].wrapping_add(707070);
+        });
+    });
+}
+
+criterion_group!(benches, small_key);
+criterion_main!(benches);

--- a/src/storage/bloom/src/lib.rs
+++ b/src/storage/bloom/src/lib.rs
@@ -20,8 +20,8 @@
 //! _ε_ and a rough estimate of _n_, the number of elements that will be
 //! stored in the bloom filter. Then, the optimal values of _k_ and _m_ are
 //! given by
-//! - _k_ = (_m_ / _n_) ln(2)
-//! - _m_ = (_n_ ln _ε_) / (ln 2)<sup>2</sup>
+//! - _k_ = - (_m_ / _n_) ln(2)
+//! - _m_ = - (_n_ ln _ε_) / (ln 2)<sup>2</sup>
 //! 
 
 use std::hash::{Hash, Hasher};

--- a/src/storage/bloom/src/lib.rs
+++ b/src/storage/bloom/src/lib.rs
@@ -1,0 +1,262 @@
+//! This library contains an implementation of a bloom filter.
+//! 
+//! There are two types exported by this library:
+//! - [`BloomFilter`] is a typed bloom filter that allows for inserting keys
+//!   and probabilistically checking whether they are present. This is what
+//!   you should use by default.
+//! - [`RawBloomFilter`] implements the core of the bloom filter datastructure
+//!   but it requires you to provide the two hashes used for each element. Use
+//!   this if you need absolute control over how items are placed in the bloom
+//!   filter or if you need to store items with different types into the same
+//!   bloom filter.
+//! 
+//! # Choosing bloom filter parameters
+//! A bloom filter only has two parameters:
+//! - _k_ - the number of bits that we set in the bloom filter for each value
+//!   inserted, and
+//! - _m_ - the size of the bloom filter in bits.
+//! 
+//! To figure out what these should be you need your desired error rate 
+//! _ε_ and a rough estimate of _n_, the number of elements that will be
+//! stored in the bloom filter. Then, the optimal values of _k_ and _m_ are
+//! given by
+//! - _k_ = (_m_ / _n_) ln(2)
+//! - _m_ = (_n_ ln _ε_) / (ln 2)<sup>2</sup>
+//! 
+
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+
+use bitvec::prelude::BitVec;
+use metrohash::MetroHash64;
+use twox_hash::Xxh3Hash64;
+
+fn xxh3hash<T: Hash + ?Sized>(value: &T, seed: u64) -> u64 {
+    let mut hasher = Xxh3Hash64::with_seed(seed);
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn metrohash<T: Hash + ?Sized>(value: &T, seed: u64) -> u64 {
+    let mut hasher = MetroHash64::with_seed(seed);
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Low-level bloom filter implementation that directly uses element hashes.
+#[derive(Clone)]
+pub struct RawBloomFilter {
+    bits: BitVec,
+    k: u64,
+}
+
+impl RawBloomFilter {
+    /// Create a new bloom filter with `m` bits that stores `k` hashes for each
+    /// value inserted.
+    /// 
+    /// # Panics
+    /// Panics if
+    /// - `m` is 0
+    /// - `k` is 0
+    /// - `k` > `m`
+    /// - `m` is not a multiple of `usize::BITS`
+    pub fn new(m: usize, k: usize) -> Self {
+        assert_ne!(m, 0, "m must be greater than 0");
+        assert_ne!(k, 0, "k must be greater than 0");
+        assert!(k <= m, "m must be greater than k (got {k} > {m})");
+        assert!(
+            m % usize::BITS as usize == 0,
+            "len must be a multiple of usize::BITS"
+        );
+
+        Self {
+            bits: BitVec::repeat(false, m),
+            k: k as u64,
+        }
+    }
+
+    /// Insert the value corresponding to the two provided hashes.
+    pub fn insert(&mut self, hash1: u64, hash2: u64) {
+        for index in self.indices(hash1, hash2) {
+            self.bits.set(index, true);
+        }
+    }
+
+    /// Check whether this bloom filter contains the value corresponding
+    /// to these two hashes.
+    pub fn contains(&self, hash1: u64, hash2: u64) -> bool {
+        self.indices(hash1, hash2).all(|index| self.bits[index])
+    }
+
+    /// Erase all items from the bloom filter.
+    pub fn clear(&mut self) {
+        self.bits.fill(false);
+    }
+
+    pub fn from_parts(data: BitVec, k: usize) -> Self {
+        Self {
+            bits: data,
+            k: k as u64,
+        }
+    }
+
+    /// Compute the bit indices within the bloom filter for the provided values.
+    fn indices(&self, hash1: u64, hash2: u64) -> impl Iterator<Item = usize> {
+        // Instead of coming up with k different hash functinos we can use linear
+        // combinations to create an unlimited number of hashes from only two initial
+        // hashes.
+        //
+        // To do this we first calculate two hashes, h1 and h2, then we form the rest of
+        // the hashes like this:
+        //   g_i = h1 + i * h2
+        //
+        // This ends up with the same distribution properties as just evaluating k
+        // different hash functions but it is far cheaper to execute.
+        //
+        // The source for this is "Less hashing, same performance: Building a better
+        // bloom filter" by Kirtz and Mitzenmacher.
+        let len = self.bits.len();
+        (0..self.k)
+            .map(move |i| hash1.wrapping_add(hash2.wrapping_mul(i)))
+            .map(move |hash| (hash % len as u64) as usize)
+    }
+}
+
+/// Bloom filter.
+pub struct BloomFilter<T: ?Sized> {
+    raw: RawBloomFilter,
+    seed: u64,
+    _dummy: PhantomData<*const T>,
+}
+
+impl<T: Hash + ?Sized> BloomFilter<T> {
+    /// Create a new bloom filter with a random seed and `m` bits which stores
+    /// `k` hashes for each inserted element.
+    /// 
+    /// Note that `m` will be rounded up to the next multiple of `usize::BITS`.
+    /// 
+    /// # Panics
+    /// Panics if
+    /// - `m` is 0
+    /// - `k` is 0
+    /// - `k` is greater than `m`
+    #[cfg(feature = "rand")]
+    pub fn new(m: usize, k: usize) -> Self {
+        Self::with_seed(m, k, rand::random())
+    }
+
+    /// Create a bloom filter with the provided seen and `m` bits which stores
+    /// `k` hashes for each inserted element.
+    /// 
+    /// Note that `m` will be rounded up to the next multiple of `usize::BITS`.
+    /// 
+    /// # Panics
+    /// Panics if
+    /// - `m` is 0
+    /// - `k` is 0
+    /// - `k` is greater than `m`
+    pub fn with_seed(m: usize, k: usize, seed: u64) -> Self {
+        const MASK: usize = (usize::BITS - 1) as usize;
+
+        Self {
+            // Note that we round the size of the bloom filter up to the next
+            // word size for convenience.
+            raw: RawBloomFilter::new((m + MASK) & !MASK, k),
+            seed,
+            _dummy: PhantomData,
+        }
+    }
+
+    /// Hash a value into the two hashes used by the bloom filter.
+    fn hash_value(&self, value: &T) -> [u64; 2] {
+        [xxh3hash(value, self.seed), metrohash(value, self.seed)]
+    }
+
+    /// Insert a value into this bloom filter.
+    pub fn insert(&mut self, value: &T) {
+        let [hash1, hash2] = self.hash_value(value);
+        self.raw.insert(hash1, hash2)
+    }
+
+    /// Check whether this bloom filter contains a given value.
+    /// 
+    /// This may return true even if `value` has not been inserted into the
+    /// filter.
+    pub fn contains(&self, value: &T) -> bool {
+        let [hash1, hash2] = self.hash_value(value);
+        self.raw.contains(hash1, hash2)
+    }
+
+    /// Erase all items from the bloom filter.
+    pub fn clear(&mut self) {
+        self.raw.clear()
+    }
+}
+
+impl<T: ?Sized> Clone for BloomFilter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            raw: self.raw.clone(),
+            seed: self.seed,
+            _dummy: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let mut bloom = RawBloomFilter::new(64, 4);
+
+        bloom.insert(0, 3);
+
+        assert!(bloom.contains(0, 3));
+    }
+
+    #[test]
+    fn empty_by_default() {
+        let bloom = RawBloomFilter::new(64, 4);
+
+        assert!(!bloom.contains(0, 4));
+        assert!(!bloom.contains(5, 7));
+    }
+
+    #[test]
+    fn missing() {
+        let mut bloom = RawBloomFilter::new(64, 4);
+
+        bloom.insert(5, 3);
+
+        assert!(!bloom.contains(0, 4));
+        assert!(!bloom.contains(5, 7));
+    }
+
+    #[test]
+    fn collision() {
+        let mut bloom = RawBloomFilter::new(64, 8);
+
+        bloom.insert(0, 8);
+        bloom.insert(4, 8);
+
+        assert!(bloom.contains(24, 4));
+    }
+
+    #[test]
+    fn clear() {
+        let mut bloom = RawBloomFilter::new(64, 8);
+
+        bloom.insert(0, 8);
+        bloom.insert(7, 3);
+
+        assert!(bloom.contains(0, 8));
+        assert!(bloom.contains(7, 3));
+
+        bloom.clear();
+
+        assert!(!bloom.contains(0, 8));
+        assert!(!bloom.contains(7, 3));
+    }
+}


### PR DESCRIPTION
This PR introduces a bloom filter storage module. At the moment it only contains the bloom filter data structure, docs, benchmarks, and tests. In future PRs I will add a protocol that makes use of the bloom filter.

# Performance
I don't think I could get this to be appreciably faster if I tried. I have added some criterion benchmarks under `src/storage/bloom/benches`. Here are the results:
```
unit                    time:   [116.81 ns 118.67 ns 120.47 ns]

u64                     time:   [130.20 ns 131.42 ns 132.77 ns]

small_slice             time:   [251.02 ns 252.92 ns 254.75 ns]

large_slice             time:   [21.259 µs 21.306 µs 21.352 µs]
```