### PR TITLE
Momento proxy fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY . .
 RUN apt-get update
 RUN apt-get install -y cmake
 RUN apt-get install -y clang
-RUN mkdir .cargo
 RUN cargo vendor > .cargo/config
 
 RUN cargo build --release

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This software is licensed under the Apache 2.0 license, see [LICENSE](LICENSE) f
 [check-linker-bug]: (https://sourceforge.net/p/check/mailman/message/32835594/)
 [license-badge]: https://img.shields.io/badge/license-Apache%202.0-blue.svg
 [license-url]: https://github.com/twitter/pelikan/blob/master/LICENSE
-[momento_proxy-url]: src/rust/proxy/momento/README.md
+[momento_proxy-url]: src/proxy/momento/README.md
 [NSDI'21 paper]: https://www.usenix.org/conference/nsdi21/presentation/yang-juncheng
 [zulip-badge]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [zulip-url]: https://pelikan.zulipchat.com/


### PR DESCRIPTION
Docker build was failing with following error.
```console
 => [cargo-build 5/8] RUN apt-get install -y clang                                                                                                                                                                                                      17.5s
 => ERROR [cargo-build 6/8] RUN mkdir .cargo                                                                                                                                                                                                             0.3s
------
 > [cargo-build 6/8] RUN mkdir .cargo:
#14 0.251 mkdir: cannot create directory '.cargo': File exists
------
executor failed running [/bin/sh -c mkdir .cargo]: exit code: 1                                                                                                                                                                                                       
```

This fixes the docker build since `.cargo` directory is checked into the repo root now we don't need to create that directory in Docker build anymore.

Validated this locally with `docker build .` as well.

Published a new version of container to Docker hub from our fork after fix from release workflow and tested with new Redis protocol functionality as well working great!
``` console
$ docker run -d \
   -p 6379:6379 \
   -p 11211:11211 \
   -p 9999:9999 \
   -e MOMENTO_AUTHENTICATION=eyJ***  \
   gomomento/momento-proxy

$ redis-cli -h 0.0.0.0 -p 6379 SET FOO BAR
OK
$ redis-cli -h 0.0.0.0 -p 6379 GET FOO
"BAR"
```

Also fixes broken link in README that broke when we 🪓 the `rust` directory under `src`.