### PR TITLE
ci: set opt-level for debug builds

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
       - name: Update cargo flags
         if: ${{ matrix.profile == 'debug' }}
-        run: echo 'CARGO_FLAGS=' >> $GITHUB_ENV
+        run: echo 'CARGO_FLAGS=-C opt-level 3' >> $GITHUB_ENV
         shell: bash
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
       - name: Update cargo flags
         if: ${{ matrix.profile == 'debug' }}
-        run: echo 'CARGO_FLAGS=-C opt-level 3' >> $GITHUB_ENV
+        run: echo 'CARGO_FLAGS=' >> $GITHUB_ENV
         shell: bash
 
       - uses: Swatinem/rust-cache@v1
@@ -38,18 +38,18 @@ jobs:
         name: build
         with:
           command: test
-          args: ${{ env.CARGO_FLAGS }} --workspace --all-features --tests --lib --bins --examples --no-run
+          args: ${{ env.CARGO_FLAGS }} --workspace --all-features --tests --lib --bins --examples --no-run -- -C opt-level 3
       - uses: actions-rs/cargo@v1
         name: test
         with:
           command: test
-          args: ${{ env.CARGO_FLAGS }} --workspace  --all-features --tests --lib --bins --examples
+          args: ${{ env.CARGO_FLAGS }} --workspace  --all-features --tests --lib --bins --examples -- -C opt-level 3
       - uses: actions-rs/cargo@v1
         if: ${{ matrix.profile == 'debug' }}
         name: doctests
         with:
           command: test
-          args: ${{ env.CARGO_FLAGS }} --workspace --all-features --doc -- --test-threads 16
+          args: ${{ env.CARGO_FLAGS }} --workspace --all-features --doc -- --test-threads 16 -- -C opt-level 3
 
   bench-check:
     strategy:


### PR DESCRIPTION
Sets the opt-level to 3 for debug builds in an attempt to reduce flakeyness of integration tests (which cannot be reproduced outside of the ci environment).