### PR TITLE
Make error messages in segcache and pingserver use stderr

### DIFF
--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
         error!("{}", s);
-        println!("{:?}", Backtrace::new());
+        eprintln!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
 
@@ -96,7 +96,7 @@ fn main() {
         match PingserverConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("error launching pingserver: {}", e);
+                eprintln!("error loading config file: {}", e);
                 std::process::exit(1);
             }
         }
@@ -108,7 +108,7 @@ fn main() {
     match Pingserver::new(config) {
         Ok(s) => s.wait(),
         Err(e) => {
-            println!("error launching pingserver: {}", e);
+            eprintln!("error launching pingserver: {}", e);
             std::process::exit(1);
         }
     }

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
         error!("{}", s);
-        println!("{:?}", Backtrace::new());
+        eprintln!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
 
@@ -103,7 +103,7 @@ fn main() {
         match SegcacheConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("{}", e);
+                eprintln!("unable to load config file: {}", e);
                 std::process::exit(1);
             }
         }
@@ -120,7 +120,7 @@ fn main() {
     match Segcache::new(config) {
         Ok(segcache) => segcache.wait(),
         Err(e) => {
-            println!("error launching segcache: {}", e);
+            eprintln!("error launching segcache: {}", e);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
This was noticed in the review of #468. We should really be writing error messages to stderr. This PR switches segcache and pingserver over to using eprintln.