### PR TITLE
ci: update runner os versions

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-11 ]
+        os: [ ubuntu-latest, macos-12 ]
         profile: [ release, debug ]
     name: build-${{ matrix.os }}-${{ matrix.profile }}
     runs-on: ${{ matrix.os }}
@@ -54,7 +54,7 @@ jobs:
   bench-check:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-11 ]
+        os: [ ubuntu-latest, macos-12 ]
     name: build-${{ matrix.os }}-bench
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,7 +85,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-11 ]
+        os: [ ubuntu-latest, macos-12 ]
     name: check-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-latest ]
         target: [
           protocol/admin,
           protocol/memcache,


### PR DESCRIPTION
We're using a deprecated version of ubuntu for GH CI. Changes the workflow configs to use `ubuntu-latest`.

Also trying bumping the macos version to 12, in the hopes that it is less likely to be flakey.