### PR TITLE
workspace config and update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "admin"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "common",
  "config",
@@ -31,7 +31,7 @@ dependencies = [
  "protocol-admin",
  "protocol-common",
  "queues",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "session",
  "slab",
  "tiny_http",
@@ -40,10 +40,11 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
 dependencies = [
+ "cfg-if 1.0.0",
  "getrandom",
  "once_cell",
  "version_check",
@@ -51,11 +52,20 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -75,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "arrayref"
@@ -99,9 +109,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ascii"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-stream"
@@ -184,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -235,16 +245,16 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bloom"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "criterion 0.4.0",
@@ -255,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "boring"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6953f3fea6f9f20c15e81b3f4ef2217ea06cc05652a0db49c0abb35626b0fad1"
+checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -268,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "boring-sys"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e43b1d5c3524929bc64d56e604f7362e357d509ff8b29903605fd72f4f41eae"
+checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
 dependencies = [
  "bindgen",
  "cmake",
@@ -290,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -308,18 +318,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cast"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cast"
@@ -356,15 +357,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
@@ -403,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
@@ -459,20 +462,20 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "boring",
  "macros",
  "net",
  "rustcommon-logger",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
+ "rustcommon-time",
  "serde",
 ]
 
 [[package]]
 name = "config"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "common",
  "log",
@@ -506,14 +509,14 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast 0.2.7",
+ "cast",
  "clap 2.34.0",
- "criterion-plot 0.4.4",
+ "criterion-plot 0.4.5",
  "csv",
  "itertools",
  "lazy_static",
@@ -538,7 +541,7 @@ checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
  "anes",
  "atty",
- "cast 0.3.0",
+ "cast",
  "ciborium",
  "clap 3.2.22",
  "criterion-plot 0.5.0",
@@ -558,11 +561,11 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
- "cast 0.2.7",
+ "cast",
  "itertools",
 ]
 
@@ -572,15 +575,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
- "cast 0.3.0",
+ "cast",
  "itertools",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -588,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -599,23 +602,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -623,19 +625,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -665,20 +666,20 @@ dependencies = [
 
 [[package]]
 name = "datapool"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "common",
  "libc",
- "memmap2 0.5.4",
+ "memmap2",
  "tempfile",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -687,13 +688,13 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "entrystore"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
  "common",
  "config",
@@ -705,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -753,11 +754,10 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -785,36 +785,36 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -834,13 +834,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -857,11 +857,11 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -870,7 +870,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 
@@ -885,6 +885,16 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heatmap"
+version = "0.0.0"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
+dependencies = [
+ "histogram",
+ "rustcommon-time",
+ "thiserror",
+]
 
 [[package]]
 name = "heck"
@@ -905,14 +915,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "histogram"
+version = "0.0.0"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.3",
 ]
 
 [[package]]
@@ -921,16 +939,16 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "http",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -944,7 +962,7 @@ version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -953,7 +971,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -975,12 +993,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.3"
+name = "iana-time-zone"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
- "matches",
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1015,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1030,15 +1060,15 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1094,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -1110,18 +1140,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.2.10"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd4ad156b9934dc21cad96fd17278a7cb6f30a5657a9d976cd7b71d6d49c02c"
+checksum = "f1fcc556441a74961e26e894f9837dc5d2eb6e8f6bc8ec3bbe7ac445ddcf732e"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.2.10"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fd9dc7072de7168cbdaba9125e8f742cd3a965aa12bde994b4611a174488d8"
+checksum = "8ea60989e1675e85b206a8e44835d06727f5794e095a7229c81f70078c63fea9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1130,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1149,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "common",
  "config",
@@ -1167,18 +1197,12 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -1191,15 +1215,6 @@ name = "memmap2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5172b50c23043ff43dd53e51392f36519d9b35a8f3a410d30ece5d1aedd58ae"
 dependencies = [
  "libc",
 ]
@@ -1227,9 +1242,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
@@ -1311,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "momento_proxy"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -1324,7 +1339,7 @@ dependencies = [
  "protocol-admin",
  "protocol-memcache",
  "protocol-resp",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "session",
  "storage-types",
  "tokio",
@@ -1344,14 +1359,14 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "net"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "boring",
  "boring-sys",
  "foreign-types-shared",
  "libc",
  "mio 0.8.4",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
@@ -1446,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -1508,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
@@ -1524,18 +1539,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1556,7 +1571,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingproxy"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -1565,30 +1580,30 @@ dependencies = [
  "logger",
  "protocol-ping",
  "proxy",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
 name = "pingserver"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
  "common",
  "config",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "entrystore",
  "logger",
  "protocol-ping",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "server",
 ]
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1599,15 +1614,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -1620,19 +1635,20 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1643,7 +1659,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost-derive",
 ]
 
@@ -1653,7 +1669,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "heck",
  "itertools",
  "lazy_static",
@@ -1686,83 +1702,83 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "prost",
 ]
 
 [[package]]
 name = "protocol-admin"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
  "common",
  "config",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "logger",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "storage-types",
 ]
 
 [[package]]
 name = "protocol-common"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "common",
  "config",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "logger",
  "storage-types",
 ]
 
 [[package]]
 name = "protocol-memcache"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "common",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "logger",
  "nom 5.1.2",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
 name = "protocol-ping"
-version = "0.0.2"
+version = "0.3.0"
 dependencies = [
  "common",
  "config",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "logger",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "storage-types",
 ]
 
 [[package]]
 name = "protocol-resp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "common",
  "nom 5.1.2",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
 name = "protocol-thrift"
