### PR TITLE
seg: change all recent timestamps to now

### DIFF
--- a/src/storage/seg/src/builder.rs
+++ b/src/storage/seg/src/builder.rs
@@ -167,7 +167,7 @@ impl Builder {
             hashtable,
             segments,
             ttl_buckets,
-            time: Instant::recent(),
+            time: Instant::now(),
         })
     }
 }

--- a/src/storage/seg/src/eviction/mod.rs
+++ b/src/storage/seg/src/eviction/mod.rs
@@ -70,7 +70,7 @@ impl Eviction {
     }
 
     pub fn should_rerank(&mut self) -> bool {
-        let now = Instant::recent();
+        let now = Instant::now();
         match self.policy {
             Policy::None | Policy::Random | Policy::RandomFifo | Policy::Merge { .. } => false,
             Policy::Fifo | Policy::Cte | Policy::Util => {

--- a/src/storage/seg/src/seg.rs
+++ b/src/storage/seg/src/seg.rs
@@ -288,15 +288,13 @@ impl Seg {
     /// assert!(cache.get(b"coffee").is_none());
     /// ```
     pub fn expire(&mut self) -> usize {
-        common::time::refresh_clock();
-        self.time = Instant::recent();
+        self.time = Instant::now();
         self.ttl_buckets
             .expire(&mut self.hashtable, &mut self.segments)
     }
 
     pub fn clear(&mut self) -> usize {
-        common::time::refresh_clock();
-        self.time = Instant::recent();
+        self.time = Instant::now();
         self.ttl_buckets
             .clear(&mut self.hashtable, &mut self.segments)
     }

--- a/src/storage/seg/src/segments/builder.rs
+++ b/src/storage/seg/src/segments/builder.rs
@@ -29,7 +29,7 @@ impl Default for SegmentsBuilder {
     }
 }
 
-impl<'a> SegmentsBuilder {
+impl SegmentsBuilder {
     /// Set the segment size in bytes.
     ///
     /// # Panics

--- a/src/storage/seg/src/segments/header.rs
+++ b/src/storage/seg/src/segments/header.rs
@@ -65,6 +65,7 @@ pub struct SegmentHeader {
 
 impl SegmentHeader {
     pub fn new(id: NonZeroU32) -> Self {
+        let now = Instant::now();
         Self {
             id,
             write_offset: 0,
@@ -72,9 +73,9 @@ impl SegmentHeader {
             live_items: 0,
             prev_seg: None,
             next_seg: None,
-            create_at: Instant::recent(),
+            create_at: now,
             ttl: 0,
-            merge_at: Instant::recent(),
+            merge_at: now,
             accessible: false,
             evictable: false,
             _pad: [0; 25],
@@ -89,12 +90,13 @@ impl SegmentHeader {
         assert!(!self.evictable());
 
         self.reset();
+        let now = Instant::now();
 
         self.prev_seg = None;
         self.next_seg = None;
         self.live_items = 0;
-        self.create_at = Instant::recent();
-        self.merge_at = Instant::recent();
+        self.create_at = now;
+        self.merge_at = now;
         self.accessible = true;
     }
 
@@ -249,7 +251,7 @@ impl SegmentHeader {
     #[inline]
     /// Update the created time
     pub fn mark_created(&mut self) {
-        self.create_at = Instant::recent();
+        self.create_at = Instant::now();
     }
 
     #[inline]
@@ -261,7 +263,7 @@ impl SegmentHeader {
     #[inline]
     /// Update the created time
     pub fn mark_merged(&mut self) {
-        self.merge_at = Instant::recent();
+        self.merge_at = Instant::now();
     }
 
     #[inline]
@@ -273,6 +275,6 @@ impl SegmentHeader {
     pub fn can_evict(&self) -> bool {
         self.evictable()
             && self.next_seg().is_some()
-            && (self.create_at() + self.ttl()) >= (Instant::recent() + SEG_MATURE_TIME)
+            && (self.create_at() + self.ttl()) >= (Instant::now() + SEG_MATURE_TIME)
     }
 }

--- a/src/storage/seg/src/ttl_buckets/ttl_bucket.rs
+++ b/src/storage/seg/src/ttl_buckets/ttl_bucket.rs
@@ -85,7 +85,7 @@ impl TtlBucket {
         }
 
         let mut expired = 0;
-        let ts = Instant::recent();
+        let ts = Instant::now();
 
         loop {
             let seg_id = self.head;
@@ -99,7 +99,7 @@ impl TtlBucket {
                         self.head = None;
                         self.tail = None;
                     }
-                    let _ = segment.clear(hashtable, true);
+                    segment.clear(hashtable, true);
                     segments.push_free(seg_id);
                     SEGMENT_EXPIRE.increment();
                     expired += 1;
@@ -131,7 +131,7 @@ impl TtlBucket {
                     self.head = None;
                     self.tail = None;
                 }
-                let _ = segment.clear(hashtable, true);
+                segment.clear(hashtable, true);
                 segments.push_free(seg_id);
                 SEGMENT_CLEAR.increment();
                 cleared += 1;


### PR DESCRIPTION
In an effort to debug flakey CI for macos, let's try using now() instead of recent() within the storage library.