### PR TITLE
fix: improve error messages

### DIFF
--- a/src/config/src/segcache.rs
+++ b/src/config/src/segcache.rs
@@ -73,7 +73,7 @@ impl SegcacheConfig {
         match toml::from_str(&content) {
             Ok(t) => Ok(t),
             Err(e) => {
-                error!("{}", e);
+                eprintln!("{}", e);
                 Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Error parsing config",

--- a/src/net/src/tls_tcp.rs
+++ b/src/net/src/tls_tcp.rs
@@ -210,7 +210,10 @@ impl TlsTcpAcceptorBuilder {
         // load the CA file, if provided
         if let Some(f) = self.ca_file {
             self.inner.set_ca_file(f.clone()).map_err(|e| {
-                Error::new(ErrorKind::Other, format!("failed to load CA file: {}\n{}", f.display(), e))
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed to load CA file: {}\n{}", f.display(), e),
+                )
             })?;
         }
 
@@ -248,20 +251,32 @@ impl TlsTcpAcceptorBuilder {
                 let pem = std::fs::read(chain.clone()).map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}\n{}", chain.display(), e),
+                        format!(
+                            "failed to load certificate chain file: {}\n{}",
+                            chain.display(),
+                            e
+                        ),
                     )
                 })?;
                 let cert_chain = X509::stack_from_pem(&pem).map_err(|e| {
                     Error::new(
                         ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}\n{}", chain.display(), e),
+                        format!(
+                            "failed to load certificate chain file: {}\n{}",
+                            chain.display(),
+                            e
+                        ),
                     )
                 })?;
                 for cert in cert_chain {
                     self.inner.add_extra_chain_cert(cert).map_err(|e| {
                         Error::new(
                             ErrorKind::Other,
-                            format!("bad certificate in certificate chain file: {}\n{}", chain.display(), e),
+                            format!(
+                                "bad certificate in certificate chain file: {}\n{}",
+                                chain.display(),
+                                e
+                            ),
                         )
                     })?;
                 }
@@ -271,12 +286,18 @@ impl TlsTcpAcceptorBuilder {
                 // one file
 
                 // load the entire chain
-                self.inner.set_certificate_chain_file(chain.clone()).map_err(|e| {
-                    Error::new(
-                        ErrorKind::Other,
-                        format!("failed to load certificate chain file: {}\n{}", chain.display(), e),
-                    )
-                })?;
+                self.inner
+                    .set_certificate_chain_file(chain.clone())
+                    .map_err(|e| {
+                        Error::new(
+                            ErrorKind::Other,
+                            format!(
+                                "failed to load certificate chain file: {}\n{}",
+                                chain.display(),
+                                e
+                            ),
+                        )
+                    })?;
             }
             (None, Some(cert)) => {
                 // this will just load the leaf certificate from the file

--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -24,13 +24,8 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-<<<<<<< HEAD
         eprintln!("{}", s);
-        println!("{:?}", Backtrace::new());
-=======
-        error!("{}", s);
         eprintln!("{:?}", Backtrace::new());
->>>>>>> master
         std::process::exit(101);
     }));
 
@@ -101,12 +96,8 @@ fn main() {
         match PingserverConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-<<<<<<< HEAD
-                eprintln!("failed to load config: {file}");
+                eprintln!("error loading config file: {file}");
                 eprintln!("{}", e);
-=======
-                eprintln!("error loading config file: {}", e);
->>>>>>> master
                 std::process::exit(1);
             }
         }

--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -24,7 +24,7 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-        error!("{}", s);
+        eprintln!("{}", s);
         println!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
@@ -96,7 +96,8 @@ fn main() {
         match PingserverConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("error launching pingserver: {}", e);
+                eprintln!("failed to load config: {file}");
+                eprintln!("{}", e);
                 std::process::exit(1);
             }
         }

--- a/src/server/pingserver/src/main.rs
+++ b/src/server/pingserver/src/main.rs
@@ -95,9 +95,8 @@ fn main() {
         debug!("loading config: {}", file);
         match PingserverConfig::load(file) {
             Ok(c) => c,
-            Err(e) => {
-                eprintln!("error loading config file: {file}");
-                eprintln!("{}", e);
+            Err(error) => {
+                eprintln!("error loading config file: {file}\n{error}");
                 std::process::exit(1);
             }
         }

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -103,9 +103,8 @@ fn main() {
         debug!("loading config: {}", file);
         match SegcacheConfig::load(file) {
             Ok(c) => c,
-            Err(e) => {
-                eprintln!("error loading config file: {file}");
-                eprintln!("{}", e);
+            Err(error) => {
+                eprintln!("error loading config file: {file}\n{error}");
                 std::process::exit(1);
             }
         }

--- a/src/server/segcache/src/main.rs
+++ b/src/server/segcache/src/main.rs
@@ -28,7 +28,7 @@ use server::PERCENTILES;
 fn main() {
     // custom panic hook to terminate whole process after unwinding
     std::panic::set_hook(Box::new(|s| {
-        error!("{}", s);
+        eprintln!("{}", s);
         println!("{:?}", Backtrace::new());
         std::process::exit(101);
     }));
@@ -100,10 +100,12 @@ fn main() {
 
     // load config from file
     let config = if let Some(file) = matches.value_of("CONFIG") {
+        debug!("loading config: {}", file);
         match SegcacheConfig::load(file) {
             Ok(c) => c,
             Err(e) => {
-                println!("{}", e);
+                eprintln!("failed to load config: {file}");
+                eprintln!("{}", e);
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
The panic hook should really print to stderr directly instead of using
a log macro, as we cannot guarantee the logger flushes before the
program terminates. 

Also improves some of the error messages for loading TOML configs
and TLS key materials to print the filename as well as the error
message.