-version = "0.0.2"
+version = "0.3.0"
 dependencies = [
  "common",
  "logger",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
 name = "proxy"
-version = "0.0.2"
+version = "0.3.0"
 dependencies = [
  "admin",
  "common",
@@ -1774,7 +1790,7 @@ dependencies = [
  "protocol-admin",
  "protocol-common",
  "queues",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "session",
  "slab",
  "waker",
@@ -1793,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1829,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -1871,18 +1887,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1897,9 +1913,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1938,125 +1954,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustcommon-atomics"
-version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustcommon-atomics"
-version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustcommon-heatmap"
-version = "0.1.2"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
-dependencies = [
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-histogram 1.0.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "thiserror",
-]
-
-[[package]]
-name = "rustcommon-heatmap"
-version = "0.1.2"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
-dependencies = [
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-histogram 1.0.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon)",
- "thiserror",
-]
-
-[[package]]
-name = "rustcommon-histogram"
-version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
-dependencies = [
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "thiserror",
-]
-
-[[package]]
-name = "rustcommon-histogram"
-version = "1.0.1"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
-dependencies = [
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon)",
- "thiserror",
-]
-
-[[package]]
 name = "rustcommon-logger"
-version = "0.1.0"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
+version = "0.1.1"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
 dependencies = [
  "ahash",
  "log",
  "mpmc",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
+ "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-metrics"
-version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
+version = "0.1.2"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
 dependencies = [
+ "heatmap",
  "linkme",
  "once_cell",
  "parking_lot",
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-heatmap 0.1.2 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-metrics-derive 0.1.1 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon?rev=fc9c565)",
-]
-
-[[package]]
-name = "rustcommon-metrics"
-version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
-dependencies = [
- "linkme",
- "once_cell",
- "parking_lot",
- "rustcommon-atomics 1.0.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-heatmap 0.1.2 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-metrics-derive 0.1.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics-derive",
+ "rustcommon-time",
 ]
 
 [[package]]
 name = "rustcommon-metrics-derive"
 version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "rustcommon-metrics-derive"
-version = "0.1.1"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2066,25 +1991,13 @@ dependencies = [
 
 [[package]]
 name = "rustcommon-time"
-version = "0.0.12"
-source = "git+https://github.com/twitter/rustcommon?rev=fc9c565#fc9c565288ac50b9e2df68cbbc40b00f5114a707"
+version = "0.0.13"
+source = "git+https://github.com/twitter/rustcommon?rev=87e0c87#87e0c87cc8ad42466ec0eeba0fee8742325e52c0"
 dependencies = [
  "lazy_static",
  "libc",
  "mach",
- "time 0.3.9",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rustcommon-time"
-version = "0.0.12"
-source = "git+https://github.com/twitter/rustcommon#eb44fc27260fbd64fa41b8744f1831be7d1db945"
-dependencies = [
- "lazy_static",
- "libc",
- "mach",
- "time 0.3.9",
+ "time 0.3.14",
  "winapi 0.3.9",
 ]
 
@@ -2115,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -2156,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2179,49 +2092,43 @@ dependencies = [
 
 [[package]]
 name = "seg"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "common",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "datapool",
  "logger",
- "memmap2 0.2.3",
+ "memmap2",
  "rand",
  "rand_chacha",
  "rand_xoshiro",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "storage-types",
  "thiserror",
 ]
 
 [[package]]
 name = "segcache"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
  "common",
  "config",
- "criterion 0.3.5",
+ "criterion 0.3.6",
  "entrystore",
  "logger",
  "protocol-memcache",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "server",
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
-
-[[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -2238,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2249,18 +2156,18 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "admin",
  "common",
@@ -2272,7 +2179,7 @@ dependencies = [
  "protocol-admin",
  "protocol-common",
  "queues",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
  "session",
  "slab",
  "waker",
@@ -2280,14 +2187,14 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "log",
  "net",
  "protocol-common",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
- "rustcommon-time 0.0.12 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
+ "rustcommon-time",
 ]
 
 [[package]]
@@ -2314,20 +2221,23 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.14",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "snowflake"
@@ -2337,9 +2247,9 @@ checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2359,7 +2269,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-types"
-version = "0.1.0"
+version = "0.3.0"
 
 [[package]]
 name = "strsim"
@@ -2375,9 +2285,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2421,18 +2331,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2441,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "thriftproxy"
-version = "0.0.1"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "clap 2.34.0",
@@ -2450,7 +2360,7 @@ dependencies = [
  "logger",
  "protocol-thrift",
  "proxy",
- "rustcommon-metrics 0.1.1 (git+https://github.com/twitter/rustcommon)",
+ "rustcommon-metrics",
 ]
 
 [[package]]
@@ -2466,11 +2376,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "libc",
  "num_threads",
  "time-macros",
@@ -2491,7 +2401,7 @@ dependencies = [
  "ascii",
  "chunked_transfer",
  "log",
- "time 0.3.9",
+ "time 0.3.14",
  "url",
 ]
 
@@ -2522,17 +2432,16 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2575,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2590,7 +2499,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "log",
@@ -2600,11 +2509,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2630,7 +2539,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-util",
  "h2",
@@ -2681,7 +2590,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util 0.7.4",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2701,9 +2610,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -2725,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]
@@ -2772,30 +2681,30 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -2805,9 +2714,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2828,7 +2737,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "libc",
  "mio 0.8.4",
@@ -2869,9 +2778,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2879,13 +2788,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2894,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2904,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2917,15 +2826,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2952,13 +2861,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[workspace.package]
+version = "0.3.0"
+edition = "2021"
+homepage = "https://pelikan.io"
+repository = "https://github.com/twitter/pelikan"
+license = "Apache-2.0"
+
 [workspace]
 members = [
     "src/common",
@@ -28,6 +35,42 @@ members = [
     "src/storage/seg",
     "src/storage/types",
 ]
+
+[workspace.dependencies]
+ahash = "0.8.0"
+backtrace = "0.3.66"
+bitvec = "1.0.1"
+blake3 = "1.3.1"
+boring = "2.1.0"
+boring-sys = "2.1.0"
+bytes = "1.2.1"
+clap = "2.33.3"
+crossbeam-channel = "0.5.6"
+crossbeam-queue = "0.3.5"
+foreign-types-shared = "0.3.1"
+libc = "0.2.134"
+log = "0.4.17"
+memmap2 = "0.2.2"
+metrohash = "1.0.6"
+mio = "0.8.4"
+nom = "5.1.2"
+proc-macro2 = "1.0.46"
+quote = "1.0.21"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+rand_xoshiro = "0.6.0"
+rustcommon-logger = { git = "https://github.com/twitter/rustcommon", rev = "87e0c87" }
+rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", rev = "87e0c87" }
+rustcommon-time = { git = "https://github.com/twitter/rustcommon", rev = "87e0c87" }
+serde = "1.0.145"
+serde_json = "1.0.85"
+slab = "0.4.7"
+syn = "1.0.101"
+thiserror = "1.0.24"
+tiny_http = "0.11.0"
+toml = "0.5.9"
+twox-hash = { version = "1.6.3", default-features = false }
+zookeeper = "0.6.1"
 
 [profile.release]
 opt-level = 3

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,28 +1,19 @@
 [package]
 name = "common"
-version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "common types, traits, and helper functions for Pelikan servers"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-boring = "2.0.0"
-serde = { version = "1.0.117", features = ["derive"] }
+boring.workspace = true
+serde = { workspace = true, features = ["derive"] }
 net = { path = "../net" }
 macros = { path = "../macros" }
-
-[dependencies.rustcommon-metrics]
-git = "https://github.com/twitter/rustcommon"
-features = ["heatmap"]
-rev = "fc9c565"
-
-[dependencies.rustcommon-logger]
-git = "https://github.com/twitter/rustcommon"
-
-[dependencies.rustcommon-time]
-git = "https://github.com/twitter/rustcommon"
+rustcommon-metrics.workspace = true
+rustcommon-logger.workspace = true
+rustcommon-time.workspace = true

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -14,6 +14,6 @@ boring.workspace = true
 serde = { workspace = true, features = ["derive"] }
 net = { path = "../net" }
 macros = { path = "../macros" }
-rustcommon-metrics.workspace = true
-rustcommon-logger.workspace = true
-rustcommon-time.workspace = true
+rustcommon-metrics = { workspace = true }
+rustcommon-logger = { workspace = true }
+rustcommon-time = { workspace = true }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -3,14 +3,14 @@ name = "common"
 description = "common types, traits, and helper functions for Pelikan servers"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-boring.workspace = true
+boring = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 net = { path = "../net" }
 macros = { path = "../macros" }

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "config"
-version = "0.1.1"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "component configurations for Pelikan"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 common = { path = "../common" }
-log = "0.4.11"
-serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0.79"
-toml = "0.5.7"
-zookeeper = "0.6.1"
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
+zookeeper.workspace = true

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -9,12 +9,10 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 common = { path = "../common" }
-log.workspace = true
+log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
-toml.workspace = true
-zookeeper.workspace = true
+serde_json = { workspace = true }
+toml = { workspace = true }
+zookeeper = { workspace = true }

--- a/src/config/Cargo.toml
+++ b/src/config/Cargo.toml
@@ -3,11 +3,11 @@ name = "config"
 description = "component configurations for Pelikan"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../common" }

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -1,27 +1,26 @@
 [package]
 name = "admin"
-version = "0.1.0"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel = "0.5.0"
+crossbeam-channel.workspace = true
 entrystore = { path = "../../entrystore" }
-libc = "0.2.132"
+libc.workspace = true
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 session = { path = "../../session" }
-slab = "0.4.2"
-tiny_http = "0.11.0"
+slab.workspace = true
+tiny_http.workspace = true
 waker = { path = "../waker" }

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -11,16 +11,16 @@ license.workspace = true
 [dependencies]
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel.workspace = true
+crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
-libc.workspace = true
+libc = { workspace = true }
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 session = { path = "../../session" }
-slab.workspace = true
-tiny_http.workspace = true
+slab = { workspace = true }
+tiny_http = { workspace = true }
 waker = { path = "../waker" }

--- a/src/core/admin/Cargo.toml
+++ b/src/core/admin/Cargo.toml
@@ -2,11 +2,11 @@
 name = "admin"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../../common" }

--- a/src/core/admin/src/lib.rs
+++ b/src/core/admin/src/lib.rs
@@ -474,7 +474,7 @@ impl Admin {
                 data.push(format!("{}: {}", metric.name(), gauge.value()));
             } else if let Some(heatmap) = any.downcast_ref::<Heatmap>() {
                 for (label, value) in PERCENTILES {
-                    let percentile = heatmap.percentile(*value).unwrap_or(0);
+                    let percentile = heatmap.percentile(*value).map(|b| b.high()).unwrap_or(0);
                     data.push(format!("{}_{}: {}", metric.name(), label, percentile));
                 }
             }
@@ -512,7 +512,7 @@ impl Admin {
                 data.push(format!("\"{}\": {}", metric.name(), gauge.value()));
             } else if let Some(heatmap) = any.downcast_ref::<Heatmap>() {
                 for (label, value) in PERCENTILES {
-                    let percentile = heatmap.percentile(*value).unwrap_or(0);
+                    let percentile = heatmap.percentile(*value).map(|b| b.high()).unwrap_or(0);
                     data.push(format!("\"{}_{}\": {}", metric.name(), label, percentile));
                 }
             }
@@ -583,7 +583,7 @@ impl Admin {
                 ));
             } else if let Some(heatmap) = any.downcast_ref::<Heatmap>() {
                 for (label, value) in PERCENTILES {
-                    let percentile = heatmap.percentile(*value).unwrap_or(0);
+                    let percentile = heatmap.percentile(*value).map(|b| b.high()).unwrap_or(0);
                     data.push(format!(
                         "# TYPE {} gauge\n{}{{percentile=\"{}\"}} {}",
                         metric.name(),

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name = "proxy"
-version = "0.0.2"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 admin = { path = "../admin" }
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel = "0.5.0"
+crossbeam-channel.workspace = true
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 session = { path = "../../session" }
-slab = "0.4.2"
+slab.workspace = true
 waker = { path = "../waker" }

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -12,14 +12,14 @@ license.workspace = true
 admin = { path = "../admin" }
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel.workspace = true
+crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 session = { path = "../../session" }
-slab.workspace = true
+slab = { workspace = true }
 waker = { path = "../waker" }

--- a/src/core/proxy/Cargo.toml
+++ b/src/core/proxy/Cargo.toml
@@ -2,11 +2,11 @@
 name = "proxy"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 admin = { path = "../admin" }

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -3,11 +3,11 @@ name = "server"
 description = "core server event loops and threads for Pelikan servers"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 admin = { path = "../admin" }

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -13,14 +13,14 @@ license.workspace = true
 admin = { path = "../admin" }
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel.workspace = true
+crossbeam-channel = { workspace = true }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 session = { path = "../../session" }
-slab.workspace = true
+slab = { workspace = true }
 waker = { path = "../waker" }

--- a/src/core/server/Cargo.toml
+++ b/src/core/server/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "server"
-version = "0.2.0"
-edition = "2021"
-authors = ["Brian Martin <bmartin@twitter.com>"]
 description = "core server event loops and threads for Pelikan servers"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 admin = { path = "../admin" }
 common = { path = "../../common" }
 config = { path = "../../config" }
-crossbeam-channel = "0.5.0"
+crossbeam-channel.workspace = true
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-common = { path = "../../protocol/common" }
 queues = { path = "../../queues" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 session = { path = "../../session" }
-slab = "0.4.2"
+slab.workspace = true
 waker = { path = "../waker" }

--- a/src/core/waker/Cargo.toml
+++ b/src/core/waker/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-mio.workspace = true
+mio = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc.workspace = true
+libc = { workspace = true }

--- a/src/core/waker/Cargo.toml
+++ b/src/core/waker/Cargo.toml
@@ -2,11 +2,11 @@
 name = "waker"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 mio = { workspace = true }

--- a/src/core/waker/Cargo.toml
+++ b/src/core/waker/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "waker"
-version = "0.1.0"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-mio = "0.8.4"
+mio.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2.126"
+libc.workspace = true

--- a/src/entrystore/Cargo.toml
+++ b/src/entrystore/Cargo.toml
@@ -3,11 +3,11 @@ name = "entrystore"
 description = "a collection of entry storage types for use in Pelikan servers"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [features]
 debug = ["seg/debug"]

--- a/src/entrystore/Cargo.toml
+++ b/src/entrystore/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "entrystore"
-version = "0.0.1"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "a collection of entry storage types for use in Pelikan servers"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [features]
 debug = ["seg/debug"]

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -10,4 +10,4 @@ license.workspace = true
 [dependencies]
 common = { path = "../common" }
 config = { path = "../config" }
-rustcommon-logger.workspace = true
+rustcommon-logger = { workspace = true }

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "logger"
-version = "0.1.0"
-edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 common = { path = "../common" }
 config = { path = "../config" }
-rustcommon-logger = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-logger.workspace = true

--- a/src/logger/Cargo.toml
+++ b/src/logger/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "logger"
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../common" }

--- a/src/macros/Cargo.toml
+++ b/src/macros/Cargo.toml
@@ -3,11 +3,11 @@ name = "macros"
 description = "Utility macros for use within pelikan"
 authors = ["Sean Lynch <seanl@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/src/macros/Cargo.toml
+++ b/src/macros/Cargo.toml
@@ -13,6 +13,6 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-quote.workspace = true
-syn.workspace = true
-proc-macro2.workspace = true
+quote = { workspace = true }
+syn = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/src/macros/Cargo.toml
+++ b/src/macros/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "macros"
-version = "0.1.0"
-authors = ["Sean Lynch <seanl@twitter.com>"]
-edition = "2018"
-license = "Apache-2.0"
 description = "Utility macros for use within pelikan"
+authors = ["Sean Lynch <seanl@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-quote = "1.0.9"
-syn = "1.0.0"
-proc-macro2 = "1.0.0"
+quote.workspace = true
+syn.workspace = true
+proc-macro2.workspace = true

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -3,11 +3,11 @@ name = "net"
 description = "Networking abstractions for non-blocking event loops"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 boring = { workspace = true }

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-boring.workspace = true
-boring-sys.workspace = true
-foreign-types-shared.workspace = true
-libc.workspace = true
+boring = { workspace = true }
+boring-sys = { workspace = true }
+foreign-types-shared = { workspace = true }
+libc = { workspace = true }
 mio = { workspace = true, features = ["os-poll", "net"] }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }

--- a/src/net/Cargo.toml
+++ b/src/net/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "net"
-version = "0.1.0"
-edition = "2021"
-authors = ["Brian Martin <bmartin@twitter.com>"]
 description = "Networking abstractions for non-blocking event loops"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
 
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-boring = "2.0.0"
-boring-sys = "2.0.0"
-foreign-types-shared = "0.3.1"
-libc = "0.2"
-mio = { version = "0.8.0", features = ["os-poll", "net"] }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+boring.workspace = true
+boring-sys.workspace = true
+foreign-types-shared.workspace = true
+libc.workspace = true
+mio = { workspace = true, features = ["os-poll", "net"] }
+rustcommon-metrics.workspace = true

--- a/src/protocol/admin/Cargo.toml
+++ b/src/protocol/admin/Cargo.toml
@@ -14,7 +14,7 @@ common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 storage-types = { path = "../../storage/types" }
 
 [dev-dependencies]

--- a/src/protocol/admin/Cargo.toml
+++ b/src/protocol/admin/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "protocol-admin"
-version = "0.0.1"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "Admin ASCII protocol used in Pelikan servers"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", features = ["heatmap"] }
+rustcommon-metrics.workspace = true
 storage-types = { path = "../../storage/types" }
 
 [dev-dependencies]

--- a/src/protocol/admin/Cargo.toml
+++ b/src/protocol/admin/Cargo.toml
@@ -3,11 +3,11 @@ name = "protocol-admin"
 description = "Admin ASCII protocol used in Pelikan servers"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../../common" }

--- a/src/protocol/admin/src/admin.rs
+++ b/src/protocol/admin/src/admin.rs
@@ -137,7 +137,8 @@ impl Compose for AdminResponse {
                         data.push(format!("STAT {} {}\r\n", metric.name(), gauge.value()));
                     } else if let Some(heatmap) = any.downcast_ref::<Heatmap>() {
                         for (label, value) in PERCENTILES {
-                            let percentile = heatmap.percentile(*value).unwrap_or(0);
+                            let percentile =
+                                heatmap.percentile(*value).map(|b| b.high()).unwrap_or(0);
                             data.push(format!(
                                 "STAT {}_{} {}\r\n",
                                 metric.name(),

--- a/src/protocol/common/Cargo.toml
+++ b/src/protocol/common/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-bytes.workspace = true
+bytes = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }

--- a/src/protocol/common/Cargo.toml
+++ b/src/protocol/common/Cargo.toml
@@ -3,11 +3,11 @@ name = "protocol-common"
 description = "Traits and shared code for Pelikan protocols"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/src/protocol/common/Cargo.toml
+++ b/src/protocol/common/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "protocol-common"
-version = "0.0.1"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "Traits and shared code for Pelikan protocols"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-bytes = "1.1.0"
+bytes.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }

--- a/src/protocol/common/src/lib.rs
+++ b/src/protocol/common/src/lib.rs
@@ -25,7 +25,7 @@ pub trait Execute<Request, Response: Compose> {
     fn execute(&mut self, request: &Request) -> Response;
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseOk<T> {
     message: T,
     consumed: usize,

--- a/src/protocol/memcache/Cargo.toml
+++ b/src/protocol/memcache/Cargo.toml
@@ -15,9 +15,9 @@ harness = false
 [dependencies]
 common = { path = "../../common" }
 logger = { path = "../../logger" }
-nom.workspace = true
+nom = { workspace = true }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/protocol/memcache/Cargo.toml
+++ b/src/protocol/memcache/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "protocol-memcache"
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [[bench]]
 name = "request-parsing"

--- a/src/protocol/memcache/Cargo.toml
+++ b/src/protocol/memcache/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "protocol-memcache"
-version = "0.2.0"
-edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [[bench]]
 name = "request-parsing"
@@ -13,9 +15,9 @@ harness = false
 [dependencies]
 common = { path = "../../common" }
 logger = { path = "../../logger" }
-nom = "5.1.2"
+nom.workspace = true
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", features = ["heatmap"] }
+rustcommon-metrics.workspace = true
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/protocol/ping/Cargo.toml
+++ b/src/protocol/ping/Cargo.toml
@@ -2,11 +2,11 @@
 name = "protocol-ping"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [[bench]]
 name = "ping"

--- a/src/protocol/ping/Cargo.toml
+++ b/src/protocol/ping/Cargo.toml
@@ -18,7 +18,7 @@ common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 storage-types = { path = "../../storage/types" }
 
 [dev-dependencies]

--- a/src/protocol/ping/Cargo.toml
+++ b/src/protocol/ping/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "protocol-ping"
-version = "0.0.2"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [[bench]]
 name = "ping"
@@ -17,7 +18,7 @@ common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 storage-types = { path = "../../storage/types" }
 
 [dev-dependencies]

--- a/src/protocol/resp/Cargo.toml
+++ b/src/protocol/resp/Cargo.toml
@@ -2,11 +2,11 @@
 name = "protocol-resp"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../../common" }

--- a/src/protocol/resp/Cargo.toml
+++ b/src/protocol/resp/Cargo.toml
@@ -10,6 +10,6 @@ license.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
-nom.workspace = true
+nom = { workspace = true }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }

--- a/src/protocol/resp/Cargo.toml
+++ b/src/protocol/resp/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "protocol-resp"
-version = "0.2.0"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
-nom = "5.1.2"
+nom.workspace = true
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true

--- a/src/protocol/thrift/Cargo.toml
+++ b/src/protocol/thrift/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "protocol-thrift"
-version = "0.0.2"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true

--- a/src/protocol/thrift/Cargo.toml
+++ b/src/protocol/thrift/Cargo.toml
@@ -2,11 +2,11 @@
 name = "protocol-thrift"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 common = { path = "../../common" }

--- a/src/protocol/thrift/Cargo.toml
+++ b/src/protocol/thrift/Cargo.toml
@@ -12,4 +12,4 @@ license.workspace = true
 common = { path = "../../common" }
 logger = { path = "../../logger" }
 protocol-common = { path = "../../protocol/common" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -3,11 +3,11 @@ name = "momento_proxy"
 description = "a proxy to access Momento cache(s) over memcache protocol"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 backtrace = { workspace = true }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -10,18 +10,18 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-backtrace.workspace = true
-clap.workspace = true
+backtrace = { workspace = true }
+clap = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
-libc.workspace = true
+libc = { workspace = true }
 logger = { path = "../../logger" }
 momento = "0.3.1"
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }
 protocol-resp = { path = "../../protocol/resp" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 session = { path = "../../session" }
 storage-types = { path = "../../storage/types" }
 tokio = { version = "1.17.0", features = ["full"] }

--- a/src/proxy/momento/Cargo.toml
+++ b/src/proxy/momento/Cargo.toml
@@ -1,26 +1,27 @@
 [package]
 name = "momento_proxy"
-authors = ["Brian Martin <brayniac@gmail.com>"]
-version = "0.1.0"
-edition = "2021"
 description = "a proxy to access Momento cache(s) over memcache protocol"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <brayniac@gmail.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-backtrace = "0.3.56"
-clap = "2.33.3"
+backtrace.workspace = true
+clap.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
-libc = "0.2.83"
+libc.workspace = true
 logger = { path = "../../logger" }
 momento = "0.3.1"
 net = { path = "../../net" }
 protocol-admin = { path = "../../protocol/admin" }
 protocol-memcache = { path = "../../protocol/memcache" }
 protocol-resp = { path = "../../protocol/resp" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 session = { path = "../../session" }
 storage-types = { path = "../../storage/types" }
 tokio = { version = "1.17.0", features = ["full"] }

--- a/src/proxy/momento/src/admin.rs
+++ b/src/proxy/momento/src/admin.rs
@@ -153,7 +153,7 @@ async fn stats_response(socket: &mut tokio::net::TcpStream) -> Result<(), Error>
             data.push(format!("STAT {} {}\r\n", metric.name(), gauge.value()));
         } else if let Some(heatmap) = any.downcast_ref::<Heatmap>() {
             for (label, value) in PERCENTILES {
-                let percentile = heatmap.percentile(*value).unwrap_or(0);
+                let percentile = heatmap.percentile(*value).map(|b| b.high()).unwrap_or(0);
                 data.push(format!(
                     "STAT {}_{} {}\r\n",
                     metric.name(),

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "pingproxy"
-version = "0.0.1"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 name = "pingproxy"
@@ -20,11 +19,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-backtrace = "0.3.56"
-clap = "2.33.3"
+backtrace.workspace = true
+clap.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 proxy = { path = "../../core/proxy" }
 protocol-ping = { path = "../../protocol/ping", features = ["client", "server"] }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -2,11 +2,11 @@
 name = "pingproxy"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 name = "pingproxy"

--- a/src/proxy/ping/Cargo.toml
+++ b/src/proxy/ping/Cargo.toml
@@ -19,11 +19,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-backtrace.workspace = true
-clap.workspace = true
+backtrace = { workspace = true }
+clap = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 proxy = { path = "../../core/proxy" }
 protocol-ping = { path = "../../protocol/ping", features = ["client", "server"] }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }

--- a/src/proxy/thrift/Cargo.toml
+++ b/src/proxy/thrift/Cargo.toml
@@ -2,11 +2,11 @@
 name = "thriftproxy"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 name = "thriftproxy"

--- a/src/proxy/thrift/Cargo.toml
+++ b/src/proxy/thrift/Cargo.toml
@@ -19,11 +19,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-backtrace.workspace = true
-clap.workspace = true
+backtrace = { workspace = true }
+clap = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 proxy = { path = "../../core/proxy" }
 protocol-thrift = { path = "../../protocol/thrift" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }

--- a/src/proxy/thrift/Cargo.toml
+++ b/src/proxy/thrift/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "thriftproxy"
-version = "0.0.1"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 name = "thriftproxy"
@@ -20,11 +19,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-backtrace = "0.3.56"
-clap = "2.33.3"
+backtrace.workspace = true
+clap.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
 logger = { path = "../../logger" }
 proxy = { path = "../../core/proxy" }
 protocol-thrift = { path = "../../protocol/thrift" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true

--- a/src/queues/Cargo.toml
+++ b/src/queues/Cargo.toml
@@ -3,11 +3,11 @@ name = "queues"
 description = "queue types for inter-process communication"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 crossbeam-queue = { workspace = true }

--- a/src/queues/Cargo.toml
+++ b/src/queues/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-crossbeam-queue.workspace = true
-rand.workspace = true
-rand_chacha.workspace = true
+crossbeam-queue = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 waker = { path = "../core/waker" }
 
 [dev-dependencies]

--- a/src/queues/Cargo.toml
+++ b/src/queues/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "queues"
-version = "0.3.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "queue types for inter-process communication"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-crossbeam-queue = "0.3.5"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
+crossbeam-queue.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
 waker = { path = "../core/waker" }
 
 [dev-dependencies]

--- a/src/server/pingserver/Cargo.toml
+++ b/src/server/pingserver/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pingserver"
-version = "0.2.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "a simple ascii ping/pong server"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 name = "pelikan_pingserver_rs"
@@ -29,14 +30,14 @@ path = "benches/benchmark.rs"
 harness = false
 
 [dependencies]
-backtrace = "0.3.56"
-clap = "2.33.3"
+backtrace.workspace = true
+clap.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 protocol-ping = { path = "../../protocol/ping", features = ["server"] }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/server/pingserver/Cargo.toml
+++ b/src/server/pingserver/Cargo.toml
@@ -3,11 +3,11 @@ name = "pingserver"
 description = "a simple ascii ping/pong server"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 name = "pelikan_pingserver_rs"

--- a/src/server/pingserver/Cargo.toml
+++ b/src/server/pingserver/Cargo.toml
@@ -30,14 +30,14 @@ path = "benches/benchmark.rs"
 harness = false
 
 [dependencies]
-backtrace.workspace = true
-clap.workspace = true
+backtrace = { workspace = true }
+clap = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 protocol-ping = { path = "../../protocol/ping", features = ["server"] }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/server/segcache/Cargo.toml
+++ b/src/server/segcache/Cargo.toml
@@ -3,11 +3,11 @@ name = "segcache"
 description = "a Memcache protocol server with segment-structured storage"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 name = "pelikan_segcache_rs"

--- a/src/server/segcache/Cargo.toml
+++ b/src/server/segcache/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "segcache"
-version = "0.2.0"
-edition = "2021"
-authors = ["Brian Martin <bmartin@twitter.com>"]
 description = "a Memcache protocol server with segment-structured storage"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 name = "pelikan_segcache_rs"
@@ -37,14 +38,14 @@ harness = false
 debug = ["entrystore/debug"]
 
 [dependencies]
-backtrace = "0.3.56"
-clap = "2.33.3"
+backtrace.workspace = true
+clap.workspace = true
 common = { path = "../../common" }
 config = { path = "../../config" }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 protocol-memcache = { path = "../../protocol/memcache" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/server/segcache/Cargo.toml
+++ b/src/server/segcache/Cargo.toml
@@ -38,14 +38,14 @@ harness = false
 debug = ["entrystore/debug"]
 
 [dependencies]
-backtrace.workspace = true
-clap.workspace = true
+backtrace = { workspace = true }
+clap = { workspace = true }
 common = { path = "../../common" }
 config = { path = "../../config" }
 entrystore = { path = "../../entrystore" }
 logger = { path = "../../logger" }
 protocol-memcache = { path = "../../protocol/memcache" }
-rustcommon-metrics.workspace = true
+rustcommon-metrics = { workspace = true }
 server = { path = "../../core/server" }
 
 [dev-dependencies]

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -2,11 +2,11 @@
 name = "session"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-bytes.workspace = true
-log.workspace = true
+bytes = { workspace = true }
+log = { workspace = true }
 net = { path = "../net" }
 protocol-common = { path = "../protocol/common" }
-rustcommon-metrics.workspace = true
-rustcommon-time.workspace = true
+rustcommon-metrics = { workspace = true }
+rustcommon-time = { workspace = true }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
 name = "session"
-version = "0.1.0"
-edition = "2021"
 authors = ["Brian Martin <bmartin@twitter.com>"]
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-# buffer = { path = "../buffer" }
-bytes = "1.1.0"
-log = "0.4.17"
+bytes.workspace = true
+log.workspace = true
 net = { path = "../net" }
 protocol-common = { path = "../protocol/common" }
-rustcommon-metrics = { git = "https://github.com/twitter/rustcommon", features = ["heatmap"] }
-rustcommon-time = { git = "https://github.com/twitter/rustcommon" }
+rustcommon-metrics.workspace = true
+rustcommon-time.workspace = true

--- a/src/storage/bloom/Cargo.toml
+++ b/src/storage/bloom/Cargo.toml
@@ -11,8 +11,8 @@ license.workspace = true
 default = ["rand"]
 
 [dependencies]
-bitvec.workspace = true
-metrohash.workspace = true
+bitvec = { workspace = true }
+metrohash = { workspace = true }
 twox-hash = { workspace = true, default-features = false }
 rand = { workspace = true, optional = true }
 

--- a/src/storage/bloom/Cargo.toml
+++ b/src/storage/bloom/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bloom"
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [features]
 default = ["rand"]

--- a/src/storage/bloom/Cargo.toml
+++ b/src/storage/bloom/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 name = "bloom"
-version = "0.1.0"
-edition = "2021"
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [features]
 default = ["rand"]
 
 [dependencies]
-bitvec = "1.0.1"
-metrohash = "1.0.6"
-twox-hash = { version = "1.6.3", default-features = false }
-
-rand = { version = "0.8.5", optional = true }
+bitvec.workspace = true
+metrohash.workspace = true
+twox-hash = { workspace = true, default-features = false }
+rand = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/storage/datapool/Cargo.toml
+++ b/src/storage/datapool/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "datapool"
-version = "0.1.0"
-edition = "2021"
-authors = ["Brian Martin <bmartin@twitter.com>"]
 description = "abstractions for byte storage pools"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
-blake3 = "1.3.1"
+blake3.workspace = true
 common = { path = "../../common" }
-libc = "0.2.125"
-memmap2 = "0.5.3"
+libc.workspace = true
+memmap2.workspace = true
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/storage/datapool/Cargo.toml
+++ b/src/storage/datapool/Cargo.toml
@@ -3,11 +3,11 @@ name = "datapool"
 description = "abstractions for byte storage pools"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 blake3 = { workspace = true }

--- a/src/storage/datapool/Cargo.toml
+++ b/src/storage/datapool/Cargo.toml
@@ -10,10 +10,10 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-blake3.workspace = true
+blake3 = { workspace = true }
 common = { path = "../../common" }
-libc.workspace = true
-memmap2.workspace = true
+libc = { workspace = true }
+memmap2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/storage/seg/Cargo.toml
+++ b/src/storage/seg/Cargo.toml
@@ -3,11 +3,11 @@ name = "seg"
 description = "segment-structured in-memory storage with eager expiration"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [[bench]]
 name = "benchmark"

--- a/src/storage/seg/Cargo.toml
+++ b/src/storage/seg/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "seg"
-version = "0.1.0"
-authors = ["Brian Martin <bmartin@twitter.com>"]
-edition = "2018"
 description = "segment-structured in-memory storage with eager expiration"
-homepage = "https://pelikan.io"
-repository = "https://github.com/twitter/pelikan"
-license = "Apache-2.0"
+authors = ["Brian Martin <bmartin@twitter.com>"]
+
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [[bench]]
 name = "benchmark"
@@ -25,20 +26,17 @@ debug = ["magic"]
 default = []
 
 [dependencies]
-ahash = "0.7.2"
+ahash.workspace = true
 common = { path = "../../common" }
 datapool = { path = "../datapool" }
 logger = { path = "../../logger" }
-memmap2 = "0.2.2"
-rand = { version = "0.8.3", features = ["small_rng", "getrandom"] }
-rand_chacha = { version = "0.3.0" }
-rand_xoshiro = { version = "0.6.0" }
+memmap2.workspace = true
+rand = { workspace = true , features = ["small_rng", "getrandom"] }
+rand_chacha.workspace = true
+rand_xoshiro.workspace = true
+rustcommon-metrics.workspace = true
 storage-types = { path = "../types" }
-thiserror = "1.0.24"
-
-[dependencies.rustcommon-metrics]
-git = "https://github.com/twitter/rustcommon"
-features = ["heatmap"]
+thiserror.workspace = true
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/storage/seg/Cargo.toml
+++ b/src/storage/seg/Cargo.toml
@@ -26,17 +26,17 @@ debug = ["magic"]
 default = []
 
 [dependencies]
-ahash.workspace = true
+ahash = { workspace = true }
 common = { path = "../../common" }
 datapool = { path = "../datapool" }
 logger = { path = "../../logger" }
-memmap2.workspace = true
+memmap2 = { workspace = true }
 rand = { workspace = true , features = ["small_rng", "getrandom"] }
-rand_chacha.workspace = true
-rand_xoshiro.workspace = true
-rustcommon-metrics.workspace = true
+rand_chacha = { workspace = true }
+rand_xoshiro = { workspace = true }
+rustcommon-metrics = { workspace = true }
 storage-types = { path = "../types" }
-thiserror.workspace = true
+thiserror = { workspace = true }
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/src/storage/types/Cargo.toml
+++ b/src/storage/types/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "storage-types"
-version = "0.1.0"
-edition = "2018"
+authors = ["Brian Martin <bmartin@twitter.com>"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [dependencies]

--- a/src/storage/types/Cargo.toml
+++ b/src/storage/types/Cargo.toml
@@ -2,10 +2,10 @@
 name = "storage-types"
 authors = ["Brian Martin <bmartin@twitter.com>"]
 
-version.workspace = true
-edition.workspace = true
-homepage.workspace = true
-repository.workspace = true
-license.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]

--- a/src/storage/types/src/lib.rs
+++ b/src/storage/types/src/lib.rs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum Value<'a> {
     Bytes(&'a [u8]),
     U64(u64),
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum OwnedValue {
     Bytes(Box<[u8]>),
     U64(u64),


### PR DESCRIPTION
Two major things in this PR. First is the changes to the workspace config to make use of the new dependencies and metadata table. This change allows us to centralize the dependency versions, which makes updating dependencies much easier. Additionally, we move several metadata fields (license, edition, etc) and the version number to be declared at the workspace level. This means that all crates within Pelikan now share the same version number. The intent is to make it easier to produce changelogs and cut releases.

The second major thing in this PR is updating the dependencies, particularly bumping rustcommon up to the latest version which should bring some performance wins with metrics overhead being reduced in the latest version.